### PR TITLE
feat(1.1.6): material-aware maintenance forecasting

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -27,7 +27,7 @@ Derived from the HomeFax product vision. Items are grouped by domain, tagged wit
 | 1.1.3 | 5-year rolling calendar view | ✅ Exists | — | `FiveYearCalendar` component in `PredictiveMaintenancePage` — "Schedule" tab with year columns, per-year budget, completion checkboxes |
 | 1.1.4 | Per-task cost estimate ranges | ✅ Exists | — | `serviceCallLowCents`/`High` on `SystemPrediction`; numeric cents on `AnnualTask`; annual budget total on Annual Tasks tab; modal pre-fills service cost for Watch/Good, replacement cost for Critical/Soon |
 | 1.1.5 | Climate-adjusted aging model | ✅ Done | L | Pull zip-code weather normals; adjust HVAC/roof lifespan curves by region |
-| 1.1.6 | Material-aware forecasting | ⬜ Missing | L | Room digital twin (1.4) is a prerequisite — need material metadata |
+| 1.1.6 | Material-aware forecasting | ✅ Done | L | `MATERIAL_SPECS` + `getMaterialMultiplier` in `maintenance.ts`; 5th param `materialOverrides` on `predictMaintenance` stacks with climate multiplier; `SystemPrediction.materialMultiplier` field |
 | 1.1.7 | Exportable PDF maintenance calendar | ✅ Done | M | Generate printable 12-month schedule with estimated costs |
 
 ### 1.2 "Home Genome" Onboarding

--- a/frontend/src/__tests__/services/maintenance.test.ts
+++ b/frontend/src/__tests__/services/maintenance.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
-import { predictMaintenance, maintenanceService } from "@/services/maintenance";
+import { predictMaintenance, maintenanceService, MATERIAL_SPECS, getMaterialMultiplier } from "@/services/maintenance";
 import type { Job } from "@/services/job";
 
 // ─── Fix time so age calculations are deterministic ───────────────────────────
@@ -349,5 +349,141 @@ describe("maintenanceService.urgencyBg", () => {
 
   it("Good → light green background", () => {
     expect(maintenanceService.urgencyBg("Good")).toBe("#f0fdf4");
+  });
+});
+
+// ─── Material-aware forecasting (1.1.6) ──────────────────────────────────────
+
+describe("MATERIAL_SPECS", () => {
+  it("covers all material-sensitive systems", () => {
+    expect(MATERIAL_SPECS).toHaveProperty("Roofing");
+    expect(MATERIAL_SPECS).toHaveProperty("Flooring");
+    expect(MATERIAL_SPECS).toHaveProperty("Plumbing");
+    expect(MATERIAL_SPECS).toHaveProperty("Windows");
+    expect(MATERIAL_SPECS).toHaveProperty("Water Heater");
+    expect(MATERIAL_SPECS).toHaveProperty("HVAC");
+  });
+
+  it("every entry has a non-empty label and positive multiplier", () => {
+    for (const materials of Object.values(MATERIAL_SPECS)) {
+      for (const spec of Object.values(materials)) {
+        expect(typeof spec.label).toBe("string");
+        expect(spec.label.length).toBeGreaterThan(0);
+        expect(typeof spec.multiplier).toBe("number");
+        expect(spec.multiplier).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it("metal roof multiplier is 1.6", () => {
+    expect(MATERIAL_SPECS["Roofing"]["metal"].multiplier).toBe(1.6);
+  });
+
+  it("galvanized pipe multiplier is 0.5", () => {
+    expect(MATERIAL_SPECS["Plumbing"]["galvanized"].multiplier).toBe(0.5);
+  });
+});
+
+describe("getMaterialMultiplier", () => {
+  it("returns correct multiplier for a known system + material", () => {
+    expect(getMaterialMultiplier("Roofing", "metal")).toBe(1.6);
+    expect(getMaterialMultiplier("Plumbing", "galvanized")).toBe(0.5);
+    expect(getMaterialMultiplier("HVAC", "boiler")).toBe(1.33);
+  });
+
+  it("returns 1.0 for an unknown system", () => {
+    expect(getMaterialMultiplier("Garage Door", "steel")).toBe(1.0);
+  });
+
+  it("returns 1.0 for an unknown material in a known system", () => {
+    expect(getMaterialMultiplier("Roofing", "mystery-material")).toBe(1.0);
+  });
+
+  it("returns 1.0 for an empty material key", () => {
+    expect(getMaterialMultiplier("HVAC", "")).toBe(1.0);
+  });
+});
+
+describe("predictMaintenance — material overrides", () => {
+  // ── Metal roof: asphalt Critical → Watch ──
+  // Roofing baseline 25yr; yearBuilt 2001 → age 25 → pct 100 → Critical (asphalt)
+  // Metal 1.6× → effectiveLifespan = round(25*1.6)=40 → pct = round(25/40*100)=63 → Watch
+  it("metal roof extends effective lifespan: Critical becomes Watch", () => {
+    const plain = predictMaintenance(2001, []).systemPredictions
+      .find((s) => s.systemName === "Roofing")!;
+    expect(plain.urgency).toBe("Critical");
+
+    const withMetal = predictMaintenance(2001, [], {}, undefined, { Roofing: "metal" })
+      .systemPredictions.find((s) => s.systemName === "Roofing")!;
+    expect(withMetal.urgency).toBe("Watch");
+  });
+
+  // ── Galvanized pipes: Watch → Critical ──
+  // Plumbing baseline 50yr; yearBuilt 1990 → age 36 → pct 72 → Watch
+  // Galvanized 0.5× → effectiveLifespan = round(50*0.5)=25 → pct = round(36/25*100)=144 → Critical
+  it("galvanized pipes shorten effective lifespan: Watch becomes Critical", () => {
+    const plain = predictMaintenance(1990, []).systemPredictions
+      .find((s) => s.systemName === "Plumbing")!;
+    expect(plain.urgency).toBe("Watch");
+
+    const withGalvanized = predictMaintenance(1990, [], {}, undefined, { Plumbing: "galvanized" })
+      .systemPredictions.find((s) => s.systemName === "Plumbing")!;
+    expect(withGalvanized.urgency).toBe("Critical");
+  });
+
+  // ── Boiler HVAC: Critical (age 18) → Soon ──
+  // HVAC baseline 18yr; age 18 → pct 100 → Critical
+  // Boiler 1.33× → effectiveLifespan = round(18*1.33)=24 → pct = round(18/24*100)=75 → Soon
+  it("boiler HVAC extends lifespan: Critical (age 18) becomes Soon", () => {
+    const withBoiler = predictMaintenance(CURRENT_YEAR - 18, [], {}, undefined, { HVAC: "boiler" })
+      .systemPredictions.find((s) => s.systemName === "HVAC")!;
+    expect(withBoiler.urgency).toBe("Soon");
+  });
+
+  // ── Unknown material → no change ──
+  it("unknown material key leaves urgency and percentLifeUsed unchanged", () => {
+    const baseline = predictMaintenance(2001, []).systemPredictions
+      .find((s) => s.systemName === "Roofing")!;
+    const withUnknown = predictMaintenance(2001, [], {}, undefined, { Roofing: "mystery-material" })
+      .systemPredictions.find((s) => s.systemName === "Roofing")!;
+    expect(withUnknown.urgency).toBe(baseline.urgency);
+    expect(withUnknown.percentLifeUsed).toBe(baseline.percentLifeUsed);
+  });
+
+  // ── Climate × material stack ──
+  // Cold (MI): HVAC 0.88× → effectiveLifespan = round(18*0.88)=16; age 10 → pct 63 → Watch
+  // + heatPump 0.83× → effectiveLifespan = round(18*0.88*0.83)=13; pct = round(10/13*100)=77 → Soon
+  it("climate and material multipliers stack multiplicatively", () => {
+    const coldOnly = predictMaintenance(CURRENT_YEAR - 10, [], {}, "MI")
+      .systemPredictions.find((s) => s.systemName === "HVAC")!;
+    expect(coldOnly.urgency).toBe("Watch");
+
+    const coldHeatPump = predictMaintenance(CURRENT_YEAR - 10, [], {}, "MI", { HVAC: "heatPump" })
+      .systemPredictions.find((s) => s.systemName === "HVAC")!;
+    expect(coldHeatPump.urgency).toBe("Soon");
+  });
+
+  it("SystemPrediction includes materialMultiplier = 1.6 for metal roof", () => {
+    const pred = predictMaintenance(2001, [], {}, undefined, { Roofing: "metal" })
+      .systemPredictions.find((s) => s.systemName === "Roofing")!;
+    expect(pred.materialMultiplier).toBe(1.6);
+  });
+
+  it("materialMultiplier defaults to 1.0 when no override given", () => {
+    const pred = predictMaintenance(2001, []).systemPredictions
+      .find((s) => s.systemName === "Roofing")!;
+    expect(pred.materialMultiplier).toBe(1.0);
+  });
+
+  it("MaintenanceReport includes the materialOverrides passed in", () => {
+    const overrides = { Roofing: "metal", Plumbing: "copper" };
+    const report = predictMaintenance(2001, [], {}, undefined, overrides);
+    expect(report.materialOverrides).toEqual(overrides);
+  });
+
+  it("empty materialOverrides produces identical urgencies to no override", () => {
+    const baseline = predictMaintenance(2001, []).systemPredictions.map((s) => s.urgency);
+    const withEmpty = predictMaintenance(2001, [], {}, undefined, {}).systemPredictions.map((s) => s.urgency);
+    expect(withEmpty).toEqual(baseline);
   });
 });

--- a/frontend/src/services/maintenance.ts
+++ b/frontend/src/services/maintenance.ts
@@ -69,6 +69,63 @@ function fromEntry(raw: any): ScheduleEntry {
   };
 }
 
+// ─── Material Specs (1.1.6) ──────────────────────────────────────────────────
+//
+// Per-system material keys with lifespan multipliers relative to the baseline.
+// Multipliers > 1.0 extend lifespan; < 1.0 shorten it.
+// These stack with climate multipliers inside predictMaintenance.
+
+export interface MaterialSpec {
+  label: string;
+  multiplier: number;
+}
+
+export const MATERIAL_SPECS: Record<string, Record<string, MaterialSpec>> = {
+  Roofing: {
+    asphalt:   { label: "Asphalt Shingles",       multiplier: 1.0  },
+    metal:     { label: "Metal",                   multiplier: 1.6  },
+    tile:      { label: "Clay/Concrete Tile",      multiplier: 2.0  },
+    woodShake: { label: "Wood Shake",              multiplier: 0.80 },
+    slate:     { label: "Slate",                   multiplier: 2.4  },
+  },
+  Flooring: {
+    hardwood:  { label: "Hardwood",                multiplier: 1.0  },
+    carpet:    { label: "Carpet",                  multiplier: 0.40 },
+    lvp:       { label: "Luxury Vinyl",            multiplier: 0.80 },
+    tile:      { label: "Ceramic/Porcelain Tile",  multiplier: 1.20 },
+    laminate:  { label: "Laminate",                multiplier: 0.60 },
+  },
+  Plumbing: {
+    copper:    { label: "Copper",                  multiplier: 1.0  },
+    pvc:       { label: "PVC/PEX",                 multiplier: 1.0  },
+    galvanized:{ label: "Galvanized Steel",         multiplier: 0.50 },
+    castIron:  { label: "Cast Iron",               multiplier: 1.40 },
+  },
+  Windows: {
+    doublePane:{ label: "Double-Pane Vinyl",       multiplier: 1.0  },
+    singlePane:{ label: "Single-Pane",             multiplier: 0.68 },
+    triplePane:{ label: "Triple-Pane",             multiplier: 1.36 },
+    wood:      { label: "Wood Frame",              multiplier: 0.86 },
+  },
+  "Water Heater": {
+    tank:      { label: "Tank (Standard)",         multiplier: 1.0  },
+    tankless:  { label: "Tankless",                multiplier: 1.67 },
+    heatPump:  { label: "Heat Pump Water Heater",  multiplier: 1.50 },
+  },
+  HVAC: {
+    central:   { label: "Central Air/Furnace",     multiplier: 1.0  },
+    heatPump:  { label: "Heat Pump",               multiplier: 0.83 },
+    miniSplit:  { label: "Mini-Split",              multiplier: 1.11 },
+    boiler:    { label: "Boiler",                  multiplier: 1.33 },
+  },
+};
+
+/** Returns the lifespan multiplier for a given system + material key.
+ *  Falls back to 1.0 (no adjustment) for unknown systems or materials. */
+export function getMaterialMultiplier(systemName: string, materialKey: string): number {
+  return MATERIAL_SPECS[systemName]?.[materialKey]?.multiplier ?? 1.0;
+}
+
 // ─── Climate Zone Model ──────────────────────────────────────────────────────
 //
 // Five practical zones derived from DOE Building America climate zones.
@@ -178,6 +235,7 @@ export interface SystemPrediction {
   serviceCallHighCents: number;      // routine service / inspection cost
   recommendation: string;
   diyViable: boolean;
+  materialMultiplier: number;        // 1.0 if no material override applied
 }
 
 export interface AnnualTask {
@@ -199,6 +257,7 @@ export interface MaintenanceReport {
   annualTaskBudgetHighCents: number;
   climateZone: ClimateZone;
   generatedAt: number;
+  materialOverrides: Partial<Record<string, string>>;
 }
 
 export interface ScheduleEntry {
@@ -293,7 +352,8 @@ export function predictMaintenance(
   yearBuilt: number,
   jobs: Job[],
   systemInstallYears: Partial<Record<string, number>> = {},
-  state?: string
+  state?: string,
+  materialOverrides: Partial<Record<string, string>> = {}
 ): MaintenanceReport {
   const year  = currentYear();
   const zone  = state ? getClimateZone(state) : CLIMATE_ZONES.mixed;
@@ -311,9 +371,11 @@ export function predictMaintenance(
       }
     }
 
-    // Apply climate multiplier to effective lifespan
-    const multiplier       = zone.lifespanMultipliers[sys.name] ?? 1.0;
-    const effectiveLifespan = Math.round(sys.lifespanYears * multiplier);
+    // Apply climate multiplier then material multiplier to effective lifespan
+    const climateMultiplier  = zone.lifespanMultipliers[sys.name] ?? 1.0;
+    const matKey             = materialOverrides[sys.name] ?? "";
+    const materialMult       = getMaterialMultiplier(sys.name, matKey);
+    const effectiveLifespan  = Math.round(sys.lifespanYears * climateMultiplier * materialMult);
 
     const age       = Math.max(0, year - lastYear);
     const pctUsed   = Math.round((age / effectiveLifespan) * 100);
@@ -332,6 +394,7 @@ export function predictMaintenance(
       serviceCallHighCents:   sys.serviceCallHighCents,
       recommendation:         recommendationFor(sys, urgency, remaining),
       diyViable:              sys.diyViable,
+      materialMultiplier:     materialMult,
     });
 
     if (urgency === "Critical" || urgency === "Soon") {
@@ -355,6 +418,7 @@ export function predictMaintenance(
     annualTaskBudgetHighCents: annualHigh,
     climateZone:               zone,
     generatedAt:               Date.now(),
+    materialOverrides,
   };
 }
 
@@ -364,8 +428,8 @@ const scheduleStore = new Map<string, ScheduleEntry>();
 let scheduleCounter = 0;
 
 export const maintenanceService = {
-  predict(yearBuilt: number, jobs: Job[], systemInstallYears?: Partial<Record<string, number>>, state?: string): MaintenanceReport {
-    return predictMaintenance(yearBuilt, jobs, systemInstallYears, state);
+  predict(yearBuilt: number, jobs: Job[], systemInstallYears?: Partial<Record<string, number>>, state?: string, materialOverrides?: Partial<Record<string, string>>): MaintenanceReport {
+    return predictMaintenance(yearBuilt, jobs, systemInstallYears, state, materialOverrides);
   },
 
   async createScheduleEntry(


### PR DESCRIPTION
## Summary
- Adds `MATERIAL_SPECS` table covering 6 systems (Roofing, Flooring, Plumbing, Windows, Water Heater, HVAC) with per-material lifespan multipliers (e.g. metal roof 1.6×, galvanized pipe 0.5×, boiler 1.33×)
- `getMaterialMultiplier(system, materialKey)` helper — returns 1.0 for unknown keys
- `predictMaintenance` gains a 5th param `materialOverrides` that stacks with existing climate multipliers
- `SystemPrediction` gains `materialMultiplier` field; `MaintenanceReport` gains `materialOverrides` field
- Backlog item 1.1.6 ✅

## Test plan
- [x] 15 new TDD tests all green (548/548 total passing)
- [ ] Metal roof converts Critical → Watch for a 25-year-old roof
- [ ] Galvanized pipes convert Watch → Critical for a 36-year-old home
- [ ] Climate × material multipliers stack correctly (cold MI + heat pump → Soon vs Watch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)