### PR TITLE
Potential fix for code scanning alert no. 15: DOM text reinterpreted as HTML

### DIFF
--- a/frontend/src/services/agentProfile.ts
+++ b/frontend/src/services/agentProfile.ts
@@ -13,20 +13,47 @@ export interface AgentProfile {
   logoUrl:   string;
 }
 
+function sanitizeAgentProfile(profile: AgentProfile): AgentProfile {
+  const name = profile.name?.trim() ?? "";
+  const brokerage = profile.brokerage?.trim() ?? "";
+  const phone = profile.phone?.trim() ?? "";
+  let logoUrl = profile.logoUrl?.trim() ?? "";
+
+  if (logoUrl) {
+    try {
+      const parsed = new URL(logoUrl, window.location.origin);
+      const protocol = parsed.protocol.toLowerCase();
+      if (protocol !== "http:" && protocol !== "https:") {
+        logoUrl = "";
+      } else {
+        logoUrl = parsed.toString();
+      }
+    } catch {
+      // Invalid URL; clear it to avoid using an unsafe value.
+      logoUrl = "";
+    }
+  }
+
+  return { name, brokerage, phone, logoUrl };
+}
+
 const STORAGE_KEY = "homefax_agent_profile";
 
 export const agentProfileService = {
   load(): AgentProfile | null {
     try {
       const raw = localStorage.getItem(STORAGE_KEY);
-      return raw ? (JSON.parse(raw) as AgentProfile) : null;
+      if (!raw) return null;
+      const parsed = JSON.parse(raw) as AgentProfile;
+      return sanitizeAgentProfile(parsed);
     } catch {
       return null;
     }
   },
 
   save(profile: AgentProfile): void {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(profile));
+    const sanitized = sanitizeAgentProfile(profile);
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(sanitized));
   },
 
   clear(): void {
@@ -38,11 +65,12 @@ export const agentProfileService = {
    * Only includes non-empty fields.
    */
   appendToUrl(url: string, profile: AgentProfile): string {
+    const safeProfile = sanitizeAgentProfile(profile);
     const u = new URL(url, window.location.origin);
-    if (profile.name)      u.searchParams.set("an",  profile.name);
-    if (profile.brokerage) u.searchParams.set("ab",  profile.brokerage);
-    if (profile.phone)     u.searchParams.set("aph", profile.phone);
-    if (profile.logoUrl)   u.searchParams.set("al",  profile.logoUrl);
+    if (safeProfile.name)      u.searchParams.set("an",  safeProfile.name);
+    if (safeProfile.brokerage) u.searchParams.set("ab",  safeProfile.brokerage);
+    if (safeProfile.phone)     u.searchParams.set("aph", safeProfile.phone);
+    if (safeProfile.logoUrl)   u.searchParams.set("al",  safeProfile.logoUrl);
     return u.toString();
   },
 
@@ -50,11 +78,12 @@ export const agentProfileService = {
   fromParams(params: URLSearchParams): AgentProfile | null {
     const name = params.get("an") ?? "";
     if (!name) return null;
-    return {
+    const profile: AgentProfile = {
       name,
       brokerage: params.get("ab")  ?? "",
       phone:     params.get("aph") ?? "",
       logoUrl:   params.get("al")  ?? "",
     };
+    return sanitizeAgentProfile(profile);
   },
 };


### PR DESCRIPTION
Potential fix for [https://github.com/MeteSr/HomeFax/security/code-scanning/15](https://github.com/MeteSr/HomeFax/security/code-scanning/15)

General approach: Prevent untrusted DOM text from being interpreted in a risky way by validating and constraining the data before it is persisted/used, and by ensuring only safe URL schemes are allowed for `logoUrl`. Since React already escapes text for `<p>` elements, our main concern is the image URL and any future use of the stored profile. The cleanest fix is to introduce a small utility to sanitize the agent profile before saving/loading and ensure `logoUrl` is restricted to http/https (or empty).

Best concrete fix with minimal behavior change:

1. In `frontend/src/services/agentProfile.ts`, add a helper function `sanitizeAgentProfile` that:
   - Trims `name`, `brokerage`, `phone`, `logoUrl`.
   - Validates `logoUrl` by:
     - Attempting to construct a `URL` with base `window.location.origin`.
     - Rejecting / clearing it if the resulting scheme is not `http:` or `https:`.
   - Returns a sanitized `AgentProfile`.

2. Use this sanitizer:
   - In `save(profile: AgentProfile)`, call `sanitizeAgentProfile(profile)` and store the sanitized version.
   - In `load()`, after `JSON.parse`, pass the parsed object through `sanitizeAgentProfile` before returning.
   - In `fromParams`, pass the constructed object through `sanitizeAgentProfile` before returning.

This way, any `logoUrl` coming from the DOM inputs, from localStorage, or from URL parameters must pass the same safety checks. We are not changing imports or public API surface; we’re just centralizing and tightening validation inside `agentProfileService`. No changes are required in `SettingsPage.tsx`, because `logoUrl` will now always be sanitized before it reaches that component, addressing all the alert variants that derive from tainted `e.target.value`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
