### PR TITLE
Potential fix for code scanning alert no. 7: Missing rate limiting

### DIFF
--- a/agents/iot-gateway/server.ts
+++ b/agents/iot-gateway/server.ts
@@ -21,6 +21,7 @@ import "dotenv/config";
 import crypto from "crypto";
 import express, { Request, Response, NextFunction } from "express";
 import cors from "cors";
+import rateLimit from "express-rate-limit";
 import { handleNestEvent, handleEcobeeEvent, handleMoenFloEvent } from "./handlers";
 import { recordSensorEvent, getGatewayPrincipal } from "./icp";
 import type {
@@ -31,6 +32,13 @@ import type {
 
 const app = express();
 const port = Number(process.env.IOT_GATEWAY_PORT) || 3002;
+
+const ecobeeLimiter = rateLimit({
+  windowMs: 60 * 1000, // 1 minute
+  max: 60, // max 60 requests per minute per IP for Ecobee webhook
+  standardHeaders: true,
+  legacyHeaders: false,
+});
 
 // Store raw body for HMAC verification before JSON parsing
 app.use(
@@ -115,7 +123,7 @@ app.post("/webhooks/nest", async (req: Request, res: Response): Promise<void> =>
 // ── POST /webhooks/ecobee ─────────────────────────────────────────────────────
 // Ecobee sends alert notifications here.
 // Validates X-Ecobee-Signature HMAC-SHA256.
-app.post("/webhooks/ecobee", async (req: Request, res: Response): Promise<void> => {
+app.post("/webhooks/ecobee", ecobeeLimiter, async (req: Request, res: Response): Promise<void> => {
   if (!verifyHmac(req, "x-ecobee-signature", process.env.ECOBEE_WEBHOOK_SECRET)) {
     console.warn("[ecobee] rejected — invalid signature");
     res.status(401).json({ error: "Unauthorized" });


### PR DESCRIPTION
Potential fix for [https://github.com/MeteSr/HomeFax/security/code-scanning/7](https://github.com/MeteSr/HomeFax/security/code-scanning/7)

In general, the problem is fixed by adding a rate-limiting middleware to the Express app or to the specific sensitive routes, so that each client (typically identified by IP address) can only make a bounded number of requests in a specific time window. This prevents a single source from flooding the handler that performs authorization and subsequent expensive work.

The best targeted fix here, without changing existing functionality, is to introduce a rate limiter specifically for the `/webhooks/ecobee` route (and optionally the other webhook routes if desired). We can use the well-known `express-rate-limit` library. We will: (1) import `express-rate-limit` at the top of `server.ts`; (2) define a limiter instance configured for a reasonable window and maximum requests; and (3) apply that limiter to the `/webhooks/ecobee` route (by passing it as middleware before the async handler). This preserves existing logic while adding protection. Concretely, in `agents/iot-gateway/server.ts`, we will add the import right after the existing imports, define an `ecobeeLimiter` constant near other configuration (after `const app`/`const port`), and update the `app.post("/webhooks/ecobee", ...)` definition to `app.post("/webhooks/ecobee", ecobeeLimiter, async (req, res) => { ... })`. No other behavior of the handler is changed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
