### PR TITLE
Potential fix for code scanning alert no. 8: Missing rate limiting

### DIFF
--- a/agents/iot-gateway/server.ts
+++ b/agents/iot-gateway/server.ts
@@ -33,6 +33,14 @@ import type {
 const app = express();
 const port = Number(process.env.IOT_GATEWAY_PORT) || 3002;
 
+// Rate limiting for webhook endpoints
+const moenFloLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per windowMs
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
 const ecobeeLimiter = rateLimit({
   windowMs: 60 * 1000, // 1 minute
   max: 60, // max 60 requests per minute per IP for Ecobee webhook
@@ -154,7 +162,7 @@ app.post("/webhooks/ecobee", ecobeeLimiter, async (req: Request, res: Response):
 // ── POST /webhooks/moen-flo ───────────────────────────────────────────────────
 // Moen Flo cloud sends leak/flow alerts here.
 // Validates X-Moen-Signature HMAC-SHA256.
-app.post("/webhooks/moen-flo", async (req: Request, res: Response): Promise<void> => {
+app.post("/webhooks/moen-flo", moenFloLimiter, async (req: Request, res: Response): Promise<void> => {
   if (!verifyHmac(req, "x-moen-signature", process.env.MOEN_FLO_WEBHOOK_SECRET)) {
     console.warn("[moen-flo] rejected — invalid signature");
     res.status(401).json({ error: "Unauthorized" });


### PR DESCRIPTION
Potential fix for [https://github.com/MeteSr/HomeFax/security/code-scanning/8](https://github.com/MeteSr/HomeFax/security/code-scanning/8)

In general, to fix this kind of issue, you add an appropriate rate-limiting middleware to any route that performs authorization and then does non-trivial work (I/O, database, external API, etc.). In Express, this typically means configuring `express-rate-limit` with limits suitable for the endpoint and attaching the resulting middleware to the route (or router) so that bursts of requests are constrained.

For this codebase, the best, least-invasive fix is to define a rate limiter specific to the Moen Flo webhook, mirroring the existing `ecobeeLimiter`, and then apply it to the `/webhooks/moen-flo` route. The limiter should be defined near the other configuration (where `ecobeeLimiter` likely already exists) and re-use the already-imported `rateLimit` from `express-rate-limit`, so no new imports are needed. Then the route definition at line 157 should be updated from `app.post("/webhooks/moen-flo", async (req, res) => { ... })` to `app.post("/webhooks/moen-flo", moenFloLimiter, async (req, res) => { ... })`. This preserves all existing behavior while adding rate limiting before any authorization or business logic runs.

Concretely:
- In `agents/iot-gateway/server.ts`, in the configuration section where the Express app is set up (shortly after `const app = express(); const port = ...;` and where any existing rate limiters such as `ecobeeLimiter` are defined), add a new constant `moenFloLimiter = rateLimit({ ... })` with reasonable settings (e.g., `windowMs: 1 * 60 * 1000`, `max: 60` or similar, matching whatever pattern is used for Ecobee if present).
- At the `/webhooks/moen-flo` route definition (line 157), insert `moenFloLimiter` as a middleware argument before the async handler.
- No new imports or helper methods are required, since `rateLimit` is already imported.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
