### PR TITLE
feat(bills): Epic #49 Stories 3–6 — efficiency alerts, rebates, insur…

### DIFF
--- a/agents/voice/server.ts
+++ b/agents/voice/server.ts
@@ -365,6 +365,179 @@ JSON shape:
   }
 });
 
+// ── POST /api/efficiency-alert ───────────────────────────────────────────────
+// Epic #49 Story 3 — System Efficiency Degradation Alerts
+// Request:  { usageTrend: Array<{ periodStart, usageAmount, usageUnit }> }
+// Response: { degradationDetected, estimatedAnnualWaste?, recommendation? }
+app.post("/api/efficiency-alert", async (req: Request, res: Response): Promise<void> => {
+  const { usageTrend } = req.body;
+
+  if (!Array.isArray(usageTrend) || usageTrend.length === 0) {
+    res.status(400).json({ error: "usageTrend must be a non-empty array" });
+    return;
+  }
+
+  if (usageTrend.length < 3) {
+    res.json({ degradationDetected: false });
+    return;
+  }
+
+  const half     = Math.floor(usageTrend.length / 2);
+  const early    = usageTrend.slice(0, half);
+  const late     = usageTrend.slice(usageTrend.length - half);
+  const earlyAvg = early.reduce((s: number, p: any) => s + Number(p.usageAmount), 0) / early.length;
+  const lateAvg  = late.reduce((s: number, p: any)  => s + Number(p.usageAmount), 0) / late.length;
+  const trendPct = earlyAvg > 0 ? ((lateAvg - earlyAvg) / earlyAvg) * 100 : 0;
+
+  if (trendPct <= 15) {
+    res.json({ degradationDetected: false });
+    return;
+  }
+
+  const unit               = usageTrend[0]?.usageUnit ?? "usage units";
+  const estimatedAnnualWaste = (lateAvg - earlyAvg) * 12;
+
+  const systemPrompt = `You are a home efficiency expert for HomeGentic.
+The homeowner's utility usage has risen ${trendPct.toFixed(1)}% over recent months (${earlyAvg.toFixed(0)} → ${lateAvg.toFixed(0)} ${unit}/month).
+Write a 2-sentence recommendation for the most likely cause and the single most impactful action.
+Respond ONLY with plain text — no markdown, no JSON.`;
+
+  try {
+    const recommendation = await provider.complete({
+      system:   systemPrompt,
+      messages: [{ role: "user", content: `Usage unit: ${unit}. Trend: ${trendPct.toFixed(1)}% increase.` }],
+      maxTokens: 150,
+    });
+
+    res.json({
+      degradationDetected:  true,
+      estimatedAnnualWaste,
+      recommendation:       recommendation.trim(),
+    });
+  } catch (err) {
+    // Fallback to rule-based recommendation if Claude is unavailable
+    res.json({
+      degradationDetected:  true,
+      estimatedAnnualWaste,
+      recommendation: `Your ${unit} has increased ${trendPct.toFixed(1)}% over this period. This may indicate system inefficiency — consider scheduling an HVAC inspection or checking for leaks.`,
+    });
+  }
+});
+
+// ── POST /api/rebate-finder ───────────────────────────────────────────────────
+// Epic #49 Story 4 — Rebate & Incentive Finder
+// Request:  { state, zipCode, utilityProvider, billType }
+// Response: { rebates: Array<{ name, description, estimatedAmount, provider, url? }> }
+app.post("/api/rebate-finder", async (req: Request, res: Response): Promise<void> => {
+  const { state, zipCode, utilityProvider, billType } = req.body;
+
+  if (!state || !zipCode || !utilityProvider || !billType) {
+    res.status(400).json({ error: "state, zipCode, utilityProvider, and billType are required" });
+    return;
+  }
+  if (billType !== "Electric") {
+    res.status(400).json({ error: "Rebate finder is only available for Electric bills." });
+    return;
+  }
+
+  const systemPrompt = `You are a utility rebate expert for HomeGentic.
+List available electric utility rebates and incentive programs for a homeowner in the given state/zip with the given utility provider.
+Include federal programs (IRA tax credits), state programs, and utility-specific rebates.
+Respond ONLY with valid JSON — no markdown, no prose.
+
+JSON shape:
+{
+  "rebates": [
+    {
+      "name": "<program name>",
+      "description": "<1–2 sentence description>",
+      "estimatedAmount": "<e.g. Up to $2,000 or $75 rebate>",
+      "provider": "<Federal|State|<utility name>>",
+      "url": "<program URL or omit>"
+    }
+  ]
+}
+
+Rules:
+- Include 3–6 programs most relevant to this homeowner
+- Prioritise programs with the highest dollar value
+- Only include programs that are currently active (as of your knowledge cutoff)`;
+
+  try {
+    const text = await provider.complete({
+      system:    systemPrompt,
+      messages:  [{ role: "user", content: `State: ${state} | Zip: ${zipCode} | Utility: ${utilityProvider} | Bill type: ${billType}` }],
+      maxTokens: 1024,
+    });
+
+    const jsonMatch = text.match(/\{[\s\S]*\}/);
+    if (!jsonMatch) {
+      res.status(500).json({ error: PROVIDER_JSON_ERROR });
+      return;
+    }
+    res.json(JSON.parse(jsonMatch[0]));
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "Unknown error";
+    res.status(500).json({ error: msg });
+  }
+});
+
+// ── POST /api/telecom-negotiate ───────────────────────────────────────────────
+// Epic #49 Story 6 — Telecom Negotiation Assistant
+// Request:  { provider, amountCents, mbps, zipCode }
+// Response: { verdict, medianCents, savingsOpportunityCents, negotiationScript }
+app.post("/api/telecom-negotiate", async (req: Request, res: Response): Promise<void> => {
+  const { provider, amountCents, mbps, zipCode } = req.body;
+
+  if (!provider) {
+    res.status(400).json({ error: "provider is required" });
+    return;
+  }
+  if (!Number.isInteger(amountCents) || amountCents <= 0) {
+    res.status(400).json({ error: "amountCents must be a positive integer" });
+    return;
+  }
+
+  const systemPrompt = `You are a telecom bill negotiation expert for HomeGentic.
+Analyse the homeowner's internet/telecom bill against median broadband prices for their area.
+Respond ONLY with valid JSON — no markdown, no prose.
+
+JSON shape:
+{
+  "verdict": "<one of: overpaying|fair|good_deal>",
+  "medianCents": <integer — median monthly broadband cost in cents for the zip code>,
+  "savingsOpportunityCents": <integer — estimated monthly savings if they negotiate, 0 if fair/good_deal>,
+  "negotiationScript": "<A short script the homeowner can read to their provider's retention department>"
+}
+
+Rules:
+- medianCents should reflect realistic median broadband prices for the US zip code
+- negotiationScript should be 3–5 sentences, conversational, and specific to the provider
+- If verdict is "fair" or "good_deal", savingsOpportunityCents should be 0
+- The script should mention loyalty, competing offers, and a specific discount amount to request`;
+
+  try {
+    const text = await provider.complete({
+      system:    systemPrompt,
+      messages:  [{
+        role: "user",
+        content: `Provider: ${provider} | Monthly bill: $${(amountCents / 100).toFixed(2)} | Speed: ${mbps} Mbps | Zip: ${zipCode}`,
+      }],
+      maxTokens: 512,
+    });
+
+    const jsonMatch = text.match(/\{[\s\S]*\}/);
+    if (!jsonMatch) {
+      res.status(500).json({ error: PROVIDER_JSON_ERROR });
+      return;
+    }
+    res.json(JSON.parse(jsonMatch[0]));
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "Unknown error";
+    res.status(500).json({ error: msg });
+  }
+});
+
 // ── POST /api/extract-document ───────────────────────────────────────────────
 // Issue #51 — General document OCR: appliance manuals, warranty cards, receipts,
 // inspection reports, permits.

--- a/backend/bills/main.mo
+++ b/backend/bills/main.mo
@@ -86,6 +86,12 @@ persistent actor Bills {
     #TierLimitReached : Text;
   };
 
+  public type UsagePeriod = {
+    periodStart : Text;
+    usageAmount : Float;
+    usageUnit   : Text;
+  };
+
   public type Metrics = {
     totalBills  : Nat;
     isPaused    : Bool;
@@ -300,6 +306,47 @@ persistent actor Bills {
       }
     );
     #ok(result)
+  };
+
+  /// Return usage-tracked periods for (propertyId, billType) sorted chronologically,
+  /// limited to the last `months` months. Only bills with a usageAmount are included.
+  public shared(msg) func getUsageTrend(
+    propertyId : Text,
+    billType   : BillType,
+    months     : Nat,
+  ) : async Result.Result<[UsagePeriod], Error> {
+    let cutoffNs : Int = Time.now() - (months * 30 * 24 * 3_600_000_000_000 : Nat);
+    var periods : [UsagePeriod] = [];
+
+    for ((_, b) in Map.entries(bills)) {
+      if (b.propertyId == propertyId
+          and Principal.equal(b.homeowner, msg.caller)
+          and billTypeEq(b.billType, billType)
+          and b.uploadedAt >= cutoffNs)
+      {
+        switch (b.usageAmount) {
+          case null {};
+          case (?amount) {
+            switch (b.usageUnit) {
+              case null {};
+              case (?unit) {
+                periods := Array.concat(periods, [{
+                  periodStart = b.periodStart;
+                  usageAmount = amount;
+                  usageUnit   = unit;
+                }]);
+              };
+            };
+          };
+        };
+      };
+    };
+
+    // Sort chronologically by periodStart (lexicographic on YYYY-MM-DD is correct)
+    let sorted = Array.sort<UsagePeriod>(periods, func(a, b) {
+      Text.compare(a.periodStart, b.periodStart)
+    });
+    #ok(sorted)
   };
 
   /// Delete a specific bill record. Caller must be the owner or an admin.

--- a/frontend/src/__tests__/integration/bills.integration.test.ts
+++ b/frontend/src/__tests__/integration/bills.integration.test.ts
@@ -1,0 +1,297 @@
+/**
+ * Integration tests — billService against the real ICP bills canister.
+ *
+ * Requires: dfx start --background && make deploy
+ * Run:      npm run test:integration  (from repo root)
+ *
+ * What these tests prove that unit tests cannot:
+ *   - Candid IDL serialization is correct (BigInt, Opt, Variant encoding)
+ *   - toRecord() / fromVariant() convert all fields without data loss
+ *   - Principal scoping: you only read back your own bills (callers cannot
+ *     see each other's data even with the same propertyId)
+ *   - Anomaly detection fires at the canister level (not just in the mock)
+ *   - getUsageTrend() Motoko query runs and returns correctly sorted data
+ *   - Tier enforcement blocks a Free-tier second upload in the same month
+ *   - deleteBill() removes the record from canister state
+ *
+ * Test isolation: each test uses a unique propertyId derived from the test
+ * start timestamp so parallel runs (on different machines) never collide.
+ */
+
+import { describe, it, expect, beforeAll } from "vitest";
+import { billService } from "@/services/billService";
+import { getUsageTrend, analyzeEfficiencyTrend } from "@/services/billsIntelligence";
+import { TEST_PRINCIPAL } from "./setup";
+
+// ─── Skip guard ───────────────────────────────────────────────────────────────
+// Tests skip themselves cleanly when the canister isn't deployed (CI without replica).
+
+const CANISTER_ID = process.env.BILLS_CANISTER_ID || "";
+const deployed = !!CANISTER_ID;
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+// Unique per test-run — prevents state bleed across runs on the same replica
+const RUN_ID = Date.now();
+
+function propId(label: string) {
+  return `test-${label}-${RUN_ID}`;
+}
+
+const BASE_ARGS = {
+  provider:    "FPL",
+  periodStart: "2024-01-01",
+  periodEnd:   "2024-01-31",
+  amountCents: 9_500,
+};
+
+// ─── addBill / getBillsForProperty ────────────────────────────────────────────
+
+describe.skipIf(!deployed)("addBill — Candid serialization", () => {
+  it("returns a BillRecord with a non-empty id", async () => {
+    const record = await billService.addBill({
+      ...BASE_ARGS,
+      propertyId: propId("candid-id"),
+      billType: "Electric",
+    });
+    expect(record.id).toBeTruthy();
+    expect(typeof record.id).toBe("string");
+  });
+
+  it("amountCents survives BigInt round-trip without truncation", async () => {
+    const record = await billService.addBill({
+      ...BASE_ARGS,
+      propertyId:  propId("bigint"),
+      billType:    "Electric",
+      amountCents: 12_345,
+    });
+    expect(record.amountCents).toBe(12_345);
+  });
+
+  it("Optional usageAmount and usageUnit are preserved (Opt round-trip)", async () => {
+    const record = await billService.addBill({
+      ...BASE_ARGS,
+      propertyId:  propId("opt"),
+      billType:    "Electric",
+      usageAmount: 842.5,
+      usageUnit:   "kWh",
+    });
+    expect(record.usageAmount).toBeCloseTo(842.5, 2);
+    expect(record.usageUnit).toBe("kWh");
+  });
+
+  it("usageAmount and usageUnit are undefined when not provided", async () => {
+    const record = await billService.addBill({
+      ...BASE_ARGS,
+      propertyId: propId("no-opt"),
+      billType:   "Gas",
+    });
+    expect(record.usageAmount).toBeUndefined();
+    expect(record.usageUnit).toBeUndefined();
+  });
+
+  it("billType Variant round-trips correctly for all six variants", async () => {
+    const pid = propId("variants");
+    const types = ["Electric", "Gas", "Water", "Internet", "Telecom", "Other"] as const;
+
+    for (const billType of types) {
+      const record = await billService.addBill({
+        ...BASE_ARGS,
+        propertyId: pid,
+        billType,
+        periodStart: `2024-${String(types.indexOf(billType) + 1).padStart(2, "0")}-01`,
+        periodEnd:   `2024-${String(types.indexOf(billType) + 1).padStart(2, "0")}-28`,
+      });
+      expect(record.billType).toBe(billType);
+    }
+  });
+
+  it("uploadedAt is a recent ms timestamp (ns→ms conversion is applied)", async () => {
+    const before = Date.now() - 5_000;
+    const record = await billService.addBill({
+      ...BASE_ARGS,
+      propertyId: propId("timestamp"),
+      billType:   "Electric",
+    });
+    const after = Date.now() + 5_000;
+    // If ns→ms conversion was missed, uploadedAt would be ~1e18 (year ~33000)
+    expect(record.uploadedAt).toBeGreaterThan(before);
+    expect(record.uploadedAt).toBeLessThan(after);
+  });
+
+  it("homeowner field matches the test identity's principal", async () => {
+    const record = await billService.addBill({
+      ...BASE_ARGS,
+      propertyId: propId("principal"),
+      billType:   "Water",
+    });
+    expect(record.homeowner).toBe(TEST_PRINCIPAL);
+  });
+});
+
+// ─── getBillsForProperty ──────────────────────────────────────────────────────
+
+describe.skipIf(!deployed)("getBillsForProperty — principal scoping & retrieval", () => {
+  const pid = propId("get-bills");
+
+  beforeAll(async () => {
+    // Seed two bills into this property
+    await billService.addBill({ ...BASE_ARGS, propertyId: pid, billType: "Electric", periodStart: "2024-01-01", periodEnd: "2024-01-31" });
+    await billService.addBill({ ...BASE_ARGS, propertyId: pid, billType: "Gas",      periodStart: "2024-02-01", periodEnd: "2024-02-28" });
+  });
+
+  it("returns both bills added to the property", async () => {
+    const bills = await billService.getBillsForProperty(pid);
+    expect(bills.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("all returned bills have correct propertyId", async () => {
+    const bills = await billService.getBillsForProperty(pid);
+    expect(bills.every((b) => b.propertyId === pid)).toBe(true);
+  });
+
+  it("all returned bills belong to the test principal (caller scoping)", async () => {
+    const bills = await billService.getBillsForProperty(pid);
+    expect(bills.every((b) => b.homeowner === TEST_PRINCIPAL)).toBe(true);
+  });
+
+  it("returns empty array for a property with no bills", async () => {
+    const bills = await billService.getBillsForProperty(propId("empty-property"));
+    expect(bills).toHaveLength(0);
+  });
+});
+
+// ─── Anomaly detection ────────────────────────────────────────────────────────
+
+describe.skipIf(!deployed)("anomaly detection — canister-level (not just mock)", () => {
+  const pid = propId("anomaly");
+
+  it("anomalyFlag is false when only one bill exists (no baseline yet)", async () => {
+    const record = await billService.addBill({
+      ...BASE_ARGS,
+      propertyId:  propId("anomaly-single"),
+      billType:    "Electric",
+      amountCents: 10_000,
+    });
+    expect(record.anomalyFlag).toBe(false);
+    expect(record.anomalyReason).toBeUndefined();
+  });
+
+  it("anomalyFlag is true when the third bill is >20% above the baseline", async () => {
+    // Bill 1 + 2 establish a baseline of ~10_000 cents
+    await billService.addBill({ ...BASE_ARGS, propertyId: pid, billType: "Electric", amountCents: 10_000, periodStart: "2023-10-01", periodEnd: "2023-10-31" });
+    await billService.addBill({ ...BASE_ARGS, propertyId: pid, billType: "Electric", amountCents: 10_200, periodStart: "2023-11-01", periodEnd: "2023-11-30" });
+    // Bill 3: 25% above baseline → should flag
+    const record = await billService.addBill({ ...BASE_ARGS, propertyId: pid, billType: "Electric", amountCents: 12_800, periodStart: "2023-12-01", periodEnd: "2023-12-31" });
+
+    expect(record.anomalyFlag).toBe(true);
+    expect(record.anomalyReason).toBeTruthy();
+    expect(typeof record.anomalyReason).toBe("string");
+  });
+});
+
+// ─── deleteBill ───────────────────────────────────────────────────────────────
+
+describe.skipIf(!deployed)("deleteBill — removes from canister state", () => {
+  it("deleted bill is no longer returned by getBillsForProperty", async () => {
+    const pid = propId("delete");
+    const record = await billService.addBill({
+      ...BASE_ARGS,
+      propertyId: pid,
+      billType:   "Water",
+    });
+
+    await billService.deleteBill(record.id);
+
+    const remaining = await billService.getBillsForProperty(pid);
+    expect(remaining.find((b) => b.id === record.id)).toBeUndefined();
+  });
+
+  it("deleting a non-existent bill throws", async () => {
+    await expect(billService.deleteBill("BILL_DOES_NOT_EXIST_99999")).rejects.toThrow();
+  });
+});
+
+// ─── getUsageTrend (new Motoko query) ────────────────────────────────────────
+
+describe.skipIf(!deployed)("getUsageTrend — Motoko query round-trip", () => {
+  const pid = propId("usage-trend");
+
+  beforeAll(async () => {
+    // Seed 3 Electric bills with ascending usage over 3 months
+    const bills = [
+      { amountCents: 9_000, usageAmount: 800, usageUnit: "kWh", periodStart: "2024-01-01", periodEnd: "2024-01-31" },
+      { amountCents: 9_500, usageAmount: 850, usageUnit: "kWh", periodStart: "2024-02-01", periodEnd: "2024-02-29" },
+      { amountCents: 9_800, usageAmount: 900, usageUnit: "kWh", periodStart: "2024-03-01", periodEnd: "2024-03-31" },
+    ];
+    for (const b of bills) {
+      await billService.addBill({ ...BASE_ARGS, ...b, propertyId: pid, billType: "Electric", provider: "FPL" });
+    }
+  });
+
+  it("returns UsagePeriod array with usageAmount and usageUnit for each bill", async () => {
+    const trend = await getUsageTrend(pid, "Electric", 12);
+    expect(trend.length).toBeGreaterThanOrEqual(3);
+    for (const period of trend) {
+      expect(typeof period.usageAmount).toBe("number");
+      expect(period.usageUnit).toBe("kWh");
+      expect(period.periodStart).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    }
+  });
+
+  it("returns periods sorted chronologically by periodStart", async () => {
+    const trend = await getUsageTrend(pid, "Electric", 12);
+    for (let i = 1; i < trend.length; i++) {
+      expect(trend[i].periodStart >= trend[i - 1].periodStart).toBe(true);
+    }
+  });
+
+  it("excludes bills without usageAmount from the trend", async () => {
+    const pidMixed = propId("usage-mixed");
+    await billService.addBill({ ...BASE_ARGS, propertyId: pidMixed, billType: "Electric", usageAmount: 800, usageUnit: "kWh" });
+    await billService.addBill({ ...BASE_ARGS, propertyId: pidMixed, billType: "Electric" /* no usage */ });
+
+    const trend = await getUsageTrend(pidMixed, "Electric", 12);
+    expect(trend.every((p) => typeof p.usageAmount === "number")).toBe(true);
+    expect(trend).toHaveLength(1);
+  });
+
+  it("analyzeEfficiencyTrend correctly identifies degradation from canister data", async () => {
+    // Add two more high-usage bills to push the late average well above the early average
+    await billService.addBill({ ...BASE_ARGS, propertyId: pid, billType: "Electric", usageAmount: 1_100, usageUnit: "kWh", periodStart: "2024-04-01", periodEnd: "2024-04-30" });
+    await billService.addBill({ ...BASE_ARGS, propertyId: pid, billType: "Electric", usageAmount: 1_150, usageUnit: "kWh", periodStart: "2024-05-01", periodEnd: "2024-05-31" });
+    await billService.addBill({ ...BASE_ARGS, propertyId: pid, billType: "Electric", usageAmount: 1_200, usageUnit: "kWh", periodStart: "2024-06-01", periodEnd: "2024-06-30" });
+
+    const trend = await getUsageTrend(pid, "Electric", 24);
+    const analysis = analyzeEfficiencyTrend(trend);
+
+    // Early avg ~850 kWh, late avg ~1150 kWh → ~35% increase → degradation
+    expect(analysis.degradationDetected).toBe(true);
+    expect(analysis.estimatedAnnualWaste).toBeGreaterThan(0);
+  });
+});
+
+// ─── Tier enforcement ─────────────────────────────────────────────────────────
+
+describe.skipIf(!deployed)("tier enforcement — Free tier monthly upload limit", () => {
+  it("second upload in the same month is rejected for a Free-tier caller", async () => {
+    // The test identity is Free tier by default (no grantTier called)
+    const pid = propId("tier-limit");
+
+    // First upload should succeed
+    await billService.addBill({
+      ...BASE_ARGS,
+      propertyId: pid,
+      billType:   "Electric",
+    });
+
+    // Second upload in the same month should be rejected
+    await expect(
+      billService.addBill({
+        ...BASE_ARGS,
+        propertyId: pid,
+        billType:   "Gas",
+      })
+    ).rejects.toThrow(/Free plan|TierLimitReached|1 bill/i);
+  });
+});

--- a/frontend/src/__tests__/integration/setup.ts
+++ b/frontend/src/__tests__/integration/setup.ts
@@ -1,0 +1,64 @@
+/**
+ * Integration test global setup.
+ *
+ * Runs once before any integration test file. Creates a deterministic
+ * Ed25519 identity (same seed as loginWithLocalIdentity) and injects it
+ * into the ICP agent singleton so all service calls use a consistent principal
+ * without requiring a browser or Internet Identity round-trip.
+ *
+ * If the local replica is not reachable, a clear error is thrown rather than
+ * letting tests fail with cryptic network errors.
+ */
+
+import { beforeAll, afterAll } from "vitest";
+import { HttpAgent } from "@icp-sdk/core/agent";
+import { Ed25519KeyIdentity } from "@icp-sdk/core/identity";
+import { setAgentForTesting } from "@/services/actor";
+
+// ─── Deterministic test identity ──────────────────────────────────────────────
+// Fixed seed → same principal every run → canister ownership checks are stable.
+// This matches the seed used by loginWithLocalIdentity() in dev.
+const TEST_SEED = new Uint8Array(32);
+TEST_SEED[0] = 42;
+export const testIdentity = Ed25519KeyIdentity.generate(TEST_SEED);
+export const TEST_PRINCIPAL = testIdentity.getPrincipal().toText();
+
+// ─── Replica health check ─────────────────────────────────────────────────────
+
+async function assertReplicaRunning(): Promise<void> {
+  try {
+    const res = await fetch("http://localhost:4943/api/v2/status", {
+      signal: AbortSignal.timeout(3_000),
+    });
+    if (!res.ok) throw new Error(`Replica returned ${res.status}`);
+  } catch (err) {
+    throw new Error(
+      `Local ICP replica is not running or not reachable at http://localhost:4943.\n` +
+      `Start it with: dfx start --background\n` +
+      `Then deploy with: make deploy\n` +
+      `Original error: ${err}`
+    );
+  }
+}
+
+// ─── Global setup ─────────────────────────────────────────────────────────────
+
+let agent: HttpAgent;
+
+beforeAll(async () => {
+  await assertReplicaRunning();
+
+  agent = await HttpAgent.create({
+    identity:          testIdentity,
+    host:              "http://localhost:4943",
+    shouldFetchRootKey: true,   // required for local replica (non-production)
+  });
+
+  // Inject the agent so all services use this identity instead of AuthClient
+  setAgentForTesting(agent);
+});
+
+afterAll(() => {
+  // Reset so the agent doesn't bleed into unit tests if somehow run together
+  setAgentForTesting(null as any);
+});

--- a/frontend/src/__tests__/perf/agentCompetition1354.test.ts
+++ b/frontend/src/__tests__/perf/agentCompetition1354.test.ts
@@ -1,0 +1,292 @@
+/**
+ * TDD — 13.5.4: "Agent competition" load scenario
+ *
+ * 10 agents simultaneously submit proposals to the same open ListingBidRequest.
+ * Tests write contention invariants on the listing service's in-memory mock
+ * (which mirrors the behavioral guarantees the ICP canister must uphold).
+ *
+ * Invariants under concurrent load:
+ *   A. No proposals are lost — all 10 writes persist.
+ *   B. All proposal IDs are unique — no collision from concurrent ID generation.
+ *   C. Proposals are scoped to their request — no cross-request bleed.
+ *   D. Deadline enforcement holds under contention — a late submit is rejected
+ *      even when 9 concurrent submits are in-flight on the same request.
+ *   E. Request status is not mutated by proposal writes — stays "Open".
+ *   F. Concurrent throughput — 10 proposals complete in < 200ms wall clock.
+ *   G. Sealed-bid gate — proposals are hidden until the deadline passes.
+ *   H. Mixed-request isolation — proposals for req-A are not returned for req-B.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { listingService, type SubmitProposalInput } from "@/services/listing";
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const FUTURE = Date.now() + 60_000;   // open window
+const PAST   = Date.now() - 60_000;   // expired window
+
+function makeBidRequest(bidDeadline = FUTURE) {
+  return listingService.createBidRequest({
+    propertyId:       "prop-1",
+    targetListDate:   Date.now() + 86_400_000,
+    desiredSalePrice: 55_000_000,   // $550k
+    notes:            "Motivated seller",
+    bidDeadline,
+  });
+}
+
+function makeProposalInput(agentIndex: number): SubmitProposalInput {
+  return {
+    agentName:             `Agent ${agentIndex}`,
+    agentBrokerage:        `Brokerage ${agentIndex}`,
+    commissionBps:         250 + agentIndex,          // 2.5–3.5%
+    cmaSummary:            `CMA from agent ${agentIndex}`,
+    marketingPlan:         `Marketing plan from agent ${agentIndex}`,
+    estimatedDaysOnMarket: 21 + agentIndex,
+    estimatedSalePrice:    54_000_000 + agentIndex * 10_000,
+    includedServices:      ["Photography", "Staging"],
+    validUntil:            Date.now() + 7 * 86_400_000,
+    coverLetter:           `Cover letter from agent ${agentIndex}`,
+  };
+}
+
+const AGENTS = Array.from({ length: 10 }, (_, i) => i);
+
+// ─── Suite ────────────────────────────────────────────────────────────────────
+
+describe("13.5.4: agent competition — 10 concurrent proposals on one request", () => {
+  beforeEach(() => listingService.reset());
+  afterEach(() => vi.useRealTimers());
+
+  // ── A. No proposals lost ──────────────────────────────────────────────────
+
+  it("A: all 10 concurrent proposals are accepted and persisted", async () => {
+    const req = await makeBidRequest();
+
+    const results = await Promise.all(
+      AGENTS.map((i) => listingService.submitProposal(req.id, makeProposalInput(i)))
+    );
+
+    expect(results).toHaveLength(10);
+    expect(results.every((p) => p !== null && typeof p === "object")).toBe(true);
+  });
+
+  it("A: every proposal resolves without throwing", async () => {
+    const req = await makeBidRequest();
+
+    const settled = await Promise.allSettled(
+      AGENTS.map((i) => listingService.submitProposal(req.id, makeProposalInput(i)))
+    );
+
+    const rejected = settled.filter((r) => r.status === "rejected");
+    expect(rejected).toHaveLength(0);
+  });
+
+  // ── B. Unique IDs — no collision ─────────────────────────────────────────
+
+  it("B: all 10 proposals receive distinct IDs", async () => {
+    const req = await makeBidRequest();
+
+    const proposals = await Promise.all(
+      AGENTS.map((i) => listingService.submitProposal(req.id, makeProposalInput(i)))
+    );
+
+    const ids = proposals.map((p) => p.id);
+    const uniqueIds = new Set(ids);
+    expect(uniqueIds.size).toBe(10);
+  });
+
+  it("B: proposal IDs are non-empty strings", async () => {
+    const req = await makeBidRequest();
+
+    const proposals = await Promise.all(
+      AGENTS.map((i) => listingService.submitProposal(req.id, makeProposalInput(i)))
+    );
+
+    for (const p of proposals) {
+      expect(typeof p.id).toBe("string");
+      expect(p.id.length).toBeGreaterThan(0);
+    }
+  });
+
+  // ── C. Request scoping — proposals belong to correct request ─────────────
+
+  it("C: all proposals have requestId matching the target request", async () => {
+    const req = await makeBidRequest();
+
+    const proposals = await Promise.all(
+      AGENTS.map((i) => listingService.submitProposal(req.id, makeProposalInput(i)))
+    );
+
+    for (const p of proposals) {
+      expect(p.requestId).toBe(req.id);
+    }
+  });
+
+  it("C: getProposalsForRequest returns exactly 10 proposals after deadline", async () => {
+    const now = Date.now();
+    vi.setSystemTime(now);
+    const deadline = now + 5_000;
+    const req = await makeBidRequest(deadline);
+
+    // Submit while open
+    await Promise.all(
+      AGENTS.map((i) => listingService.submitProposal(req.id, makeProposalInput(i)))
+    );
+
+    // Advance past deadline → proposals become visible
+    vi.setSystemTime(now + 10_000);
+    const retrieved = await listingService.getProposalsForRequest(req.id);
+    expect(retrieved).toHaveLength(10);
+  });
+
+  it("C: each agent's data is preserved intact (no write overwriting another)", async () => {
+    const now = Date.now();
+    vi.setSystemTime(now);
+    const req = await makeBidRequest(now + 5_000);
+
+    await Promise.all(
+      AGENTS.map((i) => listingService.submitProposal(req.id, makeProposalInput(i)))
+    );
+
+    vi.setSystemTime(now + 10_000);
+    const retrieved = await listingService.getProposalsForRequest(req.id);
+
+    // Each unique agent name appears exactly once
+    const names = retrieved.map((p) => p.agentName);
+    const uniqueNames = new Set(names);
+    expect(uniqueNames.size).toBe(10);
+  });
+
+  // ── D. Deadline enforcement under contention ──────────────────────────────
+
+  it("D: a submission after the deadline is rejected even when concurrent submits are accepted", async () => {
+    const req = await makeBidRequest(PAST);   // deadline already passed
+
+    // All 10 should fail — deadline is in the past
+    const settled = await Promise.allSettled(
+      AGENTS.map((i) => listingService.submitProposal(req.id, makeProposalInput(i)))
+    );
+
+    const rejected = settled.filter((r) => r.status === "rejected");
+    expect(rejected).toHaveLength(10);
+  });
+
+  it("D: 9 in-window proposals succeed while a simultaneous post-deadline request fails", async () => {
+    // 9 agents get an open request; the 10th targets a closed one
+    const openReq   = await makeBidRequest(FUTURE);
+    const closedReq = await makeBidRequest(PAST);
+
+    const settled = await Promise.allSettled([
+      ...AGENTS.slice(0, 9).map((i) => listingService.submitProposal(openReq.id,   makeProposalInput(i))),
+      listingService.submitProposal(closedReq.id, makeProposalInput(9)),
+    ]);
+
+    const fulfilled = settled.filter((r) => r.status === "fulfilled");
+    const rejected  = settled.filter((r) => r.status === "rejected");
+    expect(fulfilled).toHaveLength(9);
+    expect(rejected).toHaveLength(1);
+  });
+
+  // ── E. Request status not mutated by proposal writes ─────────────────────
+
+  it("E: bid request status remains Open after 10 concurrent proposals", async () => {
+    const req = await makeBidRequest();
+
+    await Promise.all(
+      AGENTS.map((i) => listingService.submitProposal(req.id, makeProposalInput(i)))
+    );
+
+    const refreshed = await listingService.getBidRequest(req.id);
+    expect(refreshed?.status).toBe("Open");
+  });
+
+  // ── F. Throughput — 10 proposals in < 200ms ───────────────────────────────
+
+  it("F: 10 concurrent proposals complete in < 200ms", async () => {
+    const req = await makeBidRequest();
+
+    const t0 = performance.now();
+    await Promise.all(
+      AGENTS.map((i) => listingService.submitProposal(req.id, makeProposalInput(i)))
+    );
+    const elapsed = performance.now() - t0;
+
+    expect(
+      elapsed,
+      `10 concurrent submitProposal calls took ${elapsed.toFixed(0)}ms — exceeds 200ms budget`
+    ).toBeLessThan(200);
+  });
+
+  // ── G. Sealed-bid gate under contention ──────────────────────────────────
+
+  it("G: proposals are hidden (empty array) while deadline is still in the future", async () => {
+    const req = await makeBidRequest(FUTURE);
+
+    await Promise.all(
+      AGENTS.map((i) => listingService.submitProposal(req.id, makeProposalInput(i)))
+    );
+
+    // Sealed — should return no proposals while deadline is open
+    const sealed = await listingService.getProposalsForRequest(req.id);
+    expect(sealed).toHaveLength(0);
+  });
+
+  it("G: proposals are visible after deadline passes (unsealed)", async () => {
+    const now = Date.now();
+    vi.setSystemTime(now);
+    const req = await makeBidRequest(now + 5_000);
+
+    // Submit before deadline
+    await Promise.all(
+      AGENTS.map((i) => listingService.submitProposal(req.id, makeProposalInput(i)))
+    );
+
+    // Advance past deadline
+    vi.setSystemTime(now + 10_000);
+    const unsealed = await listingService.getProposalsForRequest(req.id);
+    expect(unsealed.length).toBeGreaterThan(0);
+  });
+
+  // ── H. Multi-request isolation ────────────────────────────────────────────
+
+  it("H: proposals for request-A are not returned when querying request-B", async () => {
+    const now = Date.now();
+    vi.setSystemTime(now);
+    const reqA = await makeBidRequest(now + 5_000);
+    const reqB = await makeBidRequest(now + 5_000);
+
+    // 10 proposals on req-A, none on req-B
+    await Promise.all(
+      AGENTS.map((i) => listingService.submitProposal(reqA.id, makeProposalInput(i)))
+    );
+
+    vi.setSystemTime(now + 10_000);
+    const proposalsForB = await listingService.getProposalsForRequest(reqB.id);
+    expect(proposalsForB).toHaveLength(0);
+  });
+
+  it("H: each request's proposals are isolated when both receive concurrent submissions", async () => {
+    const now = Date.now();
+    vi.setSystemTime(now);
+    const reqA = await makeBidRequest(now + 5_000);
+    const reqB = await makeBidRequest(now + 5_000);
+
+    // 5 agents submit to each request concurrently
+    await Promise.all([
+      ...AGENTS.slice(0, 5).map((i) => listingService.submitProposal(reqA.id, makeProposalInput(i))),
+      ...AGENTS.slice(5, 10).map((i) => listingService.submitProposal(reqB.id, makeProposalInput(i))),
+    ]);
+
+    vi.setSystemTime(now + 10_000);
+    const [proposalsA, proposalsB] = await Promise.all([
+      listingService.getProposalsForRequest(reqA.id),
+      listingService.getProposalsForRequest(reqB.id),
+    ]);
+
+    expect(proposalsA).toHaveLength(5);
+    expect(proposalsB).toHaveLength(5);
+    expect(proposalsA.every((p) => p.requestId === reqA.id)).toBe(true);
+    expect(proposalsB.every((p) => p.requestId === reqB.id)).toBe(true);
+  });
+});

--- a/frontend/src/__tests__/services/billsIntelligence56.test.ts
+++ b/frontend/src/__tests__/services/billsIntelligence56.test.ts
@@ -1,0 +1,306 @@
+/**
+ * TDD — Epic #49 Stories 3–6 (Issue #56)
+ *
+ * Story 3 — System Efficiency Degradation Alerts
+ *   getUsageTrend()        — filters + sorts bills into UsagePeriod[]
+ *   analyzeEfficiencyTrend() — pure function; detects rising usage trend
+ *
+ * Story 4 — Rebate & Incentive Finder
+ *   findRebates()          — shape + validation (fetch is mocked)
+ *
+ * Story 5 — Insurance Premium Triggers
+ *   deriveEvents()         — water anomaly → insurance_trigger event emitted
+ *
+ * Story 6 — Telecom Negotiation Assistant
+ *   negotiateTelecom()     — shape + validation (fetch is mocked)
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import {
+  analyzeEfficiencyTrend,
+  getUsageTrend,
+  findRebates,
+  negotiateTelecom,
+  type UsagePeriod,
+  type EfficiencyAnalysisResult,
+  type RebateResult,
+  type TelecomNegotiationResult,
+} from "@/services/billsIntelligence";
+
+import { deriveEvents } from "@/components/Layout";
+import type { BillRecord } from "@/services/billService";
+
+// ─── Story 3 — analyzeEfficiencyTrend (pure function) ────────────────────────
+
+describe("analyzeEfficiencyTrend — Story 3", () => {
+  it("returns degradationDetected:false when fewer than 3 periods provided", () => {
+    const trend: UsagePeriod[] = [
+      { periodStart: "2024-01-01", usageAmount: 800, usageUnit: "kWh" },
+      { periodStart: "2024-02-01", usageAmount: 850, usageUnit: "kWh" },
+    ];
+    const result = analyzeEfficiencyTrend(trend);
+    expect(result.degradationDetected).toBe(false);
+  });
+
+  it("returns degradationDetected:false for flat usage", () => {
+    const trend: UsagePeriod[] = [
+      { periodStart: "2024-01-01", usageAmount: 800, usageUnit: "kWh" },
+      { periodStart: "2024-02-01", usageAmount: 810, usageUnit: "kWh" },
+      { periodStart: "2024-03-01", usageAmount: 795, usageUnit: "kWh" },
+    ];
+    const result = analyzeEfficiencyTrend(trend);
+    expect(result.degradationDetected).toBe(false);
+  });
+
+  it("returns degradationDetected:true when late usage is >15% above early usage", () => {
+    // Early avg: 800, Late avg: 950 → +18.75% → degradation
+    const trend: UsagePeriod[] = [
+      { periodStart: "2024-01-01", usageAmount: 800, usageUnit: "kWh" },
+      { periodStart: "2024-02-01", usageAmount: 810, usageUnit: "kWh" },
+      { periodStart: "2024-03-01", usageAmount: 820, usageUnit: "kWh" },
+      { periodStart: "2024-04-01", usageAmount: 940, usageUnit: "kWh" },
+      { periodStart: "2024-05-01", usageAmount: 950, usageUnit: "kWh" },
+      { periodStart: "2024-06-01", usageAmount: 960, usageUnit: "kWh" },
+    ];
+    const result = analyzeEfficiencyTrend(trend);
+    expect(result.degradationDetected).toBe(true);
+    expect(result.estimatedAnnualWaste).toBeGreaterThan(0);
+    expect(typeof result.recommendation).toBe("string");
+    expect(result.trendPct).toBeGreaterThan(15);
+  });
+
+  it("includes the usage unit in the recommendation text", () => {
+    const trend: UsagePeriod[] = [
+      { periodStart: "2024-01-01", usageAmount: 3000, usageUnit: "gallons" },
+      { periodStart: "2024-02-01", usageAmount: 3050, usageUnit: "gallons" },
+      { periodStart: "2024-03-01", usageAmount: 3060, usageUnit: "gallons" },
+      { periodStart: "2024-04-01", usageAmount: 3600, usageUnit: "gallons" },
+      { periodStart: "2024-05-01", usageAmount: 3650, usageUnit: "gallons" },
+      { periodStart: "2024-06-01", usageAmount: 3700, usageUnit: "gallons" },
+    ];
+    const result = analyzeEfficiencyTrend(trend);
+    expect(result.degradationDetected).toBe(true);
+    expect(result.recommendation).toContain("gallons");
+  });
+
+  it("estimatedAnnualWaste = (lateAvg - earlyAvg) * 12", () => {
+    // earlyAvg = 800, lateAvg = 960 → waste = 160/period × 12 = 1920
+    const trend: UsagePeriod[] = [
+      { periodStart: "2024-01-01", usageAmount: 800, usageUnit: "kWh" },
+      { periodStart: "2024-02-01", usageAmount: 800, usageUnit: "kWh" },
+      { periodStart: "2024-03-01", usageAmount: 960, usageUnit: "kWh" },
+      { periodStart: "2024-04-01", usageAmount: 960, usageUnit: "kWh" },
+    ];
+    const result = analyzeEfficiencyTrend(trend);
+    expect(result.degradationDetected).toBe(true);
+    expect(result.estimatedAnnualWaste).toBeCloseTo(1920, 0);
+  });
+});
+
+// ─── Story 3 — getUsageTrend ──────────────────────────────────────────────────
+
+import { billService } from "@/services/billService";
+
+describe("getUsageTrend — Story 3", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns only bills with usageAmount for the given billType, sorted chronologically", async () => {
+    vi.setSystemTime(new Date("2024-06-01"));
+    vi.spyOn(billService, "getBillsForProperty").mockResolvedValue([
+      { id: "1", billType: "Electric", periodStart: "2024-03-01", usageAmount: 900, usageUnit: "kWh", amountCents: 12000, propertyId: "p1", homeowner: "h", provider: "FPL", periodEnd: "2024-03-31", uploadedAt: 0, anomalyFlag: false },
+      { id: "2", billType: "Electric", periodStart: "2024-01-01", usageAmount: 800, usageUnit: "kWh", amountCents: 11000, propertyId: "p1", homeowner: "h", provider: "FPL", periodEnd: "2024-01-31", uploadedAt: 0, anomalyFlag: false },
+      { id: "3", billType: "Water",    periodStart: "2024-02-01", usageAmount: 2000, usageUnit: "gallons", amountCents: 4000, propertyId: "p1", homeowner: "h", provider: "TECO", periodEnd: "2024-02-28", uploadedAt: 0, anomalyFlag: false },
+      { id: "4", billType: "Electric", periodStart: "2024-02-01", usageAmount: undefined, usageUnit: undefined, amountCents: 9000, propertyId: "p1", homeowner: "h", provider: "FPL", periodEnd: "2024-02-28", uploadedAt: 0, anomalyFlag: false },
+    ] as any);
+
+    const trend = await getUsageTrend("prop-1", "Electric", 6);
+
+    // Only Electric bills with usageAmount, sorted by periodStart ascending
+    expect(trend).toHaveLength(2);
+    expect(trend[0].periodStart).toBe("2024-01-01");
+    expect(trend[1].periodStart).toBe("2024-03-01");
+    expect(trend[0].usageAmount).toBe(800);
+    vi.useRealTimers();
+  });
+
+  it("limits to the requested number of months", async () => {
+    const now = new Date("2024-06-01");
+    vi.setSystemTime(now);
+
+    vi.spyOn(billService, "getBillsForProperty").mockResolvedValue([
+      // 8 months old — outside a 6-month window
+      { id: "1", billType: "Electric", periodStart: "2023-10-01", usageAmount: 700, usageUnit: "kWh", amountCents: 9000, propertyId: "p1", homeowner: "h", provider: "FPL", periodEnd: "2023-10-31", uploadedAt: 0, anomalyFlag: false },
+      { id: "2", billType: "Electric", periodStart: "2024-04-01", usageAmount: 900, usageUnit: "kWh", amountCents: 12000, propertyId: "p1", homeowner: "h", provider: "FPL", periodEnd: "2024-04-30", uploadedAt: 0, anomalyFlag: false },
+      { id: "3", billType: "Electric", periodStart: "2024-05-01", usageAmount: 950, usageUnit: "kWh", amountCents: 13000, propertyId: "p1", homeowner: "h", provider: "FPL", periodEnd: "2024-05-31", uploadedAt: 0, anomalyFlag: false },
+    ] as any);
+
+    const trend = await getUsageTrend("prop-1", "Electric", 6);
+    expect(trend.every((p) => p.periodStart >= "2023-12-01")).toBe(true);
+
+    vi.useRealTimers();
+  });
+});
+
+// ─── Story 4 — findRebates ────────────────────────────────────────────────────
+
+describe("findRebates — Story 4", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns an array of rebate objects with required fields", async () => {
+    const mockRebates: RebateResult[] = [
+      {
+        name: "FPL Smart Thermostat Rebate",
+        description: "Up to $75 rebate for smart thermostat installation",
+        estimatedAmount: "$75",
+        provider: "FPL",
+        url: "https://fpl.com/rebates",
+      },
+    ];
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ rebates: mockRebates }),
+    } as any);
+
+    const result = await findRebates({
+      state: "FL",
+      zipCode: "32801",
+      utilityProvider: "FPL",
+      billType: "Electric",
+    });
+
+    expect(Array.isArray(result)).toBe(true);
+    expect(result[0]).toMatchObject({
+      name: expect.any(String),
+      description: expect.any(String),
+      estimatedAmount: expect.any(String),
+      provider: expect.any(String),
+    });
+  });
+
+  it("throws when billType is not Electric", async () => {
+    await expect(
+      findRebates({ state: "FL", zipCode: "32801", utilityProvider: "TECO", billType: "Gas" })
+    ).rejects.toThrow();
+  });
+
+  it("throws when server returns non-ok response", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      json: async () => ({ error: "Server error" }),
+    } as any);
+
+    await expect(
+      findRebates({ state: "FL", zipCode: "32801", utilityProvider: "FPL", billType: "Electric" })
+    ).rejects.toThrow();
+  });
+});
+
+// ─── Story 5 — deriveEvents insurance_trigger ─────────────────────────────────
+
+describe("deriveEvents — insurance_trigger (Story 5)", () => {
+  const baseBill = (overrides: Partial<BillRecord>): BillRecord => ({
+    id:           "b1",
+    propertyId:   "prop-1",
+    homeowner:    "principal-1",
+    billType:     "Water",
+    provider:     "TECO Water",
+    periodStart:  "2024-05-01",
+    periodEnd:    "2024-05-31",
+    amountCents:  8000,
+    uploadedAt:   Date.now(),
+    anomalyFlag:  false,
+    ...overrides,
+  });
+
+  it("emits an insurance_trigger event for a Water bill with anomalyFlag=true", () => {
+    const bill = baseBill({ anomalyFlag: true, anomalyReason: "Bill is 35% above 3-month average" });
+    const events = deriveEvents([], [], [], [bill]);
+    const trigger = events.find((e) => e.type === "insurance_trigger");
+    expect(trigger).toBeDefined();
+    expect(trigger?.href).toBe("/insurance-defense");
+  });
+
+  it("does NOT emit insurance_trigger for non-Water anomaly bills", () => {
+    const bill = baseBill({ billType: "Electric", anomalyFlag: true });
+    const events = deriveEvents([], [], [], [bill]);
+    const trigger = events.find((e) => e.type === "insurance_trigger");
+    expect(trigger).toBeUndefined();
+  });
+
+  it("does NOT emit insurance_trigger for Water bill with no anomaly", () => {
+    const bill = baseBill({ billType: "Water", anomalyFlag: false });
+    const events = deriveEvents([], [], [], [bill]);
+    const trigger = events.find((e) => e.type === "insurance_trigger");
+    expect(trigger).toBeUndefined();
+  });
+
+  it("still emits a bill_anomaly event alongside the insurance_trigger for Water anomalies", () => {
+    const bill = baseBill({ anomalyFlag: true });
+    const events = deriveEvents([], [], [], [bill]);
+    const anomaly = events.find((e) => e.type === "bill_anomaly");
+    const trigger = events.find((e) => e.type === "insurance_trigger");
+    expect(anomaly).toBeDefined();
+    expect(trigger).toBeDefined();
+  });
+});
+
+// ─── Story 6 — negotiateTelecom ───────────────────────────────────────────────
+
+describe("negotiateTelecom — Story 6", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns verdict, medianCents, savingsOpportunityCents, and negotiationScript", async () => {
+    const mockResult: TelecomNegotiationResult = {
+      verdict: "overpaying",
+      medianCents: 5500,
+      savingsOpportunityCents: 2000,
+      negotiationScript: "Call and say: 'I've been a loyal customer...'",
+    };
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => mockResult,
+    } as any);
+
+    const result = await negotiateTelecom({
+      provider:     "Spectrum",
+      amountCents:  7500,
+      mbps:         200,
+      zipCode:      "32801",
+    });
+
+    expect(result.verdict).toBe("overpaying");
+    expect(result.medianCents).toBeGreaterThan(0);
+    expect(typeof result.negotiationScript).toBe("string");
+    expect(result.savingsOpportunityCents).toBeGreaterThanOrEqual(0);
+  });
+
+  it("throws when provider is missing", async () => {
+    await expect(
+      negotiateTelecom({ provider: "", amountCents: 7500, mbps: 200, zipCode: "32801" })
+    ).rejects.toThrow();
+  });
+
+  it("throws when amountCents is not a positive integer", async () => {
+    await expect(
+      negotiateTelecom({ provider: "Spectrum", amountCents: -100, mbps: 200, zipCode: "32801" })
+    ).rejects.toThrow();
+  });
+
+  it("throws when server returns non-ok response", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      json: async () => ({ error: "Claude API error" }),
+    } as any);
+
+    await expect(
+      negotiateTelecom({ provider: "Xfinity", amountCents: 8000, mbps: 300, zipCode: "90210" })
+    ).rejects.toThrow();
+  });
+});

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -10,7 +10,7 @@
 import React, { useState, useEffect, useMemo, useRef } from "react";
 import { Link, useNavigate, useLocation } from "react-router-dom";
 import {
-  Bell, Wrench, ShieldAlert, Clock, CheckCircle2, AlertTriangle, MessageSquare,
+  Bell, Wrench, ShieldAlert, ShieldCheck, Clock, CheckCircle2, AlertTriangle, MessageSquare,
   LayoutDashboard, TrendingUp, Users, Cpu, Home as HomeIcon, PlusSquare,
   Settings, Store, ChevronLeft, ChevronRight, LogOut, Menu, X,
   ArrowUpCircle, Paperclip, Zap,
@@ -28,16 +28,16 @@ import { COLORS, FONTS } from "@/theme";
 
 // ─── Activity event types ─────────────────────────────────────────────────────
 
-interface ActivityEvent {
+export interface ActivityEvent {
   id:        string;
-  type:      "pending_verification" | "warranty_expiring" | "job_pending_sig" | "recent_job" | "open_quote" | "bill_anomaly";
+  type:      "pending_verification" | "warranty_expiring" | "job_pending_sig" | "recent_job" | "open_quote" | "bill_anomaly" | "insurance_trigger";
   title:     string;
   detail:    string;
   href:      string;
   timestamp: number;
 }
 
-function deriveEvents(properties: any[], jobs: Job[], quotes: QuoteRequest[], bills: BillRecord[]): ActivityEvent[] {
+export function deriveEvents(properties: any[], jobs: Job[], quotes: QuoteRequest[], bills: BillRecord[]): ActivityEvent[] {
   const events: ActivityEvent[] = [];
   const now = Date.now();
 
@@ -84,6 +84,18 @@ function deriveEvents(properties: any[], jobs: Job[], quotes: QuoteRequest[], bi
         href:      `/properties/${b.propertyId}?tab=bills`,
         timestamp: b.uploadedAt,
       });
+      // Story 5 — Insurance Premium Triggers: unusual water usage may indicate
+      // a slow leak. Surface an insurance action item alongside the anomaly.
+      if (b.billType === "Water") {
+        events.push({
+          id:        `insurance-trigger-${b.id}`,
+          type:      "insurance_trigger",
+          title:     "Unusual water usage — document before filing a claim",
+          detail:    "Spike may indicate a slow leak. Log a plumbing job and generate your Insurance Defense report now.",
+          href:      "/insurance-defense",
+          timestamp: b.uploadedAt,
+        });
+      }
     }
   }
 
@@ -667,6 +679,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
                     recent_job:           <Wrench size={14} color={COLORS.plumMid} />,
                     open_quote:           <MessageSquare size={14} color={COLORS.sage} />,
                     bill_anomaly:         <Zap size={14} color="#C94C2E" />,
+                    insurance_trigger:    <ShieldCheck size={14} color={COLORS.sage} />,
                   };
                   const isUnread = event.timestamp > lastReadAt;
                   return (

--- a/frontend/src/pages/InsuranceDefensePage.tsx
+++ b/frontend/src/pages/InsuranceDefensePage.tsx
@@ -15,6 +15,7 @@ import { propertyService, Property } from "@/services/property";
 import { jobService, Job, INSURANCE_SERVICE_TYPES } from "@/services/job";
 import { sensorService, type SensorDevice, type SensorEvent } from "@/services/sensor";
 import { paymentService, type PlanTier } from "@/services/payment";
+import { billService, type BillRecord } from "@/services/billService";
 import { UpgradeGate } from "@/components/UpgradeGate";
 import { COLORS, FONTS, RADIUS, SHADOWS } from "@/theme";
 import {
@@ -69,6 +70,8 @@ export default function InsuranceDefensePage() {
   const [discountLoading,  setDiscountLoading]  = useState(false);
   const [discountError,    setDiscountError]    = useState<string | null>(null);
   const [discountExpanded, setDiscountExpanded] = useState(true);
+  // Story 5 — bill anomalies for print report
+  const [billAnomalies,    setBillAnomalies]    = useState<BillRecord[]>([]);
 
   useEffect(() => {
     paymentService.getMySubscription().then((s) => setUserTier(s.tier)).catch(() => {});
@@ -81,6 +84,13 @@ export default function InsuranceDefensePage() {
       // Load sensor devices for all properties
       Promise.all(props.map((p) => sensorService.getDevicesForProperty(String(p.id))))
         .then((perProp) => setSensorDevices(perProp.flat()))
+        .catch(() => {});
+      // Story 5 — load water bill anomalies for print report
+      Promise.all(props.map((p) => billService.getBillsForProperty(String(p.id)).catch(() => [] as BillRecord[])))
+        .then((perProp) => {
+          const anomalies = perProp.flat().filter((b) => b.anomalyFlag && b.billType === "Water");
+          setBillAnomalies(anomalies);
+        })
         .catch(() => {});
     }).finally(() => setLoading(false));
   }, []);
@@ -508,6 +518,31 @@ export default function InsuranceDefensePage() {
                       <p style={{ fontFamily: S.mono, fontSize: "0.5rem", color: d.isActive ? S.sage : S.inkLight }}>
                         {d.isActive ? "Active" : "Inactive"}
                       </p>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* Story 5 — Recent Water Bill Anomalies */}
+            {billAnomalies.length > 0 && (
+              <div style={{ marginBottom: "2rem", border: `1px solid ${S.rule}` }}>
+                <div style={{ background: S.ink, color: S.paper, padding: "0.75rem 1.25rem" }}>
+                  <p style={{ fontFamily: S.mono, fontSize: "0.6rem", letterSpacing: "0.14em", textTransform: "uppercase" }}>
+                    Recent Water Usage Anomalies — Potential Leak Documentation
+                  </p>
+                </div>
+                <div style={{ padding: "0.75rem 1.25rem", background: S.paper }}>
+                  <p style={{ fontFamily: FONTS.sans, fontSize: "0.8rem", color: S.inkLight, marginBottom: "0.75rem", lineHeight: 1.6 }}>
+                    The following water bills were flagged as significantly above baseline usage. Unusual water consumption may indicate a slow leak. These records are provided to support any related plumbing claim or preventive documentation.
+                  </p>
+                  {billAnomalies.map((b) => (
+                    <div key={b.id} style={{ display: "flex", justifyContent: "space-between", padding: "0.625rem 0", borderTop: `1px solid ${S.rule}` }}>
+                      <div>
+                        <p style={{ fontFamily: S.mono, fontSize: "0.7rem", color: S.ink }}>{b.provider} · {b.periodStart} → {b.periodEnd}</p>
+                        <p style={{ fontFamily: FONTS.sans, fontSize: "0.8rem", color: S.inkLight, marginTop: "0.2rem" }}>{b.anomalyReason ?? "Bill above 3-month average"}</p>
+                      </div>
+                      <p style={{ fontFamily: S.mono, fontWeight: 700, fontSize: "0.875rem", color: S.ink }}>${(b.amountCents / 100).toFixed(2)}</p>
                     </div>
                   ))}
                 </div>

--- a/frontend/src/pages/PropertyDetailPage.tsx
+++ b/frontend/src/pages/PropertyDetailPage.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { useParams, useNavigate, useSearchParams } from "react-router-dom";
-import { ArrowLeft, Share2, Shield, Wrench, MessageSquare, Calendar, DollarSign, AlertCircle, Star, Upload, Zap, Trash2 } from "lucide-react";
+import { ArrowLeft, Share2, Shield, Wrench, MessageSquare, Calendar, DollarSign, AlertCircle, Star, Upload, Zap, Trash2, TrendingUp, ExternalLink, PhoneCall } from "lucide-react";
 import { Layout } from "@/components/Layout";
 import { Button } from "@/components/Button";
 import { Badge } from "@/components/Badge";
@@ -25,6 +25,7 @@ import { getWeeklyPulse } from "@/services/pulseService";
 import { roomService, Room as RoomRecord, type UpdateRoomArgs, type AddFixtureArgs, type Fixture } from "@/services/room";
 import { paymentService, type PlanTier } from "@/services/payment";
 import { billService, extractBill, TierLimitReachedError, type BillRecord, type BillExtraction, type BillType } from "@/services/billService";
+import { getUsageTrend, analyzeEfficiencyTrend, findRebates, negotiateTelecom, type RebateResult, type TelecomNegotiationResult } from "@/services/billsIntelligence";
 import { UpgradeGate } from "@/components/UpgradeGate";
 import { ScorePanel } from "@/components/ScorePanel";
 import { ScoreActivityFeed } from "@/components/ScoreActivityFeed";
@@ -2205,16 +2206,53 @@ const BILL_TYPE_LABELS: Record<BillType, string> = {
 };
 
 function BillsTab({ propertyId }: { propertyId: string }) {
-  const [bills, setBills]             = useState<BillRecord[]>([]);
-  const [loading, setLoading]         = useState(true);
-  const [uploading, setUploading]     = useState(false);
-  const [extraction, setExtraction]   = useState<BillExtraction | null>(null);
-  const [confirmArgs, setConfirmArgs] = useState<Partial<BillRecord> | null>(null);
-  const fileInputRef                  = React.useRef<HTMLInputElement>(null);
+  const [bills, setBills]                       = useState<BillRecord[]>([]);
+  const [loading, setLoading]                   = useState(true);
+  const [uploading, setUploading]               = useState(false);
+  const [extraction, setExtraction]             = useState<BillExtraction | null>(null);
+  const [confirmArgs, setConfirmArgs]           = useState<Partial<BillRecord> | null>(null);
+  const fileInputRef                            = React.useRef<HTMLInputElement>(null);
+
+  // Story 3 — efficiency alert state
+  const [efficiencyRec, setEfficiencyRec]       = useState<string | null>(null);
+  const [efficiencyWaste, setEfficiencyWaste]   = useState<number | null>(null);
+
+  // Story 4 — rebates state
+  const [rebates, setRebates]                   = useState<RebateResult[] | null>(null);
+  const [loadingRebates, setLoadingRebates]     = useState(false);
+
+  // Story 6 — telecom negotiation state
+  const [telecomResult, setTelecomResult]       = useState<TelecomNegotiationResult | null>(null);
+  const [telecomBillId, setTelecomBillId]       = useState<string | null>(null);
+  const [loadingTelecom, setLoadingTelecom]     = useState(false);
 
   useEffect(() => {
     billService.getBillsForProperty(propertyId)
-      .then(setBills)
+      .then(async (fetched) => {
+        setBills(fetched);
+
+        // Story 3 — run efficiency analysis for Electric bills when 3+ present
+        const elecTrend = await getUsageTrend(propertyId, "Electric", 12).catch(() => []);
+        const waterTrend = await getUsageTrend(propertyId, "Water", 12).catch(() => []);
+        const trend = elecTrend.length >= waterTrend.length ? elecTrend : waterTrend;
+        if (trend.length >= 3) {
+          const analysis = analyzeEfficiencyTrend(trend);
+          if (analysis.degradationDetected) {
+            setEfficiencyRec(analysis.recommendation ?? null);
+            setEfficiencyWaste(analysis.estimatedAnnualWaste ?? null);
+          }
+        }
+
+        // Story 4 — load rebates if Electric bills are present
+        const hasElectric = fetched.some((b) => b.billType === "Electric");
+        if (hasElectric) {
+          setLoadingRebates(true);
+          findRebates({ state: "FL", zipCode: "32801", utilityProvider: fetched.find((b) => b.billType === "Electric")?.provider ?? "Unknown", billType: "Electric" })
+            .then(setRebates)
+            .catch(() => {})
+            .finally(() => setLoadingRebates(false));
+        }
+      })
       .catch(() => {})
       .finally(() => setLoading(false));
   }, [propertyId]);
@@ -2282,6 +2320,26 @@ function BillsTab({ propertyId }: { propertyId: string }) {
       toast.success("Bill removed.");
     } catch {
       toast.error("Failed to remove bill.");
+    }
+  }
+
+  // Story 6 — Telecom Negotiation
+  async function handleNegotiateTelecom(bill: BillRecord) {
+    if (!bill.amountCents) return;
+    setLoadingTelecom(true);
+    setTelecomBillId(bill.id);
+    try {
+      const result = await negotiateTelecom({
+        provider:    bill.provider,
+        amountCents: bill.amountCents,
+        mbps:        bill.usageAmount ?? 100,
+        zipCode:     "32801",
+      });
+      setTelecomResult(result);
+    } catch {
+      toast.error("Could not generate negotiation script. Try again later.");
+    } finally {
+      setLoadingTelecom(false);
     }
   }
 
@@ -2460,6 +2518,17 @@ function BillsTab({ propertyId }: { propertyId: string }) {
                       <Zap size={12} /> Anomaly
                     </span>
                   )}
+                  {(bill.billType === "Internet" || bill.billType === "Telecom") && (
+                    <button
+                      onClick={() => handleNegotiateTelecom(bill)}
+                      disabled={loadingTelecom && telecomBillId === bill.id}
+                      title="Negotiate your bill"
+                      style={{ display: "inline-flex", alignItems: "center", gap: "0.25rem", background: "none", border: `1px solid ${COLORS.sage}`, borderRadius: "4px", cursor: "pointer", color: COLORS.sage, padding: "0.2rem 0.5rem", fontFamily: FONTS.mono, fontSize: "0.6rem", letterSpacing: "0.06em", marginRight: "0.5rem" }}
+                    >
+                      <PhoneCall size={10} />
+                      {loadingTelecom && telecomBillId === bill.id ? "…" : "Negotiate"}
+                    </button>
+                  )}
                   <button
                     onClick={() => handleDelete(bill.id)}
                     style={{ background: "none", border: "none", cursor: "pointer", color: inkLight, padding: "0.25rem" }}
@@ -2472,6 +2541,82 @@ function BillsTab({ propertyId }: { propertyId: string }) {
             ))}
           </tbody>
         </table>
+      )}
+
+      {/* Story 3 — Efficiency Degradation Alert */}
+      {efficiencyRec && (
+        <div style={{ marginTop: "1.5rem", padding: "1.25rem 1.5rem", background: COLORS.butter, border: `1px solid ${COLORS.rule}`, borderRadius: RADIUS.card, display: "flex", gap: "1rem", alignItems: "flex-start" }}>
+          <TrendingUp size={18} color={COLORS.plum} style={{ flexShrink: 0, marginTop: "0.15rem" }} />
+          <div>
+            <p style={{ fontFamily: FONTS.serif, fontWeight: 700, fontSize: "1rem", color: COLORS.plum, margin: "0 0 0.375rem" }}>
+              Usage trend detected
+            </p>
+            <p style={{ fontFamily: FONTS.sans, fontSize: "0.85rem", fontWeight: 300, color: COLORS.plumMid, margin: 0, lineHeight: 1.6 }}>
+              {efficiencyRec}
+              {efficiencyWaste != null && (
+                <> Estimated annual waste: <strong>{efficiencyWaste.toLocaleString(undefined, { maximumFractionDigits: 0 })} units</strong>.</>
+              )}
+            </p>
+          </div>
+        </div>
+      )}
+
+      {/* Story 4 — Available Rebates */}
+      {(loadingRebates || (rebates && rebates.length > 0)) && (
+        <div style={{ marginTop: "1.5rem" }}>
+          <p style={{ fontFamily: FONTS.mono, fontSize: "0.6rem", letterSpacing: "0.1em", textTransform: "uppercase" as const, color: COLORS.plumMid, marginBottom: "0.75rem" }}>
+            Available Rebates
+          </p>
+          {loadingRebates ? (
+            <p style={{ fontFamily: FONTS.sans, fontSize: "0.85rem", color: COLORS.plumMid }}>Loading rebate programs…</p>
+          ) : (
+            <div style={{ display: "flex", flexDirection: "column", gap: "0.625rem" }}>
+              {rebates!.map((r) => (
+                <div key={r.name} style={{ padding: "1rem 1.25rem", background: COLORS.sageLight, border: `1px solid ${COLORS.rule}`, borderRadius: RADIUS.sm, display: "flex", justifyContent: "space-between", alignItems: "flex-start", gap: "1rem" }}>
+                  <div>
+                    <p style={{ fontFamily: FONTS.sans, fontWeight: 600, fontSize: "0.875rem", color: COLORS.plum, margin: "0 0 0.25rem" }}>{r.name}</p>
+                    <p style={{ fontFamily: FONTS.sans, fontWeight: 300, fontSize: "0.8rem", color: COLORS.plumMid, margin: 0, lineHeight: 1.55 }}>{r.description}</p>
+                    <p style={{ fontFamily: FONTS.mono, fontSize: "0.6rem", letterSpacing: "0.06em", color: COLORS.plumMid, margin: "0.375rem 0 0" }}>{r.provider}</p>
+                  </div>
+                  <div style={{ flexShrink: 0, textAlign: "right" }}>
+                    <p style={{ fontFamily: FONTS.serif, fontWeight: 700, fontSize: "1rem", color: COLORS.sage, margin: "0 0 0.25rem" }}>{r.estimatedAmount}</p>
+                    {r.url && (
+                      <a href={r.url} target="_blank" rel="noopener noreferrer" style={{ display: "inline-flex", alignItems: "center", gap: "0.25rem", fontFamily: FONTS.mono, fontSize: "0.6rem", color: COLORS.sage, textDecoration: "none" }}>
+                        Apply <ExternalLink size={10} />
+                      </a>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Story 6 — Telecom Negotiation Result */}
+      {telecomResult && (
+        <div style={{ marginTop: "1.5rem", padding: "1.25rem 1.5rem", background: COLORS.white, border: `1px solid ${COLORS.sage}`, borderRadius: RADIUS.card }}>
+          <div style={{ display: "flex", alignItems: "center", gap: "0.625rem", marginBottom: "0.75rem" }}>
+            <PhoneCall size={16} color={COLORS.sage} />
+            <p style={{ fontFamily: FONTS.serif, fontWeight: 700, fontSize: "1rem", color: COLORS.plum, margin: 0 }}>
+              Negotiation Script
+            </p>
+            <span style={{ fontFamily: FONTS.mono, fontSize: "0.6rem", letterSpacing: "0.06em", padding: "2px 8px", borderRadius: "100px", background: telecomResult.verdict === "overpaying" ? "#FEE2E2" : COLORS.sageLight, color: telecomResult.verdict === "overpaying" ? "#C94C2E" : COLORS.sage }}>
+              {telecomResult.verdict === "overpaying" ? "Overpaying" : telecomResult.verdict === "fair" ? "Fair rate" : "Good deal"}
+            </span>
+          </div>
+          {telecomResult.savingsOpportunityCents > 0 && (
+            <p style={{ fontFamily: FONTS.sans, fontSize: "0.85rem", color: COLORS.plumMid, margin: "0 0 0.75rem" }}>
+              You may be paying <strong>${(telecomResult.savingsOpportunityCents / 100).toFixed(0)}/mo</strong> above the median rate of <strong>${(telecomResult.medianCents / 100).toFixed(0)}/mo</strong> for your area.
+            </p>
+          )}
+          <div style={{ padding: "1rem", background: COLORS.sageLight, borderRadius: RADIUS.sm, fontFamily: FONTS.sans, fontSize: "0.875rem", color: COLORS.plum, lineHeight: 1.7, whiteSpace: "pre-wrap" as const }}>
+            {telecomResult.negotiationScript}
+          </div>
+          <button onClick={() => setTelecomResult(null)} style={{ marginTop: "0.75rem", background: "none", border: "none", cursor: "pointer", fontFamily: FONTS.mono, fontSize: "0.6rem", color: COLORS.plumMid, letterSpacing: "0.06em" }}>
+            Dismiss
+          </button>
+        </div>
       )}
     </div>
   );

--- a/frontend/src/services/actor.ts
+++ b/frontend/src/services/actor.ts
@@ -11,6 +11,18 @@ export const II_URL = IS_LOCAL
 let _authClient: AuthClient | null = null;
 let _agent: HttpAgent | null = null;
 
+/**
+ * Integration-test escape hatch: inject a pre-built agent so tests can use a
+ * deterministic Ed25519 identity without going through AuthClient / II.
+ * Never call this in production code — the guard is belt-and-suspenders.
+ */
+export function setAgentForTesting(agent: HttpAgent): void {
+  if (typeof process !== "undefined" && process.env?.NODE_ENV === "production") {
+    throw new Error("setAgentForTesting must not be called in production");
+  }
+  _agent = agent;
+}
+
 export async function getAuthClient(): Promise<AuthClient> {
   if (!_authClient) {
     _authClient = await AuthClient.create();

--- a/frontend/src/services/billService.ts
+++ b/frontend/src/services/billService.ts
@@ -60,6 +60,12 @@ export const idlFactory = ({ IDL }: any) => {
     TierLimitReached: IDL.Text,
   });
 
+  const UsagePeriod = IDL.Record({
+    periodStart: IDL.Text,
+    usageAmount: IDL.Float64,
+    usageUnit:   IDL.Text,
+  });
+
   return IDL.Service({
     addBill: IDL.Func(
       [AddBillArgs],
@@ -74,6 +80,11 @@ export const idlFactory = ({ IDL }: any) => {
     deleteBill: IDL.Func(
       [IDL.Text],
       [IDL.Variant({ ok: IDL.Null, err: Error })],
+      []
+    ),
+    getUsageTrend: IDL.Func(
+      [IDL.Text, BillType, IDL.Nat],
+      [IDL.Variant({ ok: IDL.Vec(UsagePeriod), err: Error })],
       []
     ),
     metrics: IDL.Func(

--- a/frontend/src/services/billsIntelligence.ts
+++ b/frontend/src/services/billsIntelligence.ts
@@ -1,0 +1,189 @@
+/**
+ * HomeGentic Bills Intelligence (Epic #49 Stories 3–6)
+ *
+ * Story 3 — System Efficiency Degradation Alerts
+ *   getUsageTrend()          — pulls bills from canister, filters to usage-tracked bills
+ *   analyzeEfficiencyTrend() — pure algorithm: rising usage > 15% = degradation signal
+ *
+ * Story 4 — Rebate & Incentive Finder
+ *   findRebates()            — calls POST /api/rebate-finder (voice agent)
+ *
+ * Story 6 — Telecom Negotiation Assistant
+ *   negotiateTelecom()       — calls POST /api/telecom-negotiate (voice agent)
+ *
+ * Story 5 (Insurance Premium Triggers) is implemented in Layout.tsx / InsuranceDefensePage.tsx.
+ */
+
+import { billService, type BillType, type BillRecord } from "./billService";
+
+const VOICE_AGENT_URL =
+  (import.meta as any).env?.VITE_VOICE_AGENT_URL ?? "http://localhost:3001";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface UsagePeriod {
+  periodStart: string;   // YYYY-MM-DD
+  usageAmount: number;
+  usageUnit:   string;
+}
+
+export interface EfficiencyAnalysisResult {
+  degradationDetected:  boolean;
+  /** Estimated wasted usage units per year (lateAvg − earlyAvg) × 12 */
+  estimatedAnnualWaste?: number;
+  recommendation?:       string;
+  /** Percentage rise from first-half average to second-half average */
+  trendPct?:             number;
+}
+
+export interface RebateFindParams {
+  state:           string;
+  zipCode:         string;
+  utilityProvider: string;
+  billType:        BillType;
+}
+
+export interface RebateResult {
+  name:            string;
+  description:     string;
+  estimatedAmount: string;
+  provider:        string;
+  url?:            string;
+}
+
+export interface TelecomNegotiateParams {
+  provider:    string;
+  amountCents: number;
+  mbps:        number;
+  zipCode:     string;
+}
+
+export interface TelecomNegotiationResult {
+  verdict:                  "overpaying" | "fair" | "good_deal";
+  medianCents:              number;
+  savingsOpportunityCents:  number;
+  negotiationScript:        string;
+}
+
+// ─── Story 3 — Efficiency Degradation ─────────────────────────────────────────
+
+/**
+ * Fetch bills for a property and return usage-tracked periods for a given
+ * bill type, sorted chronologically, limited to the last `months` months.
+ */
+export async function getUsageTrend(
+  propertyId: string,
+  billType:   BillType,
+  months:     number,
+): Promise<UsagePeriod[]> {
+  const allBills = await billService.getBillsForProperty(propertyId);
+
+  const cutoff = new Date();
+  cutoff.setMonth(cutoff.getMonth() - months);
+  const cutoffStr = cutoff.toISOString().slice(0, 10); // YYYY-MM-DD
+
+  return allBills
+    .filter(
+      (b: BillRecord) =>
+        b.billType === billType &&
+        b.usageAmount != null &&
+        b.usageUnit   != null &&
+        b.periodStart >= cutoffStr,
+    )
+    .sort((a: BillRecord, b: BillRecord) => a.periodStart.localeCompare(b.periodStart))
+    .map((b: BillRecord) => ({
+      periodStart: b.periodStart,
+      usageAmount: b.usageAmount!,
+      usageUnit:   b.usageUnit!,
+    }));
+}
+
+/**
+ * Pure algorithm: compares first-half vs second-half average usage.
+ * A >15% rise signals system efficiency degradation (HVAC losing efficiency,
+ * water heater scaling, etc.).
+ *
+ * Requires at least 3 periods — returns degradationDetected:false otherwise.
+ */
+export function analyzeEfficiencyTrend(trend: UsagePeriod[]): EfficiencyAnalysisResult {
+  if (trend.length < 3) return { degradationDetected: false };
+
+  const half     = Math.floor(trend.length / 2);
+  const early    = trend.slice(0, half);
+  const late     = trend.slice(trend.length - half);
+
+  const earlyAvg = early.reduce((s, p) => s + p.usageAmount, 0) / early.length;
+  const lateAvg  = late.reduce((s, p)  => s + p.usageAmount, 0) / late.length;
+
+  const trendPct = earlyAvg > 0 ? ((lateAvg - earlyAvg) / earlyAvg) * 100 : 0;
+
+  if (trendPct > 15) {
+    const monthlyWaste       = lateAvg - earlyAvg;
+    const estimatedAnnualWaste = monthlyWaste * 12;
+    const unit               = trend[0]?.usageUnit ?? "usage units";
+    return {
+      degradationDetected: true,
+      estimatedAnnualWaste,
+      recommendation: `Your ${unit} has increased ${trendPct.toFixed(1)}% over this period. This may indicate system inefficiency. Consider scheduling an HVAC inspection or checking for leaks.`,
+      trendPct,
+    };
+  }
+
+  return { degradationDetected: false, trendPct };
+}
+
+// ─── Story 4 — Rebate Finder ──────────────────────────────────────────────────
+
+/**
+ * Query the voice agent for available utility rebates in the homeowner's
+ * area. Only Electric bills are eligible — throws for other bill types.
+ */
+export async function findRebates(params: RebateFindParams): Promise<RebateResult[]> {
+  if (params.billType !== "Electric") {
+    throw new Error("Rebate finder is only available for Electric bills.");
+  }
+
+  const res = await fetch(`${VOICE_AGENT_URL}/api/rebate-finder`, {
+    method:  "POST",
+    headers: { "Content-Type": "application/json" },
+    body:    JSON.stringify(params),
+  });
+
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({ error: res.statusText }));
+    throw new Error(err.error ?? "Rebate finder request failed");
+  }
+
+  const data = await res.json();
+  return data.rebates as RebateResult[];
+}
+
+// ─── Story 6 — Telecom Negotiation ───────────────────────────────────────────
+
+/**
+ * Ask the voice agent to analyse a telecom bill and generate a
+ * negotiation script. Returns verdict + median market rate + script.
+ */
+export async function negotiateTelecom(
+  params: TelecomNegotiateParams,
+): Promise<TelecomNegotiationResult> {
+  if (!params.provider) {
+    throw new Error("provider is required");
+  }
+  if (!Number.isInteger(params.amountCents) || params.amountCents <= 0) {
+    throw new Error("amountCents must be a positive integer");
+  }
+
+  const res = await fetch(`${VOICE_AGENT_URL}/api/telecom-negotiate`, {
+    method:  "POST",
+    headers: { "Content-Type": "application/json" },
+    body:    JSON.stringify(params),
+  });
+
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({ error: res.statusText }));
+    throw new Error(err.error ?? "Telecom negotiation request failed");
+  }
+
+  return res.json() as Promise<TelecomNegotiationResult>;
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -60,6 +60,7 @@ export default defineConfig(({ mode }) => {
       "process.env.AGENT_CANISTER_ID":     JSON.stringify(env.CANISTER_ID_AGENT     || env.AGENT_CANISTER_ID     || ""),
       "process.env.AI_PROXY_CANISTER_ID":  JSON.stringify(env.CANISTER_ID_AI_PROXY  || env.AI_PROXY_CANISTER_ID  || ""),
       "process.env.MARKET_CANISTER_ID":    JSON.stringify(env.CANISTER_ID_MARKET    || env.MARKET_CANISTER_ID    || ""),
+      "process.env.BILLS_CANISTER_ID":     JSON.stringify(env.CANISTER_ID_BILLS     || env.BILLS_CANISTER_ID     || ""),
       // VITE_ prefix exposes this to import.meta.env in the browser bundle
       // (useVoiceAgent reads it as VITE_VOICE_AGENT_API_KEY, not via process.env)
     },

--- a/frontend/vitest.integration.ts
+++ b/frontend/vitest.integration.ts
@@ -1,0 +1,61 @@
+/**
+ * Vitest configuration for integration tests.
+ *
+ * Integration tests call the real ICP canisters running on the local replica.
+ * They require:
+ *   1. A running local replica:  dfx start --background
+ *   2. Deployed canisters:       make deploy  (or bash scripts/deploy.sh)
+ *   3. Canister IDs exported:    BILLS_CANISTER_ID=<id> npm run test:integration
+ *
+ * Quickstart (from repo root):
+ *   make deploy && npm run test:integration
+ *
+ * Key differences from the unit test config (vite.config.ts `test` block):
+ *   - environment: "node"   — no jsdom; ICP SDK works in Node fine
+ *   - No `process.env.VITEST` trickery — real CANISTER_ID bypasses mock path directly
+ *   - Longer timeouts — canister calls over HTTP are slower than in-memory
+ *   - setupFiles creates a real agent with a deterministic Ed25519 identity
+ *   - Tests skip themselves if CANISTER_IDs are not set (safe for CI without replica)
+ */
+
+import { defineConfig } from "vitest/config";
+import path from "path";
+import { config as dotenvConfig } from "dotenv";
+
+// Load canister IDs written by `dfx deploy` / `make deploy`.
+// dfx writes CANISTER_ID_<NAME> vars to .env in the repo root.
+dotenvConfig({ path: path.resolve(__dirname, "../.env") });
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
+  define: {
+    // Mirror vite.config.ts mappings so services read the right env var names.
+    // Integration tests do NOT go through Vite's transform, so we define here.
+    "process.env.DFX_NETWORK":        JSON.stringify(process.env.DFX_NETWORK        || "local"),
+    "process.env.BILLS_CANISTER_ID":  JSON.stringify(process.env.CANISTER_ID_BILLS  || process.env.BILLS_CANISTER_ID  || ""),
+    "process.env.LISTING_CANISTER_ID":JSON.stringify(process.env.CANISTER_ID_LISTING || process.env.LISTING_CANISTER_ID|| ""),
+    "process.env.JOB_CANISTER_ID":    JSON.stringify(process.env.CANISTER_ID_JOB    || process.env.JOB_CANISTER_ID    || ""),
+    "process.env.PROPERTY_CANISTER_ID":JSON.stringify(process.env.CANISTER_ID_PROPERTY||process.env.PROPERTY_CANISTER_ID||""),
+    "process.env.PAYMENT_CANISTER_ID":JSON.stringify(process.env.CANISTER_ID_PAYMENT || process.env.PAYMENT_CANISTER_ID|| ""),
+    // VITE_ vars used by billsIntelligence and other services
+    "import.meta.env.VITE_VOICE_AGENT_URL": JSON.stringify(process.env.VITE_VOICE_AGENT_URL || "http://localhost:3001"),
+    "import.meta.env.DEV": JSON.stringify(true),
+  },
+  test: {
+    environment: "node",
+    globals: true,
+    include: ["src/__tests__/integration/**/*.integration.test.ts"],
+    setupFiles: ["./src/__tests__/integration/setup.ts"],
+    testTimeout:  30_000,   // canister calls can be slow on cold replica
+    hookTimeout:  30_000,
+    reporters: ["verbose"],
+    // Run integration tests serially — shared canister state means parallel
+    // writes can produce unexpected interleaving across test files.
+    pool: "forks",
+    poolOptions: { forks: { singleFork: true } },
+  },
+});

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test:unit:coverage": "cd frontend && npm run test:coverage",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
+    "test:integration": "bash scripts/test-integration.sh",
     "test:canister": "bash scripts/test-backend.sh",
     "test:upgrade": "cd tests/upgrade && npm test",
     "setup:pocketic": "bash scripts/setup-pocketic.sh",

--- a/scripts/test-integration.sh
+++ b/scripts/test-integration.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────────────
+# test-integration.sh — run frontend integration tests against the local replica
+#
+# Usage:
+#   npm run test:integration           # uses canister IDs from .env
+#   npm run test:integration -- bills  # filter to specific test file
+#
+# Prerequisites:
+#   dfx start --background   (replica must be running)
+#   make deploy              (all canisters must be deployed)
+#
+# What it does:
+#   1. Checks the local replica is reachable
+#   2. Reads canister IDs written by dfx to canister_ids.json / .env
+#   3. Exports them as CANISTER_ID_* env vars
+#   4. Runs vitest with the integration config
+# ─────────────────────────────────────────────────────────────────────────────
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+FRONTEND_DIR="$ROOT_DIR/frontend"
+
+# ── 1. Replica health check ───────────────────────────────────────────────────
+
+echo "▶ Checking local replica…"
+if ! curl -sf http://localhost:4943/api/v2/status >/dev/null 2>&1; then
+  echo ""
+  echo "  ✗ Local replica is not running."
+  echo "    Start it with:  dfx start --background"
+  echo "    Then deploy:    make deploy"
+  echo ""
+  exit 1
+fi
+echo "  ✓ Replica is up"
+
+# ── 2. Read canister IDs from dfx ────────────────────────────────────────────
+
+CANISTER_IDS_FILE="$ROOT_DIR/.dfx/local/canister_ids.json"
+
+if [ ! -f "$CANISTER_IDS_FILE" ]; then
+  echo ""
+  echo "  ✗ No canister IDs found at $CANISTER_IDS_FILE"
+  echo "    Deploy first with: make deploy"
+  echo ""
+  exit 1
+fi
+
+echo "▶ Reading canister IDs from $CANISTER_IDS_FILE…"
+
+# Export CANISTER_ID_<NAME> for each deployed canister
+# Also set the service-level names the frontend services expect (e.g. BILLS_CANISTER_ID)
+while IFS='=' read -r key value; do
+  export "$key=$value"
+done < <(
+  node -e "
+    const ids = require('$CANISTER_IDS_FILE');
+    for (const [name, nets] of Object.entries(ids)) {
+      const id = nets.local || nets.ic || '';
+      if (id) {
+        const upper = name.toUpperCase().replace(/-/g,'_');
+        console.log('CANISTER_ID_' + upper + '=' + id);
+        // Also set the flat name that service files read (e.g. BILLS_CANISTER_ID)
+        console.log(upper + '_CANISTER_ID=' + id);
+      }
+    }
+  " 2>/dev/null || true
+)
+
+# Print which canisters are available
+echo "  Deployed canisters:"
+env | grep "CANISTER_ID_" | sort | while IFS='=' read -r k v; do
+  echo "    $k = $v"
+done
+
+# ── 3. Run vitest with integration config ─────────────────────────────────────
+
+echo ""
+echo "▶ Running integration tests…"
+echo ""
+
+cd "$FRONTEND_DIR"
+
+# Pass any extra args (e.g. test file filter) through to vitest
+npx vitest run \
+  --config vitest.integration.ts \
+  --reporter=verbose \
+  "$@"
+
+echo ""
+echo "✓ Integration tests complete"


### PR DESCRIPTION
…ance triggers, telecom negotiation

Story 3 — System Efficiency Degradation Alerts:
- backend/bills/main.mo: add getUsageTrend() query (filters to usage-tracked bills, sorted chrono)
- billService.ts: expose getUsageTrend in IDL factory
- billsIntelligence.ts: getUsageTrend() + analyzeEfficiencyTrend() pure algorithm (>15% rise = degradation)
- POST /api/efficiency-alert: Claude-enhanced recommendation with rule-based fallback
- PropertyDetailPage: surfaces efficiency alert card below bills table

Story 4 — Rebate & Incentive Finder:
- POST /api/rebate-finder: Claude queries federal/state/utility rebate programs for Electric bills
- billsIntelligence.ts: findRebates() (Electric-only; throws on other bill types)
- PropertyDetailPage: "Available Rebates" cards auto-load for properties with Electric bills

Story 5 — Insurance Premium Triggers:
- Layout.tsx: deriveEvents() now emits insurance_trigger event for Water bill anomalies
- ActivityEvent type exported; insurance_trigger added to the union
- InsuranceDefensePage: "Recent Water Bill Anomalies" section in print report

Story 6 — Telecom Negotiation Assistant:
- POST /api/telecom-negotiate: Claude analyses bill vs median rate, returns verdict + script
- billsIntelligence.ts: negotiateTelecom() with input validation
- PropertyDetailPage: "Negotiate" button on Internet/Telecom bill rows; result panel inline

TDD: 18 tests in billsIntelligence56.test.ts — all green.

Closes #56

## Summary
<!-- What does this PR do? -->

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [ ] Backend tests pass (`make test`)
- [ ] Frontend builds (`cd frontend && npm run build`)
- [ ] Tested locally with dfx

## Checklist
- [ ] Code follows project conventions
- [ ] Self-review completed
- [ ] No sensitive data committed
