### PR TITLE
fix(code-quality): silent errors, null returns, high-arity call (#81)

### DIFF
--- a/frontend/src/__tests__/services/permitImport175.test.ts
+++ b/frontend/src/__tests__/services/permitImport175.test.ts
@@ -233,8 +233,8 @@ describe("importPermitsForProperty", () => {
     expect(result.imported).toBe(2);
   });
 
-  it("returns empty result when canister returns null", async () => {
-    vi.mocked(aiProxyService.importPermits).mockResolvedValueOnce(null);
+  it("returns empty result when canister returns empty string", async () => {
+    vi.mocked(aiProxyService.importPermits).mockResolvedValueOnce("");
 
     const result = await importPermitsForProperty("prop-1", "456 Oak Ave", "Austin", "TX", "78701");
     expect(result.imported).toBe(0);

--- a/frontend/src/__tests__/services/priceBenchmark171.test.ts
+++ b/frontend/src/__tests__/services/priceBenchmark171.test.ts
@@ -64,8 +64,8 @@ describe("getPriceBenchmark", () => {
     expect(aiProxyService.getPriceBenchmark).toHaveBeenCalledWith("Roofing", "32114");
   });
 
-  it("returns null when canister returns null", async () => {
-    vi.mocked(aiProxyService.getPriceBenchmark).mockResolvedValueOnce(null);
+  it("returns null when canister returns empty string", async () => {
+    vi.mocked(aiProxyService.getPriceBenchmark).mockResolvedValueOnce("");
     const result = await getPriceBenchmark("Roofing", "00000");
     expect(result).toBeNull();
   });

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -63,7 +63,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           const profile = await authService.getProfile();
           setLastLoginAt(profile.lastLoggedIn);   // capture previous session timestamp
           setProfile(profile);
-          authService.recordLogin().catch(() => {}); // fire-and-forget
+          authService.recordLogin().catch((err) => console.error("[AuthContext] recordLogin failed:", err)); // fire-and-forget
         } catch {
           // Not registered yet
         }
@@ -80,7 +80,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       const profile = await authService.getProfile();
       setLastLoginAt(profile.lastLoggedIn);
       setProfile(profile);
-      authService.recordLogin().catch(() => {});
+      authService.recordLogin().catch((err) => console.error("[AuthContext] recordLogin failed:", err));
       if (profile.role === "Contractor") {
         navigate("/contractor-dashboard");
       } else {
@@ -113,7 +113,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       const profile = await authService.getProfile();
       setLastLoginAt(profile.lastLoggedIn);
       setProfile(profile);
-      authService.recordLogin().catch(() => {});
+      authService.recordLogin().catch((err) => console.error("[AuthContext] recordLogin failed:", err));
       if (profile.role === "Contractor") {
         navigate("/contractor-dashboard");
       } else {

--- a/frontend/src/services/aiProxy.ts
+++ b/frontend/src/services/aiProxy.ts
@@ -96,28 +96,28 @@ async function getActor(): Promise<any | null> {
 
 export const aiProxyService = {
 
-  /** Returns price benchmark JSON or null on error/missing canister. */
-  async getPriceBenchmark(service: string, zip: string): Promise<string | null> {
+  /** Returns price benchmark JSON or empty string on error/missing canister. */
+  async getPriceBenchmark(service: string, zip: string): Promise<string> {
     const actor = await getActor();
-    if (!actor) return null;
+    if (!actor) return "";
     try {
       const result = await actor.getPriceBenchmark(service, zip);
       if ("ok" in result) return result.ok as string;
-      return null;
+      return "";
     } catch {
-      return null;
+      return "";
     }
   },
 
-  /** Returns forecast JSON or null on error. */
+  /** Returns forecast JSON or empty string on error. */
   async instantForecast(
     address: string,
     yearBuilt: number,
     state?: string,
     overridesJson = "{}",
-  ): Promise<string | null> {
+  ): Promise<string> {
     const actor = await getActor();
-    if (!actor) return null;
+    if (!actor) return "";
     try {
       const result = await actor.instantForecast(
         address,
@@ -126,27 +126,27 @@ export const aiProxyService = {
         overridesJson,
       );
       if ("ok" in result) return result.ok as string;
-      return null;
+      return "";
     } catch {
-      return null;
+      return "";
     }
   },
 
-  /** Returns { source, data } JSON or null. */
+  /** Returns { source, data } JSON or empty string on error/missing canister. */
   async importPermits(
     address: string,
     city:    string,
     state:   string,
     zip:     string,
-  ): Promise<string | null> {
+  ): Promise<string> {
     const actor = await getActor();
-    if (!actor) return null;
+    if (!actor) return "";
     try {
       const result = await actor.importPermits(address, city, state, zip);
       if ("ok" in result) return result.ok as string;
-      return null;
+      return "";
     } catch {
-      return null;
+      return "";
     }
   },
 

--- a/frontend/src/services/listing.ts
+++ b/frontend/src/services/listing.ts
@@ -537,15 +537,17 @@ function createListingService() {
     }
     const actor = await getActor();
     const result = await actor.submitProposal(
-      requestId,
-      input.agentName, input.agentBrokerage,
-      BigInt(input.commissionBps),
-      input.cmaSummary, input.marketingPlan,
-      BigInt(input.estimatedDaysOnMarket),
-      BigInt(input.estimatedSalePrice),
-      input.includedServices,
-      BigInt(input.validUntil),
-      input.coverLetter
+      /* requestId            */ requestId,
+      /* agentName            */ input.agentName,
+      /* agentBrokerage       */ input.agentBrokerage,
+      /* commissionBps        */ BigInt(input.commissionBps),
+      /* cmaSummary           */ input.cmaSummary,
+      /* marketingPlan        */ input.marketingPlan,
+      /* estimatedDaysOnMarket*/ BigInt(input.estimatedDaysOnMarket),
+      /* estimatedSalePrice   */ BigInt(input.estimatedSalePrice),
+      /* includedServices     */ input.includedServices,
+      /* validUntil           */ BigInt(input.validUntil),
+      /* coverLetter          */ input.coverLetter,
     );
     if ("err" in result) throw new Error(JSON.stringify(result.err));
     return fromRawProposal(result.ok);


### PR DESCRIPTION
## Summary
- **`AuthContext.tsx`**: replaced three bare `.catch(() => {})` on `recordLogin()` with `.catch((err) => console.error("[AuthContext] recordLogin failed:", err))` so failures surface in production logs
- **`aiProxy.ts`**: `getPriceBenchmark`, `instantForecast`, and `importPermits` now return `""` instead of `null` — callers' existing `if (!json)` guards still work, but the `string | null` type is gone
- **`listing.ts`**: all 11 positional args to `actor.submitProposal(...)` labelled with inline `/* name */` comments to make argument order verifiable at a glance
- Updated `permitImport175.test.ts` and `priceBenchmark171.test.ts` mocks to pass `""` instead of `null` to match updated return types

## Test plan
- [x] All 2910 unit tests pass (`npm run test:unit`)
- [x] No TypeScript errors from the return type change (callers use falsy `if (!json)` guards)

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)