### PR TITLE
fix(ci): add npm ci to deploy workflows — fix TS2688 type definition errors

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -40,6 +40,15 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+
+      - name: Install Node dependencies
+        run: npm ci
+
       - name: Cache DFX binary
         uses: actions/cache@v5
         with:

--- a/.github/workflows/deploy-mainnet.yml
+++ b/.github/workflows/deploy-mainnet.yml
@@ -19,11 +19,11 @@ jobs:
         with:
           node-version: 20
           cache: npm
-          cache-dependency-path: frontend/package-lock.json
+          cache-dependency-path: package-lock.json
       - name: Install mops
         run: npm install -g ic-mops
-      - name: Install frontend deps
-        run: npm ci --prefix frontend
+      - name: Install Node dependencies
+        run: npm ci
       - name: Deploy to mainnet
         # Network is a positional arg ($1); --network ic would set NETWORK="--network"
         # and silently deploy to local. Must be: bash scripts/deploy.sh ic

--- a/.github/workflows/deploy-testnet.yml
+++ b/.github/workflows/deploy-testnet.yml
@@ -16,6 +16,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+
+      - name: Install Node dependencies
+        run: npm ci
+
       - name: Cache DFX binary
         uses: actions/cache@v5
         with:


### PR DESCRIPTION
## Summary
- `coverage-backend`, `deploy-testnet`, and `deploy-mainnet` all call `deploy.sh` which runs `tsc + vite build`, but none installed Node dependencies first — causing `TS2688: Cannot find type definition file for 'node'/'vite/client'/'vitest/globals'`
- `deploy-mainnet` also pointed `cache-dependency-path` and `npm ci --prefix` at `frontend/package-lock.json` which doesn't exist (lock file is at the repo root)

## Changes
| Workflow | Fix |
|---|---|
| `coverage.yml` | Add `setup-node` + `npm ci` before DFX steps |
| `deploy-testnet.yml` | Add `setup-node` + `npm ci` before DFX steps |
| `deploy-mainnet.yml` | `npm ci --prefix frontend` → `npm ci`; fix `cache-dependency-path` to root `package-lock.json` |

## Related
- Partially addresses #99 (missing secrets still need to be added in GitHub Settings)
- See also #100 #101 #102 #103 for remaining testnet deploy gaps

## Test plan
- [ ] Verify `coverage-backend` job passes after merge
- [ ] Verify `deploy-testnet` reaches the DFX deploy step (pre-flight will still fail until secrets from #99 are added)
- [ ] Verify `deploy-mainnet` frontend build step succeeds on next manual trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)