### PR TITLE
feat(ci): gate PRs with code coverage comment and fix coverage workfl…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,9 @@ jobs:
 
   test-frontend:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write   # allows posting the coverage comment on PRs
     steps:
       - uses: actions/checkout@v4
 
@@ -130,6 +133,13 @@ jobs:
           name: coverage-report
           path: frontend/coverage/
           retention-days: 14
+
+      - name: Post coverage comment on PR
+        if: github.event_name == 'pull_request'
+        uses: davelosert/vitest-coverage-report-action@v2
+        with:
+          json-summary-path: frontend/coverage/coverage-summary.json
+          vite-config-path:  frontend/vite.config.ts
 
       - name: Build
         run: cd frontend && npm run build

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -3,7 +3,7 @@ name: Code Coverage
 on:
   workflow_run:
     workflows: [CI]
-    branches: [main]
+    branches: ["**"]
     types: [completed]
 
 permissions:

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -115,7 +115,7 @@ export default defineConfig(({ mode }) => {
           "src/services/agentTools.ts",  // Claude API schema definitions — not unit-testable
           "src/services/index.ts",       // Re-export barrel — no logic to test
         ],
-        reporter: ["text", "html", "lcov"],   // terminal summary + browsable HTML + CI/tooling
+        reporter: ["text", "html", "lcov", "json-summary"],   // terminal + browsable HTML + CI/tooling + PR comments
         reportsDirectory: "./coverage",
         thresholds: {
           lines:      60,


### PR DESCRIPTION
…ow scope

- vite.config.ts: add json-summary reporter so davelosert/vitest-coverage-report-action can read per-file breakdown for the PR comment
- ci.yml: add pull-requests: write permission to test-frontend job; add davelosert/vitest-coverage-report-action@v2 step (only fires on pull_request events) to post coverage summary as a PR comment after each CI run
- coverage.yml: fix workflow_run branches filter from [main] to ["**"] so the coverage artifact is uploaded for PR branches, not only post-merge to main

Thresholds (lines/functions/statements: 60%, branches: 55%) are enforced by vitest itself — CI already fails if they are missed. The comment adds visibility.

## Summary
<!-- What does this PR do? -->

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [ ] Backend tests pass (`make test`)
- [ ] Frontend builds (`cd frontend && npm run build`)
- [ ] Tested locally with dfx

## Checklist
- [ ] Code follows project conventions
- [ ] Self-review completed
- [ ] No sensitive data committed
