### PR TITLE
feat(payment): hard-cancel subscription with billing-cycle grace period

### DIFF
--- a/backend/payment/main.mo
+++ b/backend/payment/main.mo
@@ -16,10 +16,11 @@ persistent actor Payment {
   public type Tier = { #Free; #Basic; #Pro; #Premium; #ContractorFree; #ContractorPro };
 
   public type Subscription = {
-    owner: Principal;
-    tier: Tier;
-    expiresAt: Int;
-    createdAt: Int;
+    owner:       Principal;
+    tier:        Tier;
+    expiresAt:   Int;
+    createdAt:   Int;
+    cancelledAt: ?Int;   // set when user requests cancellation; access remains until expiresAt
   };
 
   public type Error = { #NotFound; #NotAuthorized; #PaymentFailed: Text; #RateLimited; #InvalidInput: Text };
@@ -527,10 +528,11 @@ persistent actor Payment {
           return #err(#NotAuthorized);
         };
         let sub : Subscription = {
-          owner     = msg.caller;
+          owner       = msg.caller;
           tier;
-          expiresAt = now + durationNsFor(billing);
-          createdAt = now;
+          expiresAt   = now + durationNsFor(billing);
+          createdAt   = now;
+          cancelledAt = null;
         };
         Map.add(subscriptions, Principal.compare, msg.caller, sub);
         #ok(sub)
@@ -551,10 +553,11 @@ persistent actor Payment {
         if (Option.isSome(gift.redeemedBy)) return #err(#InvalidInput("Gift already redeemed"));
         let now = Time.now();
         let sub : Subscription = {
-          owner     = msg.caller;
-          tier      = gift.tier;
-          expiresAt = now + durationNsFor(gift.billing);
-          createdAt = now;
+          owner       = msg.caller;
+          tier        = gift.tier;
+          expiresAt   = now + durationNsFor(gift.billing);
+          createdAt   = now;
+          cancelledAt = null;
         };
         Map.add(subscriptions, Principal.compare, msg.caller, sub);
         let updated : PendingGift = {
@@ -686,10 +689,11 @@ persistent actor Payment {
     };
     let now = Time.now();
     let sub: Subscription = {
-      owner     = msg.caller;
+      owner       = msg.caller;
       tier;
-      expiresAt = if (durationNs == 0) 0 else now + durationNs;
-      createdAt = now;
+      expiresAt   = if (durationNs == 0) 0 else now + durationNs;
+      createdAt   = now;
+      cancelledAt = null;
     };
     Map.add(subscriptions, Principal.compare, msg.caller, sub);
     Map.remove(activeSubscribers, Text.compare, callerKey);
@@ -708,10 +712,11 @@ persistent actor Payment {
     let now = Time.now();
     let durationNs : Int = Int.fromNat(months) * 30 * 24 * 60 * 60 * 1_000_000_000;
     let sub : Subscription = {
-      owner     = userPrincipal;
+      owner       = userPrincipal;
       tier;
-      expiresAt = now + durationNs;
-      createdAt = now;
+      expiresAt   = now + durationNs;
+      createdAt   = now;
+      cancelledAt = null;
     };
     Map.add(subscriptions, Principal.compare, userPrincipal, sub);
     #ok(sub)
@@ -727,10 +732,11 @@ persistent actor Payment {
     };
     let now = Time.now();
     let sub: Subscription = {
-      owner     = principal;
+      owner       = principal;
       tier;
-      expiresAt = if (durationNs == 0) 0 else now + durationNs;
-      createdAt = now;
+      expiresAt   = if (durationNs == 0) 0 else now + durationNs;
+      createdAt   = now;
+      cancelledAt = null;
     };
     Map.add(subscriptions, Principal.compare, principal, sub);
     #ok(sub)
@@ -738,8 +744,35 @@ persistent actor Payment {
 
   public query(msg) func getMySubscription() : async Result.Result<Subscription, Error> {
     switch (Map.get(subscriptions, Principal.compare, msg.caller)) {
-      case null { #ok({ owner = msg.caller; tier = #Free; expiresAt = 0; createdAt = Time.now() }) };
+      case null { #ok({ owner = msg.caller; tier = #Free; expiresAt = 0; createdAt = Time.now(); cancelledAt = null }) };
       case (?s) { #ok(s) };
+    }
+  };
+
+  /// Mark the caller's subscription as cancelled-at-end-of-period.
+  /// Access is retained until expiresAt; the tier is not changed immediately.
+  public shared(msg) func cancelSubscription() : async Result.Result<Subscription, Error> {
+    if (Principal.isAnonymous(msg.caller)) return #err(#NotAuthorized);
+    switch (Map.get(subscriptions, Principal.compare, msg.caller)) {
+      case null { #err(#NotFound) };
+      case (?sub) {
+        let now = Time.now();
+        if (sub.expiresAt > 0 and sub.expiresAt <= now) {
+          return #err(#InvalidInput("Subscription has already expired"));
+        };
+        if (Option.isSome(sub.cancelledAt)) {
+          return #err(#InvalidInput("Subscription is already cancelled"));
+        };
+        let updated : Subscription = {
+          owner       = sub.owner;
+          tier        = sub.tier;
+          expiresAt   = sub.expiresAt;
+          createdAt   = sub.createdAt;
+          cancelledAt = ?now;
+        };
+        Map.add(subscriptions, Principal.compare, msg.caller, updated);
+        #ok(updated)
+      };
     }
   };
 

--- a/frontend/src/__tests__/components/CancelledAccount835.test.tsx
+++ b/frontend/src/__tests__/components/CancelledAccount835.test.tsx
@@ -31,7 +31,7 @@ vi.mock("@/services/payment", async (importOriginal) => {
       getMySubscription: vi.fn().mockImplementation(() =>
         Promise.resolve({ tier: mockTier, expiresAt: null })
       ),
-      cancel: vi.fn().mockResolvedValue(undefined),
+      cancel: vi.fn().mockResolvedValue({ expiresAt: null }),
       subscribe: vi.fn().mockResolvedValue(undefined),
       initiate: vi.fn().mockResolvedValue({ url: "/dashboard" }),
       getPauseState: vi.fn().mockReturnValue(null),
@@ -148,35 +148,38 @@ describe("SettingsPage — post-cancel read-only notice (8.3.2)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockTier = "Pro";
-    vi.mocked(paymentService.getMySubscription).mockResolvedValue({ tier: "Pro" as any, expiresAt: null });
-    vi.mocked(paymentService.cancel).mockResolvedValue(undefined);
+    vi.mocked(paymentService.getMySubscription).mockResolvedValue({ tier: "Pro" as any, expiresAt: null, cancelledAt: null });
+    vi.mocked(paymentService.cancel).mockResolvedValue({ expiresAt: null });
     vi.mocked(paymentService.getCancellationInfo).mockReturnValue(null);
   });
 
-  it("shows read-only mode notice after cancellation is complete", async () => {
+  it("shows 'Subscription cancelled' heading after cancellation is complete", async () => {
     await renderSettings();
     await navigateToSubscriptionTab();
     await triggerCancel();
     await waitFor(() =>
-      expect(screen.getAllByText(/read.?only/i).length).toBeGreaterThan(0)
+      expect(screen.getByText(/subscription cancelled/i)).toBeInTheDocument()
     );
   });
 
-  it("post-cancel notice mentions that score won't update", async () => {
+  it("post-cancel message confirms ICP records are intact", async () => {
     await renderSettings();
     await navigateToSubscriptionTab();
     await triggerCancel();
     await waitFor(() =>
-      expect(screen.getByText(/score.*won't.*update|score.*no longer.*update/i)).toBeInTheDocument()
+      expect(screen.getByText(/records.*intact|cancellation.*recorded/i)).toBeInTheDocument()
     );
   });
 
-  it("post-cancel notice mentions reports are static", async () => {
+  it("post-cancel message shows access end date when expiresAt is provided", async () => {
+    const futureDate = Date.now() + 30 * 24 * 60 * 60 * 1000;
+    vi.mocked(paymentService.getMySubscription).mockResolvedValue({ tier: "Pro" as any, expiresAt: futureDate, cancelledAt: null });
+    vi.mocked(paymentService.cancel).mockResolvedValue({ expiresAt: futureDate });
     await renderSettings();
     await navigateToSubscriptionTab();
     await triggerCancel();
     await waitFor(() =>
-      expect(screen.getByText(/reports.*static|existing.*reports/i)).toBeInTheDocument()
+      expect(screen.getByText(/full access until/i)).toBeInTheDocument()
     );
   });
 
@@ -273,8 +276,8 @@ describe("SettingsPage — triggers win-back schedule on cancel (8.3.5)", () => 
   beforeEach(async () => {
     vi.clearAllMocks();
     mockTier = "Pro";
-    vi.mocked(paymentService.getMySubscription).mockResolvedValue({ tier: "Pro" as any, expiresAt: null });
-    vi.mocked(paymentService.cancel).mockResolvedValue(undefined);
+    vi.mocked(paymentService.getMySubscription).mockResolvedValue({ tier: "Pro" as any, expiresAt: null, cancelledAt: null });
+    vi.mocked(paymentService.cancel).mockResolvedValue({ expiresAt: null });
     vi.mocked(paymentService.getCancellationInfo).mockReturnValue(null);
     const mod = await vi.importActual<typeof import("@/services/winBackService")>("@/services/winBackService");
     winBackService = mod.winBackService;

--- a/frontend/src/__tests__/components/CheckAddressPage174.test.tsx
+++ b/frontend/src/__tests__/components/CheckAddressPage174.test.tsx
@@ -79,10 +79,12 @@ describe("CheckAddressPage — report found", () => {
 
   it("shows a link to view the full report", async () => {
     renderPage("?address=123+Main+St+Daytona+Beach+FL");
-    await waitFor(() => {
-      const link = screen.getByRole("link", { name: /view report/i });
-      expect(link.getAttribute("href")).toContain("tok-abc123");
-    });
+    // Wait for the report-found section to stabilize, then assert the link synchronously.
+    // Keeping the assertion outside waitFor avoids timer-reset issues from continuous
+    // DOM mutations (scroll listeners, etc.) that prevent waitFor from settling.
+    await waitFor(() => screen.getByText(/HomeGentic Verified/i));
+    const link = screen.getByRole("link", { name: /view report/i });
+    expect(link.getAttribute("href")).toContain("tok-abc123");
   });
 
   it("shows the verification level", async () => {

--- a/frontend/src/__tests__/components/Gate1564.test.tsx
+++ b/frontend/src/__tests__/components/Gate1564.test.tsx
@@ -22,7 +22,7 @@ let mockTier: "Free" | "Pro" | "Premium" | "ContractorPro" = "Pro";
 vi.mock("@/services/payment", () => ({
   paymentService: {
     getMySubscription: vi.fn().mockImplementation(() =>
-      Promise.resolve({ tier: mockTier, expiresAt: null })
+      Promise.resolve({ tier: mockTier, expiresAt: null, cancelledAt: null })
     ),
   },
 }));
@@ -165,7 +165,7 @@ describe("ListingNewPage — free tier gate (15.6.4)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(paymentService.getMySubscription).mockImplementation(() =>
-      Promise.resolve({ tier: mockTier, expiresAt: null })
+      Promise.resolve({ tier: mockTier, expiresAt: null, cancelledAt: null })
     );
   });
 
@@ -209,7 +209,7 @@ describe("AgentBrowsePage — free tier gate (15.6.4)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(paymentService.getMySubscription).mockImplementation(() =>
-      Promise.resolve({ tier: mockTier, expiresAt: null })
+      Promise.resolve({ tier: mockTier, expiresAt: null, cancelledAt: null })
     );
   });
 
@@ -244,7 +244,7 @@ describe("FsboPanel — free tier gate (15.6.4)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(paymentService.getMySubscription).mockImplementation(() =>
-      Promise.resolve({ tier: mockTier, expiresAt: null })
+      Promise.resolve({ tier: mockTier, expiresAt: null, cancelledAt: null })
     );
   });
 

--- a/frontend/src/__tests__/components/GenerateReportModal.test.tsx
+++ b/frontend/src/__tests__/components/GenerateReportModal.test.tsx
@@ -80,7 +80,7 @@ let mockTier: "Free" | "Pro" | "Premium" | "ContractorPro" = "Free";
 vi.mock("@/services/payment", () => ({
   paymentService: {
     getMySubscription: vi.fn().mockImplementation(() =>
-      Promise.resolve({ tier: mockTier, expiresAt: null })
+      Promise.resolve({ tier: mockTier, expiresAt: null, cancelledAt: null })
     ),
   },
 }));
@@ -126,7 +126,7 @@ describe("GenerateReportModal — 15.7.3 in-app notification", () => {
     vi.clearAllMocks();
     mockTier = "Free";
     vi.mocked(paymentService.getMySubscription).mockImplementation(() =>
-      Promise.resolve({ tier: mockTier, expiresAt: null })
+      Promise.resolve({ tier: mockTier, expiresAt: null, cancelledAt: null })
     );
   });
 
@@ -161,7 +161,7 @@ describe("GenerateReportModal — 15.7.3 in-app notification", () => {
 
   it("does NOT call notificationService.create for Pro users", async () => {
     mockTier = "Pro";
-    vi.mocked(paymentService.getMySubscription).mockResolvedValue({ tier: "Pro", expiresAt: null });
+    vi.mocked(paymentService.getMySubscription).mockResolvedValue({ tier: "Pro", expiresAt: null, cancelledAt: null });
     renderModal();
     await clickGenerate();
     await waitFor(() =>
@@ -172,7 +172,7 @@ describe("GenerateReportModal — 15.7.3 in-app notification", () => {
 
   it("does NOT call notificationService.create for Premium users", async () => {
     mockTier = "Premium";
-    vi.mocked(paymentService.getMySubscription).mockResolvedValue({ tier: "Premium", expiresAt: null });
+    vi.mocked(paymentService.getMySubscription).mockResolvedValue({ tier: "Premium", expiresAt: null, cancelledAt: null });
     renderModal();
     await clickGenerate();
     await waitFor(() =>

--- a/frontend/src/__tests__/components/Listing96.test.tsx
+++ b/frontend/src/__tests__/components/Listing96.test.tsx
@@ -194,9 +194,10 @@ describe("AgentPublicPage — direct invite (9.6.2)", () => {
     renderProfile();
     await waitFor(() => screen.getByRole("button", { name: /request proposal/i }));
     fireEvent.click(screen.getByRole("button", { name: /request proposal/i }));
-    await waitFor(() => {
-      expect(screen.getByLabelText(/select property/i)).toBeInTheDocument();
-    });
+    // Poll until the select appears (mirrors the pattern in the "submitting" test below),
+    // then assert synchronously to avoid timer-reset hangs from continuous re-renders.
+    await waitFor(() => screen.getByLabelText(/select property/i));
+    expect(screen.getByLabelText(/select property/i)).toBeInTheDocument();
   });
 
   it("submitting the invite form calls createDirectInvite with agentId and propertyId", async () => {

--- a/frontend/src/__tests__/components/Report152.test.tsx
+++ b/frontend/src/__tests__/components/Report152.test.tsx
@@ -139,7 +139,7 @@ let mockTier: "Free" | "Pro" | "Premium" | "ContractorPro" = "Free";
 vi.mock("@/services/payment", () => ({
   paymentService: {
     getMySubscription: vi.fn().mockImplementation(() =>
-      Promise.resolve({ tier: mockTier, expiresAt: null })
+      Promise.resolve({ tier: mockTier, expiresAt: null, cancelledAt: null })
     ),
   },
 }));
@@ -236,13 +236,13 @@ describe("GenerateReportModal — success screen expiry row (15.2.3)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(paymentService.getMySubscription).mockImplementation(() =>
-      Promise.resolve({ tier: mockTier, expiresAt: null })
+      Promise.resolve({ tier: mockTier, expiresAt: null, cancelledAt: null })
     );
   });
 
   it("free user sees amber expiry row after generating a link", async () => {
     mockTier = "Free";
-    vi.mocked(paymentService.getMySubscription).mockResolvedValue({ tier: "Free", expiresAt: null });
+    vi.mocked(paymentService.getMySubscription).mockResolvedValue({ tier: "Free", expiresAt: null, cancelledAt: null });
     renderModal();
     await clickGenerate();
     await waitFor(() =>
@@ -254,7 +254,7 @@ describe("GenerateReportModal — success screen expiry row (15.2.3)", () => {
 
   it("free user sees 'Upgrade to Pro' link in the expiry row", async () => {
     mockTier = "Free";
-    vi.mocked(paymentService.getMySubscription).mockResolvedValue({ tier: "Free", expiresAt: null });
+    vi.mocked(paymentService.getMySubscription).mockResolvedValue({ tier: "Free", expiresAt: null, cancelledAt: null });
     renderModal();
     await clickGenerate();
     await waitFor(() =>
@@ -266,7 +266,7 @@ describe("GenerateReportModal — success screen expiry row (15.2.3)", () => {
 
   it("Pro user sees 'this link never expires' confirmation row", async () => {
     mockTier = "Pro";
-    vi.mocked(paymentService.getMySubscription).mockResolvedValue({ tier: "Pro", expiresAt: null });
+    vi.mocked(paymentService.getMySubscription).mockResolvedValue({ tier: "Pro", expiresAt: null, cancelledAt: null });
     renderModal();
     await clickGenerate();
     await waitFor(() =>
@@ -277,7 +277,7 @@ describe("GenerateReportModal — success screen expiry row (15.2.3)", () => {
 
   it("Premium user also sees 'this link never expires'", async () => {
     mockTier = "Premium";
-    vi.mocked(paymentService.getMySubscription).mockResolvedValue({ tier: "Premium", expiresAt: null });
+    vi.mocked(paymentService.getMySubscription).mockResolvedValue({ tier: "Premium", expiresAt: null, cancelledAt: null });
     renderModal();
     await clickGenerate();
     await waitFor(() =>

--- a/frontend/src/__tests__/contracts/__snapshots__/candid.contract.test.ts.snap
+++ b/frontend/src/__tests__/contracts/__snapshots__/candid.contract.test.ts.snap
@@ -658,6 +658,13 @@ exports[`maintenance IDL factory > full signature snapshot 1`] = `
 
 exports[`payment IDL factory > full signature snapshot 1`] = `
 {
+  "cancelSubscription": {
+    "args": [],
+    "mode": [],
+    "rets": [
+      "variant {ok:record {expiresAt:int; owner:principal; createdAt:int; tier:variant {Pro; Premium; Free; Basic; ContractorPro; ContractorFree}; cancelledAt:opt int}; err:variant {InvalidInput:text; PaymentFailed:text; NotFound; NotAuthorized; RateLimited}}",
+    ],
+  },
   "configureStripe": {
     "args": [
       "record {cancelUrl:text; secretKey:text; priceIds:record {premiumMonthly:text; contractorProYearly:text; contractorProMonthly:text; proMonthly:text; basicYearly:text; basicMonthly:text; proYearly:text; premiumYearly:text}; successUrl:text}",
@@ -693,7 +700,7 @@ exports[`payment IDL factory > full signature snapshot 1`] = `
       "query",
     ],
     "rets": [
-      "variant {ok:record {expiresAt:int; owner:principal; createdAt:int; tier:variant {Pro; Premium; Free; Basic; ContractorPro; ContractorFree}}; err:variant {InvalidInput:text; PaymentFailed:text; NotFound; NotAuthorized; RateLimited}}",
+      "variant {ok:record {expiresAt:int; owner:principal; createdAt:int; tier:variant {Pro; Premium; Free; Basic; ContractorPro; ContractorFree}; cancelledAt:opt int}; err:variant {InvalidInput:text; PaymentFailed:text; NotFound; NotAuthorized; RateLimited}}",
     ],
   },
   "getPriceQuote": {
@@ -732,7 +739,7 @@ exports[`payment IDL factory > full signature snapshot 1`] = `
     ],
     "mode": [],
     "rets": [
-      "variant {ok:record {expiresAt:int; owner:principal; createdAt:int; tier:variant {Pro; Premium; Free; Basic; ContractorPro; ContractorFree}}; err:variant {InvalidInput:text; PaymentFailed:text; NotFound; NotAuthorized; RateLimited}}",
+      "variant {ok:record {expiresAt:int; owner:principal; createdAt:int; tier:variant {Pro; Premium; Free; Basic; ContractorPro; ContractorFree}; cancelledAt:opt int}; err:variant {InvalidInput:text; PaymentFailed:text; NotFound; NotAuthorized; RateLimited}}",
     ],
   },
   "initAdmins": {
@@ -768,7 +775,7 @@ exports[`payment IDL factory > full signature snapshot 1`] = `
     ],
     "mode": [],
     "rets": [
-      "variant {ok:record {expiresAt:int; owner:principal; createdAt:int; tier:variant {Pro; Premium; Free; Basic; ContractorPro; ContractorFree}}; err:variant {InvalidInput:text; PaymentFailed:text; NotFound; NotAuthorized; RateLimited}}",
+      "variant {ok:record {expiresAt:int; owner:principal; createdAt:int; tier:variant {Pro; Premium; Free; Basic; ContractorPro; ContractorFree}; cancelledAt:opt int}; err:variant {InvalidInput:text; PaymentFailed:text; NotFound; NotAuthorized; RateLimited}}",
     ],
   },
   "subscribe": {
@@ -777,7 +784,7 @@ exports[`payment IDL factory > full signature snapshot 1`] = `
     ],
     "mode": [],
     "rets": [
-      "variant {ok:record {expiresAt:int; owner:principal; createdAt:int; tier:variant {Pro; Premium; Free; Basic; ContractorPro; ContractorFree}}; err:variant {InvalidInput:text; PaymentFailed:text; NotFound; NotAuthorized; RateLimited}}",
+      "variant {ok:record {expiresAt:int; owner:principal; createdAt:int; tier:variant {Pro; Premium; Free; Basic; ContractorPro; ContractorFree}; cancelledAt:opt int}; err:variant {InvalidInput:text; PaymentFailed:text; NotFound; NotAuthorized; RateLimited}}",
     ],
   },
   "verifyStripeSession": {
@@ -786,7 +793,7 @@ exports[`payment IDL factory > full signature snapshot 1`] = `
     ],
     "mode": [],
     "rets": [
-      "variant {ok:record {expiresAt:int; owner:principal; createdAt:int; tier:variant {Pro; Premium; Free; Basic; ContractorPro; ContractorFree}}; err:variant {InvalidInput:text; PaymentFailed:text; NotFound; NotAuthorized; RateLimited}}",
+      "variant {ok:record {expiresAt:int; owner:principal; createdAt:int; tier:variant {Pro; Premium; Free; Basic; ContractorPro; ContractorFree}; cancelledAt:opt int}; err:variant {InvalidInput:text; PaymentFailed:text; NotFound; NotAuthorized; RateLimited}}",
     ],
   },
 }

--- a/frontend/src/__tests__/contracts/candid.contract.test.ts
+++ b/frontend/src/__tests__/contracts/candid.contract.test.ts
@@ -122,6 +122,7 @@ describe("payment IDL factory", () => {
   it("exposes the expected methods", () => {
     const svc = extractService(paymentIdlFactory);
     expect(Object.keys(svc).sort()).toEqual([
+      "cancelSubscription",
       "configureStripe",
       "createStripeCheckoutSession",
       "getAllPricing",

--- a/frontend/src/__tests__/pages/SettingsPage.test.tsx
+++ b/frontend/src/__tests__/pages/SettingsPage.test.tsx
@@ -22,7 +22,7 @@ vi.mock("@/services/payment", async (importOriginal) => {
     paymentService: {
       getMySubscription: vi.fn(),
       initiate:          vi.fn().mockResolvedValue({ url: "/dashboard" }),
-      cancel:            vi.fn().mockResolvedValue(undefined),
+      cancel:            vi.fn().mockResolvedValue({ expiresAt: null }),
       recordCancellation: vi.fn(),
       pause:             vi.fn(),
       resume:            vi.fn(),

--- a/frontend/src/__tests__/perf/renderPerf1341_1342.test.tsx
+++ b/frontend/src/__tests__/perf/renderPerf1341_1342.test.tsx
@@ -93,7 +93,7 @@ vi.mock("@/services/recurringService", () => ({
 
 vi.mock("@/services/payment", () => ({
   paymentService: {
-    getMySubscription: vi.fn(() => Promise.resolve({ tier: "Pro", expiresAt: null })),
+    getMySubscription: vi.fn(() => Promise.resolve({ tier: "Pro", expiresAt: null, cancelledAt: null })),
   },
 }));
 
@@ -367,7 +367,7 @@ describe("13.4.1: Dashboard rendering with large dataset", () => {
     });
     vi.mocked(paymentService.getMySubscription).mockImplementation(() => {
       callOrder.push("payment");
-      return Promise.resolve({ tier: "Pro" as any, expiresAt: null });
+      return Promise.resolve({ tier: "Pro" as any, expiresAt: null, cancelledAt: null });
     });
 
     await act(async () => {

--- a/frontend/src/__tests__/services/__snapshots__/candidContracts.test.ts.snap
+++ b/frontend/src/__tests__/services/__snapshots__/candidContracts.test.ts.snap
@@ -118,7 +118,8 @@ unregisterCanister(1) -> (1)"
 `;
 
 exports[`Candid contract snapshots — method arity > payment 1`] = `
-"configureStripe(1) -> (1)
+"cancelSubscription(0) -> (1)
+configureStripe(1) -> (1)
 createStripeCheckoutSession(3) -> (1)
 getAllPricing(0) -> (1) [query]
 getMySubscription(0) -> (1) [query]

--- a/frontend/src/__tests__/services/payment.test.ts
+++ b/frontend/src/__tests__/services/payment.test.ts
@@ -19,10 +19,13 @@ vi.mock("@/services/icpLedger", () => ({
 }));
 
 const mockSubscribeActor = vi.fn().mockResolvedValue({
-  ok: { tier: { Free: null }, expiresAt: BigInt(0), owner: "x", createdAt: BigInt(0) },
+  ok: { tier: { Free: null }, expiresAt: BigInt(0), owner: "x", createdAt: BigInt(0), cancelledAt: [] },
 });
 const mockGetMySubscription = vi.fn().mockResolvedValue({
-  ok: { tier: { Free: null }, expiresAt: BigInt(0), owner: "x", createdAt: BigInt(0) },
+  ok: { tier: { Free: null }, expiresAt: BigInt(0), owner: "x", createdAt: BigInt(0), cancelledAt: [] },
+});
+const mockCancelSubscription = vi.fn().mockResolvedValue({
+  ok: { tier: { Pro: null }, expiresAt: BigInt(0), owner: "x", createdAt: BigInt(0), cancelledAt: [BigInt(1_000_000_000)] },
 });
 const mockGetPriceQuote = vi.fn().mockResolvedValue({ ok: BigInt(1_000_000) });
 const mockCreateStripeCheckoutSession = vi.fn().mockResolvedValue({
@@ -40,6 +43,7 @@ vi.mock("@icp-sdk/core/agent", () => ({
     createActor: vi.fn(() => ({
       subscribe:                   mockSubscribeActor,
       getMySubscription:           mockGetMySubscription,
+      cancelSubscription:          mockCancelSubscription,
       getPriceQuote:               mockGetPriceQuote,
       getPricing:                  vi.fn().mockResolvedValue({ ok: null }),
       getAllPricing:               vi.fn().mockResolvedValue({ ok: [] }),
@@ -303,7 +307,7 @@ describe("paymentService.getMySubscription — tier parsing", () => {
 
   it.each(tiers)("parses '%s' tier variant from canister response", async (tier) => {
     mockGetMySubscription.mockResolvedValueOnce({
-      ok: { tier: { [tier]: null }, expiresAt: BigInt(0), owner: "x", createdAt: BigInt(0) },
+      ok: { tier: { [tier]: null }, expiresAt: BigInt(0), owner: "x", createdAt: BigInt(0), cancelledAt: [] },
     });
     const sub = await paymentService.getMySubscription();
     expect(sub.tier).toBe(tier);
@@ -311,20 +315,36 @@ describe("paymentService.getMySubscription — tier parsing", () => {
 
   it("returns expiresAt=null when expiresAt is 0", async () => {
     mockGetMySubscription.mockResolvedValueOnce({
-      ok: { tier: { Pro: null }, expiresAt: BigInt(0), owner: "x", createdAt: BigInt(0) },
+      ok: { tier: { Pro: null }, expiresAt: BigInt(0), owner: "x", createdAt: BigInt(0), cancelledAt: [] },
     });
     const sub = await paymentService.getMySubscription();
     expect(sub.expiresAt).toBeNull();
   });
 
   it("converts non-zero expiresAt from nanoseconds to milliseconds", async () => {
-    // 1_735_689_600_000 ms = 2025-01-01T00:00:00Z in ns: * 1_000_000
     const expiresNs = BigInt(1_735_689_600_000) * BigInt(1_000_000);
     mockGetMySubscription.mockResolvedValueOnce({
-      ok: { tier: { Premium: null }, expiresAt: expiresNs, owner: "x", createdAt: BigInt(0) },
+      ok: { tier: { Premium: null }, expiresAt: expiresNs, owner: "x", createdAt: BigInt(0), cancelledAt: [] },
     });
     const sub = await paymentService.getMySubscription();
     expect(sub.expiresAt).toBeCloseTo(1_735_689_600_000, -3);
+  });
+
+  it("returns cancelledAt: null when cancelledAt is empty array", async () => {
+    mockGetMySubscription.mockResolvedValueOnce({
+      ok: { tier: { Pro: null }, expiresAt: BigInt(0), owner: "x", createdAt: BigInt(0), cancelledAt: [] },
+    });
+    const sub = await paymentService.getMySubscription();
+    expect(sub.cancelledAt).toBeNull();
+  });
+
+  it("parses cancelledAt from nanoseconds to milliseconds when present", async () => {
+    const cancelledNs = BigInt(1_735_689_600_000) * BigInt(1_000_000);
+    mockGetMySubscription.mockResolvedValueOnce({
+      ok: { tier: { Pro: null }, expiresAt: BigInt(0), owner: "x", createdAt: BigInt(0), cancelledAt: [cancelledNs] },
+    });
+    const sub = await paymentService.getMySubscription();
+    expect(sub.cancelledAt).toBeCloseTo(1_735_689_600_000, -3);
   });
 
   it("returns Free tier when canister returns an error", async () => {
@@ -332,6 +352,7 @@ describe("paymentService.getMySubscription — tier parsing", () => {
     const sub = await paymentService.getMySubscription();
     expect(sub.tier).toBe("Free");
     expect(sub.expiresAt).toBeNull();
+    expect(sub.cancelledAt).toBeNull();
   });
 });
 
@@ -369,11 +390,31 @@ describe("paymentService.cancel", () => {
     paymentService.reset();
   });
 
-  it("resolves without error (delegates to subscribe Free)", async () => {
-    mockSubscribeActor.mockResolvedValueOnce({
-      ok: { tier: { Free: null }, expiresAt: BigInt(0), owner: "x", createdAt: BigInt(0) },
+  it("returns { expiresAt: null } when expiresAt is 0", async () => {
+    mockCancelSubscription.mockResolvedValueOnce({
+      ok: { tier: { Pro: null }, expiresAt: BigInt(0), owner: "x", createdAt: BigInt(0), cancelledAt: [BigInt(1_000_000_000)] },
     });
-    await expect(paymentService.cancel()).resolves.toBeUndefined();
+    const result = await paymentService.cancel();
+    expect(result.expiresAt).toBeNull();
+  });
+
+  it("converts non-zero expiresAt from nanoseconds to milliseconds", async () => {
+    const expiresNs = BigInt(1_735_689_600_000) * BigInt(1_000_000);
+    mockCancelSubscription.mockResolvedValueOnce({
+      ok: { tier: { Pro: null }, expiresAt: expiresNs, owner: "x", createdAt: BigInt(0), cancelledAt: [BigInt(1_000_000_000)] },
+    });
+    const result = await paymentService.cancel();
+    expect(result.expiresAt).toBeCloseTo(1_735_689_600_000, -3);
+  });
+
+  it("throws with key when canister returns a non-text error", async () => {
+    mockCancelSubscription.mockResolvedValueOnce({ err: { NotAuthorized: null } });
+    await expect(paymentService.cancel()).rejects.toThrow("NotAuthorized");
+  });
+
+  it("throws with text message when canister returns InvalidInput", async () => {
+    mockCancelSubscription.mockResolvedValueOnce({ err: { InvalidInput: "Subscription already cancelled" } });
+    await expect(paymentService.cancel()).rejects.toThrow("Subscription already cancelled");
   });
 });
 

--- a/frontend/src/pages/FAQPage.tsx
+++ b/frontend/src/pages/FAQPage.tsx
@@ -185,14 +185,6 @@ export default function FAQPage() {
           maxWidth: 860, margin: "0 auto", padding: "72px 56px 0",
           textAlign: "center",
         }}>
-          <div style={{
-            display: "inline-block",
-            fontFamily: UI.mono, fontSize: 11, fontWeight: 700,
-            letterSpacing: "2px", textTransform: "uppercase",
-            color: UI.sage, marginBottom: 20,
-          }}>
-            ✦ FAQ
-          </div>
           <h1 style={{
             fontFamily: UI.serif, fontSize: "clamp(36px, 5vw, 56px)",
             fontWeight: 900, color: UI.ink, letterSpacing: "-1.5px",

--- a/frontend/src/pages/PrivacyPolicyPage.tsx
+++ b/frontend/src/pages/PrivacyPolicyPage.tsx
@@ -196,9 +196,6 @@ export default function PrivacyPolicyPage() {
 
           {/* Header */}
           <div style={{ marginBottom: "3rem", paddingBottom: "2rem", borderBottom: `1px solid ${UI.rule}` }}>
-            <div style={{ display: "inline-flex", alignItems: "center", background: UI.butter, color: UI.ink, padding: "5px 16px", borderRadius: 100, fontSize: "0.7rem", fontWeight: 700, fontFamily: UI.mono, letterSpacing: "0.06em", marginBottom: "1.25rem", border: `1px solid rgba(46,37,64,0.1)` }}>
-              LEGAL
-            </div>
             <h1 style={{ fontFamily: UI.serif, fontWeight: 900, fontSize: "clamp(2rem, 4vw, 2.75rem)", lineHeight: 1.05, color: UI.ink, marginBottom: "0.75rem" }}>
               Privacy Policy
             </h1>

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -279,6 +279,7 @@ function SubscriptionTab({ profile }: { profile: any }) {
   const navigate = useNavigate();
   const [tier,             setTier]             = useState<PlanTier>(profile?.role === "Contractor" ? "ContractorPro" : "Free");
   const [expiresAt,        setExpiresAt]        = useState<number | null>(null);
+  const [cancelledAt,      setCancelledAt]      = useState<number | null>(null);
   const [subLoaded,        setSubLoaded]        = useState(false);
   const [showUpgradeModal, setShowUpgradeModal] = useState(false);
   const [cancelStep,       setCancelStep]       = useState<"idle" | "confirm" | "loading" | "done">("idle");
@@ -288,6 +289,10 @@ function SubscriptionTab({ profile }: { profile: any }) {
     paymentService.getMySubscription().then((sub) => {
       setTier(sub.tier);
       setExpiresAt(sub.expiresAt);
+      if (sub.cancelledAt) {
+        setCancelledAt(sub.cancelledAt);
+        setCancelStep("done");
+      }
     }).catch(() => {}).finally(() => setSubLoaded(true));
   }, []);
 
@@ -309,11 +314,10 @@ function SubscriptionTab({ profile }: { profile: any }) {
   const handleCancel = async () => {
     setCancelStep("loading");
     try {
-      await paymentService.cancel();
+      const { expiresAt: accessEndsAt } = await paymentService.cancel();
       paymentService.recordCancellation();
       winBackService.schedule(Date.now());
-      setTier("Free");
-      setExpiresAt(null);
+      setCancelledAt(accessEndsAt);
       setCancelStep("done");
     } catch (err: any) {
       toast.error(err.message || "Cancellation failed");
@@ -361,12 +365,14 @@ function SubscriptionTab({ profile }: { profile: any }) {
         <div>
           <div style={{ display: "flex", alignItems: "center", gap: "0.75rem", marginBottom: "0.75rem" }}>
             <Badge variant="info" size="lg">{tier}</Badge>
-            <span style={{ fontFamily: FONTS.sans, fontSize: "0.875rem", color: expiresAt && expiresAt < Date.now() ? COLORS.rust : COLORS.plumMid }}>
+            <span style={{ fontFamily: FONTS.sans, fontSize: "0.875rem", color: expiresAt && expiresAt < Date.now() ? COLORS.rust : cancelledAt ? COLORS.rust : COLORS.plumMid }}>
               {expiresAt && expiresAt < Date.now()
                 ? "Expired"
-                : expiresAt
-                  ? `Renews ${new Date(expiresAt).toLocaleDateString()}`
-                  : "Active subscription"}
+                : cancelledAt
+                  ? `Cancelled — access ends ${new Date(expiresAt!).toLocaleDateString()}`
+                  : expiresAt
+                    ? `Renews ${new Date(expiresAt).toLocaleDateString()}`
+                    : "Active subscription"}
             </span>
           </div>
           {expiresAt && expiresAt < Date.now() && (
@@ -470,7 +476,7 @@ function SubscriptionTab({ profile }: { profile: any }) {
               )}
               <div style={{ borderTop: `1px solid ${COLORS.rule}`, paddingTop: "0.875rem" }}>
                 <p style={{ fontFamily: FONTS.sans, fontSize: "0.875rem", color: COLORS.plumMid, fontWeight: 300, lineHeight: 1.6, marginBottom: "0.75rem" }}>
-                  Cancelling will immediately downgrade your account to Free. Your records and property history will be preserved.
+                  You keep full access until the end of your current billing period{expiresAt ? ` (${new Date(expiresAt).toLocaleDateString()})` : ""}. After that, access to the platform is removed.
                 </p>
                 <button
                   onClick={() => setCancelStep("confirm")}
@@ -502,7 +508,7 @@ function SubscriptionTab({ profile }: { profile: any }) {
                 </p>
               </div>
               <p style={{ fontFamily: FONTS.sans, fontSize: "0.875rem", color: COLORS.plumMid }}>
-                Or pause instead — keeps your account active without billing.
+                Your access continues until{expiresAt ? ` ${new Date(expiresAt).toLocaleDateString()}` : " the end of your billing period"}, then your account is closed. Or pause instead — keeps your account active without billing.
               </p>
               <div style={{ display: "flex", gap: "0.75rem", flexWrap: "wrap" }}>
                 <button
@@ -549,16 +555,11 @@ function SubscriptionTab({ profile }: { profile: any }) {
                 Subscription cancelled
               </p>
               <p style={{ fontFamily: FONTS.sans, fontSize: "0.875rem", color: COLORS.plumMid }}>
-                Your account has been downgraded to Free. All your records are intact.
+                {(cancelledAt ?? expiresAt) && expiresAt
+                  ? `You have full access until ${new Date(expiresAt).toLocaleDateString()}. After that, your account will be closed.`
+                  : "Your cancellation has been recorded. All your ICP records remain intact."}
               </p>
             </div>
-          </div>
-          <div style={{ padding: "0.875rem 1rem", background: COLORS.sageLight, borderRadius: RADIUS.sm }}>
-            <p style={{ fontFamily: FONTS.sans, fontWeight: 600, fontSize: "0.8125rem", color: COLORS.sage, marginBottom: "0.25rem" }}>Read-only mode</p>
-            <p style={{ fontFamily: FONTS.sans, fontSize: "0.8125rem", color: COLORS.plumMid, lineHeight: 1.5 }}>
-              Your records are read-only. Your HomeGentic score won't update, and existing reports are static.
-              Reactivate Pro to resume tracking and generate new reports.
-            </p>
           </div>
         </>
       )}

--- a/frontend/src/services/payment.ts
+++ b/frontend/src/services/payment.ts
@@ -15,10 +15,11 @@ export const idlFactory = ({ IDL }: any) => {
   });
   const BillingPeriod = IDL.Variant({ Monthly: IDL.Null, Yearly: IDL.Null });
   const Subscription = IDL.Record({
-    owner:     IDL.Principal,
-    tier:      Tier,
-    expiresAt: IDL.Int,
-    createdAt: IDL.Int,
+    owner:       IDL.Principal,
+    tier:        Tier,
+    expiresAt:   IDL.Int,
+    createdAt:   IDL.Int,
+    cancelledAt: IDL.Opt(IDL.Int),
   });
   const Error = IDL.Variant({
     NotFound:      IDL.Null,
@@ -102,6 +103,11 @@ export const idlFactory = ({ IDL }: any) => {
       [],
       [IDL.Variant({ ok: Subscription, err: Error })],
       ["query"]
+    ),
+    cancelSubscription: IDL.Func(
+      [],
+      [IDL.Variant({ ok: Subscription, err: Error })],
+      []
     ),
     getPricing: IDL.Func(
       [Tier],
@@ -228,20 +234,22 @@ export const paymentService = {
     }
   },
 
-  async getMySubscription(): Promise<{ tier: PlanTier; expiresAt: number | null }> {
+  async getMySubscription(): Promise<{ tier: PlanTier; expiresAt: number | null; cancelledAt: number | null }> {
     if (import.meta.env.DEV && (window as any).__e2e_subscription) {
-      return (window as any).__e2e_subscription;
+      return { cancelledAt: null, ...(window as any).__e2e_subscription };
     }
-    if (import.meta.env.DEV && !PAYMENT_CANISTER_ID) return { tier: "Free", expiresAt: null };
+    if (import.meta.env.DEV && !PAYMENT_CANISTER_ID) return { tier: "Free", expiresAt: null, cancelledAt: null };
     const a = await getActor();
     const result = await a.getMySubscription();
-    if ("err" in result) return { tier: "Free", expiresAt: null };
+    if ("err" in result) return { tier: "Free", expiresAt: null, cancelledAt: null };
     const sub = result.ok;
-    const tierKey   = Object.keys(sub.tier)[0] as PlanTier;
-    const expiresNs = Number(sub.expiresAt);
+    const tierKey       = Object.keys(sub.tier)[0] as PlanTier;
+    const expiresNs     = Number(sub.expiresAt);
+    const cancelledNs   = sub.cancelledAt?.[0] != null ? Number(sub.cancelledAt[0]) : null;
     return {
-      tier:      tierKey,
-      expiresAt: expiresNs === 0 ? null : expiresNs / 1_000_000,
+      tier:        tierKey,
+      expiresAt:   expiresNs === 0 ? null : expiresNs / 1_000_000,
+      cancelledAt: cancelledNs != null ? cancelledNs / 1_000_000 : null,
     };
   },
 
@@ -263,8 +271,17 @@ export const paymentService = {
     return this.subscribe(tier, onStep);
   },
 
-  async cancel(): Promise<void> {
-    return this.subscribe("Free");
+  async cancel(): Promise<{ expiresAt: number | null }> {
+    if (import.meta.env.DEV && !PAYMENT_CANISTER_ID) return { expiresAt: null };
+    const a = await getActor();
+    const result = await a.cancelSubscription();
+    if ("err" in result) {
+      const key    = Object.keys(result.err)[0];
+      const detail = (result.err as any)[key];
+      throw new Error(typeof detail === "string" ? detail : key);
+    }
+    const expiresNs = Number(result.ok.expiresAt);
+    return { expiresAt: expiresNs === 0 ? null : expiresNs / 1_000_000 };
   },
 
   /** Record cancellation timestamp in localStorage (8.3.2). */


### PR DESCRIPTION
- Add cancelledAt field to Subscription type in Motoko; update all record constructions; add cancelSubscription() update method that marks the subscription without clearing tier or expiresAt
- Frontend payment.ts: expose cancelledAt in getMySubscription() response, rewrite cancel() to call cancelSubscription and return { expiresAt }
- SettingsPage: post-cancel state shows access end date and account-closure notice; no free-tier fallback (access ends when billing period expires)
- Remove decorative 'FAQ' label from FAQPage and 'LEGAL' badge from PrivacyPolicyPage
- Tests: update payment, SettingsPage, CancelledAccount835, and Candid contract snapshots to match new shape; fix two pre-existing 30 s test timeouts in CheckAddressPage174 and Listing96 by moving assertions outside waitFor callbacks

## Summary
<!-- What does this PR do? -->

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [ ] Backend tests pass (`make test`)
- [ ] Frontend builds (`cd frontend && npm run build`)
- [ ] Tested locally with dfx

## Checklist
- [ ] Code follows project conventions
- [ ] Self-review completed
- [ ] No sensitive data committed
