### PR TITLE
perf(ci): parallelize canister deploy, wiring, and test execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
 
       - name: Install DFX
         uses: dfinity/setup-dfx@main
+        with:
+          dfx_version: "0.31.0"
 
       - name: Cache mops packages
         uses: actions/cache@v4
@@ -86,6 +88,8 @@ jobs:
 
       - name: Install DFX
         uses: dfinity/setup-dfx@main
+        with:
+          dfx_version: "0.31.0"
 
       - name: Cache mops packages
         uses: actions/cache@v4

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -57,6 +57,8 @@ jobs:
 
       - name: Install DFX
         uses: dfinity/setup-dfx@main
+        with:
+          dfx_version: "0.31.0"
 
       - name: Cache mops packages
         uses: actions/cache@v5

--- a/.github/workflows/cycle-watchdog.yml
+++ b/.github/workflows/cycle-watchdog.yml
@@ -34,6 +34,8 @@ jobs:
 
       - name: Install DFX
         uses: dfinity/setup-dfx@main
+        with:
+          dfx_version: "0.31.0"
 
       - name: Install mops
         run: npm install -g ic-mops

--- a/.github/workflows/deploy-mainnet.yml
+++ b/.github/workflows/deploy-mainnet.yml
@@ -14,6 +14,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install DFX
         uses: dfinity/setup-dfx@main
+        with:
+          dfx_version: "0.31.0"
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/deploy-testnet.yml
+++ b/.github/workflows/deploy-testnet.yml
@@ -33,6 +33,8 @@ jobs:
 
       - name: Install DFX
         uses: dfinity/setup-dfx@main
+        with:
+          dfx_version: "0.31.0"
 
       - name: Cache mops packages
         uses: actions/cache@v5

--- a/backend/payment/test.sh
+++ b/backend/payment/test.sh
@@ -11,31 +11,39 @@ echo "▶ Ensuring payment admin is initialized..."
 dfx canister call payment initAdmins "(vec { principal \"$MY_PRINCIPAL\" })" \
   --network local 2>/dev/null || true
 
-echo "▶ Get current subscription (expect Free default)..."
-dfx canister call payment getMySubscription
+# Use a dedicated identity for subscription tier tests so that the deployer's
+# tier (Pro, from deploy.sh bootstrap) is not mutated while other test suites
+# run in parallel and depend on it staying Pro.
+if ! dfx identity list 2>/dev/null | grep -q "^payment-tier-test$"; then
+  dfx identity new payment-tier-test --disable-encryption 2>/dev/null || true
+fi
+TIER_PRINCIPAL=$(dfx identity get-principal --identity payment-tier-test)
 
-echo "▶ Grant Pro subscription (bypasses ICP payment — local dev only)..."
-dfx canister call payment grantSubscription "(principal \"$MY_PRINCIPAL\", variant { Pro })"
+echo "▶ Get current subscription for tier-test user (expect Free default)..."
+dfx canister call payment getMySubscription --identity payment-tier-test
+
+echo "▶ Grant Pro subscription to tier-test user..."
+dfx canister call payment grantSubscription "(principal \"$TIER_PRINCIPAL\", variant { Pro })"
 
 echo "▶ Get updated subscription (expect Pro)..."
-dfx canister call payment getMySubscription
+dfx canister call payment getMySubscription --identity payment-tier-test
 
 echo "▶ getTierForPrincipal — expect Pro..."
-dfx canister call payment getTierForPrincipal "(principal \"$MY_PRINCIPAL\")"
+dfx canister call payment getTierForPrincipal "(principal \"$TIER_PRINCIPAL\")"
 
 echo "▶ Grant Premium subscription..."
-dfx canister call payment grantSubscription "(principal \"$MY_PRINCIPAL\", variant { Premium })"
+dfx canister call payment grantSubscription "(principal \"$TIER_PRINCIPAL\", variant { Premium })"
 
 echo "▶ Get updated subscription (expect Premium)..."
-dfx canister call payment getMySubscription
+dfx canister call payment getMySubscription --identity payment-tier-test
 
 echo "▶ Downgrade to Free via grantSubscription..."
-dfx canister call payment grantSubscription "(principal \"$MY_PRINCIPAL\", variant { Free })"
-dfx canister call payment getMySubscription
+dfx canister call payment grantSubscription "(principal \"$TIER_PRINCIPAL\", variant { Free })"
+dfx canister call payment getMySubscription --identity payment-tier-test
 
 echo "▶ Grant ContractorFree subscription..."
-dfx canister call payment grantSubscription "(principal \"$MY_PRINCIPAL\", variant { ContractorFree })"
-SUB=$(dfx canister call payment getMySubscription)
+dfx canister call payment grantSubscription "(principal \"$TIER_PRINCIPAL\", variant { ContractorFree })"
+SUB=$(dfx canister call payment getMySubscription --identity payment-tier-test)
 echo "$SUB" | grep -q "ContractorFree" \
   && echo "  ↳ ContractorFree tier confirmed — ✓" \
   || (echo "  ↳ ❌ Expected ContractorFree tier"; exit 1)

--- a/backend/photo/test.sh
+++ b/backend/photo/test.sh
@@ -47,7 +47,12 @@ if [ -z "$PAYMENT_ID" ]; then
   echo "⚠️  payment canister not deployed — skipping payment-wired tests"
 else
 
-  MY_PRINCIPAL=$(dfx identity get-principal)
+  # Use a dedicated identity for tier-manipulation tests so the deployer's
+  # tier is not mutated while other suites run in parallel.
+  if ! dfx identity list 2>/dev/null | grep -q "^photo-tier-test$"; then
+    dfx identity new photo-tier-test --disable-encryption 2>/dev/null || true
+  fi
+  PHOTO_TIER_PRINCIPAL=$(dfx identity get-principal --identity photo-tier-test)
 
   echo ""
   echo "── [EXP-1] setPaymentCanisterId — wires photo to payment canister ───────"
@@ -55,31 +60,34 @@ else
   echo "  ↳ setPaymentCanisterId succeeded — ✓"
 
   echo ""
-  echo "── [EXP-2] Free tier: uploading 3rd photo on same job → expect LimitReached ──"
-  # Free tier = 2 photos/job. Two already uploaded above (JOB_1).
-  dfx canister call payment grantSubscription "(principal \"$MY_PRINCIPAL\", variant { Free })"
-  dfx canister call photo uploadPhoto '(
+  echo "── [EXP-2] Free tier: upload → expect full rejection (no access) ────────"
+  # Free tier has no photo upload access at all.
+  # photo-tier-test starts with no subscription (defaults to Free).
+  RESULT=$(dfx canister call photo uploadPhoto '(
     "JOB_1",
     "PROP_1",
     variant { Finishing },
-    "Third photo — should fail on Free tier",
+    "Free tier — should be rejected entirely",
     "aaa111bbb222aaa111bbb222aaa111bbb222aaa111bbb222aaa111bbb222aaa1",
     vec { 255 : nat8; 216 : nat8; 255 : nat8 }
-  )' && echo "  ↳ ❌ Expected LimitReached for Free tier via payment canister" \
-       || echo "  ↳ Free tier photo limit enforced via payment canister — ✓"
+  )' --identity photo-tier-test 2>&1)
+  echo "$RESULT" | grep -qi "subscription\|InvalidInput\|blocked" \
+    && echo "  ↳ Free tier correctly blocked from photo upload — ✓" \
+    || echo "  ↳ ❌ Expected rejection for Free tier"
 
   echo ""
-  echo "── [EXP-3] Grant Pro → 3rd photo on same job succeeds ──────────────────"
-  dfx canister call payment grantSubscription "(principal \"$MY_PRINCIPAL\", variant { Pro })"
+  echo "── [EXP-3] Grant Pro → photo upload succeeds ────────────────────────────"
+  dfx canister call payment grantSubscription "(principal \"$PHOTO_TIER_PRINCIPAL\", variant { Pro })"
   dfx canister call photo uploadPhoto '(
-    "JOB_1",
-    "PROP_1",
+    "JOB_TIER_TEST",
+    "PROP_TIER_TEST",
     variant { Finishing },
-    "Third photo — Pro tier allows 10 per job",
+    "Pro tier allows photo upload",
     "bbb222ccc333bbb222ccc333bbb222ccc333bbb222ccc333bbb222ccc333bbb2",
     vec { 255 : nat8; 216 : nat8; 255 : nat8 }
-  )' && echo "  ↳ Pro tier allows 3rd photo via payment canister — ✓" \
-       || echo "  ↳ ❌ Pro tier should allow 3rd photo"
+  )' --identity photo-tier-test \
+    && echo "  ↳ Pro tier allows photo upload via payment canister — ✓" \
+    || echo "  ↳ ❌ Pro tier should allow photo upload"
 
   echo ""
   echo "✅ Photo payment-wired tier enforcement tests complete!"

--- a/backend/property/test.sh
+++ b/backend/property/test.sh
@@ -237,7 +237,12 @@ if [ -z "$PAYMENT_ID" ]; then
   echo "⚠️  payment canister not deployed — skipping payment-wired tests"
 else
 
-  MY_PRINCIPAL=$(dfx identity get-principal)
+  # Use a dedicated identity for tier-manipulation tests so the deployer's
+  # tier is not mutated while other suites run in parallel.
+  if ! dfx identity list 2>/dev/null | grep -q "^property-tier-test$"; then
+    dfx identity new property-tier-test --disable-encryption 2>/dev/null || true
+  fi
+  PROP_TIER_PRINCIPAL=$(dfx identity get-principal --identity property-tier-test)
 
   echo ""
   echo "── [EXP-1] setPaymentCanisterId — wires property to payment canister ────"
@@ -246,8 +251,8 @@ else
 
   echo ""
   echo "── [EXP-2] On Free tier: second property → expect LimitReached ──────────"
-  # Ensure caller is Free in the payment canister
-  dfx canister call payment grantSubscription "(principal \"$MY_PRINCIPAL\", variant { Free })"
+  # Grant Free to the tier-test identity (not the deployer)
+  dfx canister call payment grantSubscription "(principal \"$PROP_TIER_PRINCIPAL\", variant { Free })"
   dfx canister call $CANISTER registerProperty '(record {
     address      = "999 Payment-Wired Street";
     city         = "Austin";
@@ -257,12 +262,13 @@ else
     yearBuilt    = 2000;
     squareFeet   = 1500;
     tier         = variant { Free };
-  })' && echo "  ↳ ❌ Expected LimitReached for Free tier via payment canister" \
-       || echo "  ↳ Free tier limit enforced via payment canister — ✓"
+  })' --identity property-tier-test \
+    && echo "  ↳ ❌ Expected LimitReached for Free tier via payment canister" \
+    || echo "  ↳ Free tier limit enforced via payment canister — ✓"
 
   echo ""
   echo "── [EXP-3] Grant Pro via payment canister → second property succeeds ─────"
-  dfx canister call payment grantSubscription "(principal \"$MY_PRINCIPAL\", variant { Pro })"
+  dfx canister call payment grantSubscription "(principal \"$PROP_TIER_PRINCIPAL\", variant { Pro })"
   dfx canister call $CANISTER registerProperty '(record {
     address      = "999 Payment-Wired Street";
     city         = "Austin";
@@ -272,12 +278,13 @@ else
     yearBuilt    = 2000;
     squareFeet   = 1500;
     tier         = variant { Pro };
-  })' && echo "  ↳ Pro tier allows second property via payment canister — ✓" \
-       || echo "  ↳ ❌ Pro tier should allow second property"
+  })' --identity property-tier-test \
+    && echo "  ↳ Pro tier allows second property via payment canister — ✓" \
+    || echo "  ↳ ❌ Pro tier should allow second property"
 
   echo ""
   echo "── [EXP-4] Downgrade back to Free → further registrations rejected ──────"
-  dfx canister call payment grantSubscription "(principal \"$MY_PRINCIPAL\", variant { Free })"
+  dfx canister call payment grantSubscription "(principal \"$PROP_TIER_PRINCIPAL\", variant { Free })"
   dfx canister call $CANISTER registerProperty '(record {
     address      = "888 Downgraded Lane";
     city         = "Austin";
@@ -287,11 +294,9 @@ else
     yearBuilt    = 2005;
     squareFeet   = 1200;
     tier         = variant { Free };
-  })' && echo "  ↳ ❌ Expected LimitReached after downgrade" \
-       || echo "  ↳ Downgraded to Free — limit correctly re-enforced via payment canister — ✓"
-
-  # Restore Pro for remaining tests
-  dfx canister call payment grantSubscription "(principal \"$MY_PRINCIPAL\", variant { Pro })" > /dev/null
+  })' --identity property-tier-test \
+    && echo "  ↳ ❌ Expected LimitReached after downgrade" \
+    || echo "  ↳ Downgraded to Free — limit correctly re-enforced via payment canister — ✓"
 
   echo ""
   echo "✅ Property payment-wired tier enforcement tests complete!"

--- a/backend/quote/test.sh
+++ b/backend/quote/test.sh
@@ -204,7 +204,12 @@ if [ -z "$PAYMENT_ID" ]; then
   echo "⚠️  payment canister not deployed — skipping payment-wired tests"
 else
 
-  MY_PRINCIPAL=$(dfx identity get-principal)
+  # Use a dedicated identity for tier-manipulation tests so the deployer's
+  # tier is not mutated while other suites run in parallel.
+  if ! dfx identity list 2>/dev/null | grep -q "^quote-tier-test$"; then
+    dfx identity new quote-tier-test --disable-encryption 2>/dev/null || true
+  fi
+  QUOTE_TIER_PRINCIPAL=$(dfx identity get-principal --identity quote-tier-test)
 
   echo ""
   echo "── [EXP-1] setPaymentCanisterId — wires quote to payment canister ───────"
@@ -213,37 +218,48 @@ else
 
   echo ""
   echo "── [EXP-2] Free tier: 4th open request → expect LimitReached ────────────"
-  # 3 open requests already created in [15]. Make sure caller is Free.
-  dfx canister call payment grantSubscription "(principal \"$MY_PRINCIPAL\", variant { Free })"
+  # Create 3 open requests as the tier-test user first, then try a 4th.
+  dfx canister call payment grantSubscription "(principal \"$QUOTE_TIER_PRINCIPAL\", variant { Free })"
+  for i in 1 2 3; do
+    dfx canister call $CANISTER createQuoteRequest "(
+      \"PROP_TIER_WIRED_$i\",
+      variant { Roofing },
+      \"open request $i for tier test\",
+      variant { Low }
+    )" --identity quote-tier-test 2>/dev/null || true
+  done
   dfx canister call $CANISTER createQuoteRequest '(
     "PROP_PAYMENT_WIRED",
     variant { Roofing },
     "4th open request — should fail on Free tier via payment canister",
     variant { Low }
-  )' && echo "  ↳ ❌ Expected LimitReached for Free tier via payment canister" \
-       || echo "  ↳ Free tier open-request limit enforced via payment canister — ✓"
+  )' --identity quote-tier-test \
+    && echo "  ↳ ❌ Expected LimitReached for Free tier via payment canister" \
+    || echo "  ↳ Free tier open-request limit enforced via payment canister — ✓"
 
   echo ""
   echo "── [EXP-3] Grant Pro → 4th open request succeeds (limit = 10) ───────────"
-  dfx canister call payment grantSubscription "(principal \"$MY_PRINCIPAL\", variant { Pro })"
+  dfx canister call payment grantSubscription "(principal \"$QUOTE_TIER_PRINCIPAL\", variant { Pro })"
   dfx canister call $CANISTER createQuoteRequest '(
     "PROP_PAYMENT_WIRED",
     variant { Roofing },
     "4th open request — Pro tier allows 10",
     variant { Low }
-  )' && echo "  ↳ Pro tier allows 4th open request via payment canister — ✓" \
-       || echo "  ↳ ❌ Pro tier should allow 4th open request"
+  )' --identity quote-tier-test \
+    && echo "  ↳ Pro tier allows 4th open request via payment canister — ✓" \
+    || echo "  ↳ ❌ Pro tier should allow 4th open request"
 
   echo ""
   echo "── [EXP-4] Downgrade to Free → next new request rejected ────────────────"
-  dfx canister call payment grantSubscription "(principal \"$MY_PRINCIPAL\", variant { Free })"
+  dfx canister call payment grantSubscription "(principal \"$QUOTE_TIER_PRINCIPAL\", variant { Free })"
   dfx canister call $CANISTER createQuoteRequest '(
     "PROP_PAYMENT_WIRED",
     variant { Plumbing },
     "Should fail — back to Free tier limit",
     variant { Low }
-  )' && echo "  ↳ ❌ Expected LimitReached after downgrade to Free" \
-       || echo "  ↳ Downgraded to Free — open-request limit re-enforced via payment canister — ✓"
+  )' --identity quote-tier-test \
+    && echo "  ↳ ❌ Expected LimitReached after downgrade to Free" \
+    || echo "  ↳ Downgraded to Free — open-request limit re-enforced via payment canister — ✓"
 
   echo ""
   echo "✅ Quote payment-wired tier enforcement tests complete!"

--- a/backend/quote/test.sh
+++ b/backend/quote/test.sh
@@ -120,36 +120,61 @@ echo ""
 echo "── [14] getQuoteRequest — status should be Closed ───────────────────────"
 dfx canister call $CANISTER getQuoteRequest "(\"$REQ2_ID\")"
 
-# ─── Tier open-request limit — Free = 3 (12.4.4) ─────────────────────────────
+# ─── Tier open-request limit — Free tier is fully blocked; Basic limit = 3 ───
 echo ""
-echo "── [15] Free tier limit: create 3 requests to hit cap (12.4.4) ──────────"
+echo "── [15] Free tier: createQuoteRequest → expect full rejection ───────────"
+# Free tier has no access at all to quote requests.
+# Use a dedicated identity so the deployer's Pro tier is not affected.
+if ! dfx identity list 2>/dev/null | grep -q "^quote-free-test$"; then
+  dfx identity new quote-free-test --disable-encryption 2>/dev/null || true
+fi
+RESULT=$(dfx canister call $CANISTER createQuoteRequest '(
+  "PROP_LIMIT",
+  variant { Roofing },
+  "Free tier should be rejected entirely.",
+  variant { Low }
+)' --identity quote-free-test 2>&1)
+echo "$RESULT" | grep -qi "subscription\|InvalidInput" \
+  && echo "  ↳ Free tier correctly blocked from creating quote requests — ✓" \
+  || echo "  ↳ ❌ Expected rejection for Free tier"
+
+echo ""
+echo "── [15b] Basic tier: fill 3 open slots then expect LimitReached ─────────"
+# Grant Basic (limit = 3) to the free-test identity.
+if ! dfx identity list 2>/dev/null | grep -q "^quote-basic-test$"; then
+  dfx identity new quote-basic-test --disable-encryption 2>/dev/null || true
+fi
+BASIC_PRINCIPAL=$(dfx identity get-principal --identity quote-basic-test)
+dfx canister call payment grantSubscription "(principal \"$BASIC_PRINCIPAL\", variant { Basic })"
 LIMIT_REQ_IDS=()
 for i in 1 2 3; do
   OUT=$(dfx canister call $CANISTER createQuoteRequest "(
     \"PROP_LIMIT\",
     variant { Roofing },
-    \"Tier limit test request $i — filling open slot.\",
+    \"Basic tier limit test request $i.\",
     variant { Low }
-  )")
-  ID=$(echo "$OUT" | grep -oP '"REQ_[^"]+"' | head -1 | tr -d '"')
-  LIMIT_REQ_IDS+=("$ID")
-  echo "  → Request $i created ($ID)"
+  )" --identity quote-basic-test)
+  ID=$(echo "$OUT" | grep -oP '"REQ_[^"]+"' | head -1 | tr -d '"' || true)
+  [ -n "$ID" ] && LIMIT_REQ_IDS+=("$ID") && echo "  → Request $i created ($ID)" \
+               || echo "  ↳ ❌ Request $i failed unexpectedly: $OUT"
 done
 
 echo ""
-echo "── [16] 4th request on Free tier → expect open-request limit error ───────"
+echo "── [16] 4th request on Basic tier → expect LimitReached (max 3 open) ────"
 dfx canister call $CANISTER createQuoteRequest '(
   "PROP_LIMIT",
   variant { Roofing },
-  "This 4th request should fail on Free tier limit.",
+  "This 4th request should fail on Basic tier limit.",
   variant { Low }
-)' || echo "  ↳ Expected LimitReached on Free tier (max 3 open) — ✓"
+)' --identity quote-basic-test \
+  && echo "  ↳ ❌ Expected LimitReached for Basic tier" \
+  || echo "  ↳ Basic tier open-request limit correctly enforced (max 3) — ✓"
 
-# Close the 3 limit-test requests so subsequent tests aren't blocked by the cap
+# Close the basic-tier limit-test requests
 echo ""
-echo "── [16-cleanup] Close limit-test requests to restore open slot ──────────"
+echo "── [16-cleanup] Close limit-test requests ────────────────────────────────"
 for ID in "${LIMIT_REQ_IDS[@]}"; do
-  [ -n "$ID" ] && dfx canister call $CANISTER closeQuoteRequest "(\"$ID\")" > /dev/null
+  [ -n "$ID" ] && dfx canister call $CANISTER closeQuoteRequest "(\"$ID\")" --identity quote-basic-test > /dev/null
 done
 echo "  ↳ Limit-test requests closed — ✓"
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -126,17 +126,36 @@ MGMT_DID
   echo "  ✓ Management canister IDL written (.dfx/local/canisters/idl/aaaaa-aa.did)"
 fi
 
-# ── Sequential canister deployment ──────────────────────────────────────────────
-# Parallel deploys race on canister_ids.json (each process read→add→write);
-# the last writer wins and all other IDs are lost. Sequential is the safe default.
+# ── Parallel canister deployment ────────────────────────────────────────────────
+# Strategy: two phases to eliminate the canister_ids.json write race.
+#   Phase 1 — dfx canister create --all (single process, writes all IDs atomically)
+#   Phase 2 — parallel dfx build + dfx canister install per canister
+#             (install never touches canister_ids.json; each build writes to its
+#              own isolated .dfx/local/canisters/<name>/ directory)
 
 CANISTERS=(auth property job contractor quote payment photo report maintenance market sensor monitoring listing agent recurring bills ai_proxy)
 LOG_DIR=$(mktemp -d /tmp/dfx-deploy-XXXXXX)
 
-echo "▶ Deploying ${#CANISTERS[@]} canisters..."
-FAILED=()
+# Phase 1: create all canister IDs in one atomic operation
+echo "▶ Creating canister IDs (phase 1/2)..."
+dfx canister create --all --network "$NETWORK" 2>/dev/null || true
+
+# Phase 2: build + install every canister in parallel
+echo "▶ Building and installing ${#CANISTERS[@]} canisters in parallel (phase 2/2)..."
+PIDS=()
 for canister in "${CANISTERS[@]}"; do
-  if dfx deploy "$canister" --network "$NETWORK" >"$LOG_DIR/$canister.log" 2>&1; then
+  (
+    dfx build "$canister" --network "$NETWORK" 2>&1 && \
+    dfx canister install "$canister" --mode install --network "$NETWORK" 2>&1
+  ) >"$LOG_DIR/$canister.log" 2>&1 &
+  PIDS+=($!)
+done
+
+# Collect results
+FAILED=()
+for i in "${!CANISTERS[@]}"; do
+  canister="${CANISTERS[$i]}"
+  if wait "${PIDS[$i]}"; then
     echo "  ✓ $canister"
   else
     echo "  ✗ $canister (failed)"
@@ -235,11 +254,14 @@ echo "  Deployer principal: $DEPLOYER"
 # All canisters that expose addAdmin, excluding ai_proxy (handled separately).
 ADMIN_CANISTERS=(auth property job contractor quote photo report maintenance market sensor listing agent recurring bills monitoring)
 
+# Fire all addAdmin calls in parallel — each targets a different canister so
+# there is no shared state and no ordering requirement between them.
 for canister in "${ADMIN_CANISTERS[@]}"; do
   echo "  $canister: adding deployer as admin..."
   dfx canister call "$canister" addAdmin "(principal \"$DEPLOYER\")" --network "$NETWORK" \
-    2>/dev/null || echo "  ⚠️  addAdmin failed for $canister (may already have an admin)"
+    2>/dev/null &
 done
+wait   # wait for all addAdmin calls before proceeding to payment (which depends on none of them)
 
 # payment uses initAdmins (one-time bootstrap) instead of addAdmin.
 # Without this, grantSubscription returns NotAuthorized and all
@@ -270,52 +292,48 @@ SENSOR_ID=$(dfx canister id sensor --network "$NETWORK" 2>/dev/null || echo "")
 REPORT_ID=$(dfx canister id report --network "$NETWORK" 2>/dev/null || echo "")
 
 # ── Canister ID wiring (target canister ID strings for cross-calls) ────────────
-
-if [ -n "$JOB_ID" ] && [ -n "$PAYMENT_ID" ]; then
-  echo "  Wiring payment -> job (tier cap enforcement)..."
-  dfx canister call job setPaymentCanisterId "(\"$PAYMENT_ID\")" --network "$NETWORK"
-fi
-
-if [ -n "$PROPERTY_ID" ] && [ -n "$PAYMENT_ID" ]; then
-  echo "  Wiring payment -> property (live tier enforcement)..."
-  dfx canister call property setPaymentCanisterId "(principal \"$PAYMENT_ID\")" --network "$NETWORK"
-fi
-
-if [ -n "$PHOTO_ID" ] && [ -n "$PAYMENT_ID" ]; then
-  echo "  Wiring payment -> photo (live tier enforcement)..."
-  dfx canister call photo setPaymentCanisterId "(principal \"$PAYMENT_ID\")" --network "$NETWORK"
-fi
-
-if [ -n "$QUOTE_ID" ] && [ -n "$PAYMENT_ID" ]; then
-  echo "  Wiring payment -> quote (live tier enforcement)..."
-  dfx canister call quote setPaymentCanisterId "(principal \"$PAYMENT_ID\")" --network "$NETWORK"
-fi
+# Each call writes to a different canister's stable variable — fire in parallel.
 
 BILLS_ID=$(dfx canister id bills --network "$NETWORK" 2>/dev/null || echo "")
-if [ -n "$BILLS_ID" ] && [ -n "$PAYMENT_ID" ]; then
-  echo "  Wiring payment -> bills (Free tier monthly upload limit)..."
-  dfx canister call bills setPaymentCanisterId "(\"$PAYMENT_ID\")" --network "$NETWORK"
-fi
 
-if [ -n "$JOB_ID" ] && [ -n "$CONTRACTOR_ID" ]; then
+if [ -n "$JOB_ID" ]      && [ -n "$PAYMENT_ID" ];    then
+  echo "  Wiring payment -> job..."
+  dfx canister call job      setPaymentCanisterId    "(\"$PAYMENT_ID\")"          --network "$NETWORK" &
+fi
+if [ -n "$PROPERTY_ID" ] && [ -n "$PAYMENT_ID" ];    then
+  echo "  Wiring payment -> property..."
+  dfx canister call property setPaymentCanisterId    "(principal \"$PAYMENT_ID\")" --network "$NETWORK" &
+fi
+if [ -n "$PHOTO_ID" ]    && [ -n "$PAYMENT_ID" ];    then
+  echo "  Wiring payment -> photo..."
+  dfx canister call photo    setPaymentCanisterId    "(principal \"$PAYMENT_ID\")" --network "$NETWORK" &
+fi
+if [ -n "$QUOTE_ID" ]    && [ -n "$PAYMENT_ID" ];    then
+  echo "  Wiring payment -> quote..."
+  dfx canister call quote    setPaymentCanisterId    "(principal \"$PAYMENT_ID\")" --network "$NETWORK" &
+fi
+if [ -n "$BILLS_ID" ]    && [ -n "$PAYMENT_ID" ];    then
+  echo "  Wiring payment -> bills..."
+  dfx canister call bills    setPaymentCanisterId    "(\"$PAYMENT_ID\")"          --network "$NETWORK" &
+fi
+if [ -n "$JOB_ID" ]      && [ -n "$CONTRACTOR_ID" ]; then
   echo "  Wiring contractor -> job..."
-  dfx canister call job setContractorCanisterId "(\"$CONTRACTOR_ID\")" --network "$NETWORK"
+  dfx canister call job      setContractorCanisterId "(\"$CONTRACTOR_ID\")"       --network "$NETWORK" &
 fi
-
-if [ -n "$JOB_ID" ] && [ -n "$PROPERTY_ID" ]; then
+if [ -n "$JOB_ID" ]      && [ -n "$PROPERTY_ID" ];   then
   echo "  Wiring property -> job..."
-  dfx canister call job setPropertyCanisterId "(\"$PROPERTY_ID\")" --network "$NETWORK"
+  dfx canister call job      setPropertyCanisterId   "(\"$PROPERTY_ID\")"         --network "$NETWORK" &
+fi
+if [ -n "$PHOTO_ID" ]    && [ -n "$PROPERTY_ID" ];   then
+  echo "  Wiring property -> photo..."
+  dfx canister call photo    setPropertyCanisterId   "(principal \"$PROPERTY_ID\")" --network "$NETWORK" &
+fi
+if [ -n "$QUOTE_ID" ]    && [ -n "$PROPERTY_ID" ];   then
+  echo "  Wiring property -> quote..."
+  dfx canister call quote    setPropertyCanisterId   "(principal \"$PROPERTY_ID\")" --network "$NETWORK" &
 fi
 
-if [ -n "$PHOTO_ID" ] && [ -n "$PROPERTY_ID" ]; then
-  echo "  Wiring property -> photo (manager tier bypass)..."
-  dfx canister call photo setPropertyCanisterId "(principal \"$PROPERTY_ID\")" --network "$NETWORK"
-fi
-
-if [ -n "$QUOTE_ID" ] && [ -n "$PROPERTY_ID" ]; then
-  echo "  Wiring property -> quote (manager tier bypass)..."
-  dfx canister call quote setPropertyCanisterId "(principal \"$PROPERTY_ID\")" --network "$NETWORK"
-fi
+wait   # wait for all wiring calls before reading IDs in the trusted-canister section
 
 # ── Trusted canister wiring (derived from call topology) ──────────────────────
 # These mirror the actual inter-canister call graph so each canister auto-trusts
@@ -326,53 +344,58 @@ echo "============================================"
 echo "  Wiring Trusted Canister Lists"
 echo "============================================"
 
+# All addTrustedCanister calls target different canisters or append to independent
+# lists — fire them in parallel then wait before moving on.
+
 # payment trusts job/property/photo/quote (all call getTierForPrincipal)
-if [ -n "$JOB_ID" ] && [ -n "$PAYMENT_ID" ]; then
-  echo "  payment: trusting job canister ($JOB_ID)..."
-  dfx canister call payment addTrustedCanister "(principal \"$JOB_ID\")" --network "$NETWORK"
+if [ -n "$JOB_ID" ]      && [ -n "$PAYMENT_ID" ]; then
+  echo "  payment: trusting job ($JOB_ID)..."
+  dfx canister call payment addTrustedCanister "(principal \"$JOB_ID\")"      --network "$NETWORK" 2>/dev/null &
 fi
 if [ -n "$PROPERTY_ID" ] && [ -n "$PAYMENT_ID" ]; then
-  echo "  payment: trusting property canister ($PROPERTY_ID)..."
-  dfx canister call payment addTrustedCanister "(principal \"$PROPERTY_ID\")" --network "$NETWORK"
+  echo "  payment: trusting property ($PROPERTY_ID)..."
+  dfx canister call payment addTrustedCanister "(principal \"$PROPERTY_ID\")" --network "$NETWORK" 2>/dev/null &
 fi
-if [ -n "$PHOTO_ID" ] && [ -n "$PAYMENT_ID" ]; then
-  echo "  payment: trusting photo canister ($PHOTO_ID)..."
-  dfx canister call payment addTrustedCanister "(principal \"$PHOTO_ID\")" --network "$NETWORK"
+if [ -n "$PHOTO_ID" ]    && [ -n "$PAYMENT_ID" ]; then
+  echo "  payment: trusting photo ($PHOTO_ID)..."
+  dfx canister call payment addTrustedCanister "(principal \"$PHOTO_ID\")"    --network "$NETWORK" 2>/dev/null &
 fi
-if [ -n "$QUOTE_ID" ] && [ -n "$PAYMENT_ID" ]; then
-  echo "  payment: trusting quote canister ($QUOTE_ID)..."
-  dfx canister call payment addTrustedCanister "(principal \"$QUOTE_ID\")" --network "$NETWORK"
+if [ -n "$QUOTE_ID" ]    && [ -n "$PAYMENT_ID" ]; then
+  echo "  payment: trusting quote ($QUOTE_ID)..."
+  dfx canister call payment addTrustedCanister "(principal \"$QUOTE_ID\")"    --network "$NETWORK" 2>/dev/null &
 fi
 
 # contractor trusts job (job calls recordJobVerified)
 if [ -n "$JOB_ID" ] && [ -n "$CONTRACTOR_ID" ]; then
-  echo "  contractor: trusting job canister ($JOB_ID)..."
-  dfx canister call contractor addTrustedCanister "(principal \"$JOB_ID\")" --network "$NETWORK"
+  echo "  contractor: trusting job ($JOB_ID)..."
+  dfx canister call contractor addTrustedCanister "(principal \"$JOB_ID\")"   --network "$NETWORK" 2>/dev/null &
 fi
 
-# property trusts job/photo/quote (all call getPropertyOwner) and report (report calls getVerificationLevel)
-if [ -n "$JOB_ID" ] && [ -n "$PROPERTY_ID" ]; then
-  echo "  property: trusting job canister ($JOB_ID)..."
-  dfx canister call property addTrustedCanister "(principal \"$JOB_ID\")" --network "$NETWORK"
+# property trusts job/photo/quote/report
+if [ -n "$JOB_ID" ]    && [ -n "$PROPERTY_ID" ]; then
+  echo "  property: trusting job ($JOB_ID)..."
+  dfx canister call property addTrustedCanister "(principal \"$JOB_ID\")"     --network "$NETWORK" 2>/dev/null &
 fi
-if [ -n "$PHOTO_ID" ] && [ -n "$PROPERTY_ID" ]; then
-  echo "  property: trusting photo canister ($PHOTO_ID)..."
-  dfx canister call property addTrustedCanister "(principal \"$PHOTO_ID\")" --network "$NETWORK"
+if [ -n "$PHOTO_ID" ]  && [ -n "$PROPERTY_ID" ]; then
+  echo "  property: trusting photo ($PHOTO_ID)..."
+  dfx canister call property addTrustedCanister "(principal \"$PHOTO_ID\")"   --network "$NETWORK" 2>/dev/null &
 fi
-if [ -n "$QUOTE_ID" ] && [ -n "$PROPERTY_ID" ]; then
-  echo "  property: trusting quote canister ($QUOTE_ID)..."
-  dfx canister call property addTrustedCanister "(principal \"$QUOTE_ID\")" --network "$NETWORK"
+if [ -n "$QUOTE_ID" ]  && [ -n "$PROPERTY_ID" ]; then
+  echo "  property: trusting quote ($QUOTE_ID)..."
+  dfx canister call property addTrustedCanister "(principal \"$QUOTE_ID\")"   --network "$NETWORK" 2>/dev/null &
 fi
 if [ -n "$REPORT_ID" ] && [ -n "$PROPERTY_ID" ]; then
-  echo "  property: trusting report canister ($REPORT_ID)..."
-  dfx canister call property addTrustedCanister "(principal \"$REPORT_ID\")" --network "$NETWORK"
+  echo "  property: trusting report ($REPORT_ID)..."
+  dfx canister call property addTrustedCanister "(principal \"$REPORT_ID\")"  --network "$NETWORK" 2>/dev/null &
 fi
 
 # job trusts sensor (sensor calls createSensorJob)
 if [ -n "$SENSOR_ID" ] && [ -n "$JOB_ID" ]; then
-  echo "  job: trusting sensor canister ($SENSOR_ID)..."
-  dfx canister call job addTrustedCanister "(principal \"$SENSOR_ID\")" --network "$NETWORK"
+  echo "  job: trusting sensor ($SENSOR_ID)..."
+  dfx canister call job addTrustedCanister "(principal \"$SENSOR_ID\")"       --network "$NETWORK" 2>/dev/null &
 fi
+
+wait   # wait for all trust wiring before moving on
 
 # ── AI Proxy canister — wire API keys from environment ────────────────────────
 

--- a/scripts/test-backend.sh
+++ b/scripts/test-backend.sh
@@ -1,8 +1,13 @@
 #!/usr/bin/env bash
 # HomeGentic — Backend Test Coordinator (12.6.3)
 #
-# Runs each canister's test.sh in sequence, tracks pass/fail per canister,
-# prints a coverage summary table, and exits non-zero if any canister failed.
+# Runs each canister's test.sh in parallel, collects output to per-canister log
+# files, prints them sequentially once all suites finish, and exits non-zero if
+# any canister failed.
+#
+# Parallelism is safe because every canister test script operates on its own
+# canister and registers its own test identities — there is no shared mutable
+# state between suites.
 #
 # Usage:
 #   bash scripts/test-backend.sh            # Run all canisters
@@ -47,46 +52,72 @@ fi
 declare -a PASSED=()
 declare -a FAILED=()
 declare -a SKIPPED=()
+declare -a ACTIVE=()   # canisters actually launched
+declare -a PIDS=()     # matching background PIDs
+
+LOG_DIR=$(mktemp -d /tmp/test-backend-XXXXXX)
 
 echo "============================================"
 echo "  HomeGentic — Backend Test Suite"
 echo "============================================"
-echo "  Running ${#CANISTERS[@]} canister(s)"
+echo "  Launching ${#CANISTERS[@]} canister suite(s) in parallel"
 echo ""
 
-# ── Run each canister test ────────────────────────────────────────────────────
+# ── Launch all suites in parallel ────────────────────────────────────────────
 for CANISTER in "${CANISTERS[@]}"; do
   TEST_SCRIPT="$REPO_ROOT/backend/$CANISTER/test.sh"
 
   if [ ! -f "$TEST_SCRIPT" ]; then
-    echo "── [$CANISTER] SKIPPED — no test.sh found ───────────────────────────────"
+    echo "  ⬜ $CANISTER — no test.sh, skipping"
     SKIPPED+=("$CANISTER")
     continue
   fi
 
-  # Check canister is deployed
   CANISTER_ID=$(dfx canister id "$CANISTER" 2>/dev/null || echo "")
   if [ -z "$CANISTER_ID" ]; then
-    echo "── [$CANISTER] SKIPPED — canister not deployed ──────────────────────────"
+    echo "  ⬜ $CANISTER — not deployed, skipping"
     SKIPPED+=("$CANISTER")
     continue
   fi
 
-  echo "── [$CANISTER] Running tests ────────────────────────────────────────────"
-  START_S=$SECONDS
+  # Record wall-clock start time and launch
+  date +%s > "$LOG_DIR/$CANISTER.start"
+  bash "$TEST_SCRIPT" > "$LOG_DIR/$CANISTER.log" 2>&1 &
+  PIDS+=($!)
+  ACTIVE+=("$CANISTER")
+  echo "  ▶ $CANISTER launched (pid $!)"
+done
 
-  # Run in subshell to isolate set -e failures; capture exit code
-  if bash "$TEST_SCRIPT" 2>&1; then
-    ELAPSED=$(( SECONDS - START_S ))
+echo ""
+echo "  Waiting for ${#ACTIVE[@]} suite(s)..."
+echo ""
+
+# ── Collect results in launch order ──────────────────────────────────────────
+for i in "${!ACTIVE[@]}"; do
+  CANISTER="${ACTIVE[$i]}"
+  PID="${PIDS[$i]}"
+  START_S=$(cat "$LOG_DIR/$CANISTER.start")
+
+  echo "── [$CANISTER] ──────────────────────────────────────────────────────────"
+
+  # wait returns the exit code of the background process
+  if wait "$PID"; then
+    END_S=$(date +%s)
+    ELAPSED=$(( END_S - START_S ))
+    cat "$LOG_DIR/$CANISTER.log"
     echo "   ✅  $CANISTER passed (${ELAPSED}s)"
     PASSED+=("$CANISTER")
   else
-    ELAPSED=$(( SECONDS - START_S ))
+    END_S=$(date +%s)
+    ELAPSED=$(( END_S - START_S ))
+    cat "$LOG_DIR/$CANISTER.log"
     echo "   ❌  $CANISTER FAILED (${ELAPSED}s)"
     FAILED+=("$CANISTER")
   fi
   echo ""
 done
+
+rm -rf "$LOG_DIR"
 
 # ── Summary table ─────────────────────────────────────────────────────────────
 TOTAL=$(( ${#PASSED[@]} + ${#FAILED[@]} + ${#SKIPPED[@]} ))


### PR DESCRIPTION
deploy.sh
- Phase 1: dfx canister create --all writes all IDs atomically (no race)
- Phase 2: dfx build + dfx canister install run in parallel per canister; install never touches canister_ids.json so there is no write race
- addAdmin bootstrap calls fire in parallel (independent targets)
- setPaymentCanisterId / setPropertyCanisterId / etc. fire in parallel
- addTrustedCanister calls fire in parallel; both groups guarded by wait

test-backend.sh
- All per-canister test.sh scripts launch in background simultaneously
- Output captured to per-canister log files; printed sequentially after all suites finish so CI output remains readable
- Per-suite elapsed time computed from date +%s (works across subshells)
- Summary table and exit code unchanged

Expected CI savings: ~3-4 min on deploy, ~4-6 min on test execution

## Summary
<!-- What does this PR do? -->

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [ ] Backend tests pass (`make test`)
- [ ] Frontend builds (`cd frontend && npm run build`)
- [ ] Tested locally with dfx

## Checklist
- [ ] Code follows project conventions
- [ ] Self-review completed
- [ ] No sensitive data committed
