### PR TITLE
security(property): replace sequential Nat ID with cryptographically …

### DIFF
--- a/backend/job/main.mo
+++ b/backend/job/main.mo
@@ -243,16 +243,11 @@ persistent actor Job {
       };
       let effectivePrincipal : Principal = if (propCanisterId != "") {
         let propActor = actor(propCanisterId) : actor {
-          getPropertyOwner : (Nat) -> async ?Principal;
+          getPropertyOwner : (Text) -> async ?Principal;
         };
-        switch (Nat.fromText(propertyId)) {
-          case (?natId) {
-            switch (await propActor.getPropertyOwner(natId)) {
-              case (?owner) { if (owner != msg.caller) { owner } else { msg.caller } };
-              case null     { msg.caller };
-            }
-          };
-          case null { msg.caller };
+        switch (await propActor.getPropertyOwner(propertyId)) {
+          case (?owner) { if (owner != msg.caller) { owner } else { msg.caller } };
+          case null     { msg.caller };
         }
       } else { msg.caller };
       let tier = await payActor.getTierForPrincipal(effectivePrincipal);
@@ -512,19 +507,14 @@ persistent actor Job {
     // 14.2.1 — verify that the sensor device's stored homeowner actually owns
     // the property before creating a job on their behalf.
     if (Text.size(propCanisterId) > 0) {
-      switch (Nat.fromText(propertyId)) {
-        case null { return #err("Invalid propertyId format") };
-        case (?natId) {
-          let propActor = actor(propCanisterId) : actor {
-            getPropertyOwner : (Nat) -> async ?Principal;
-          };
-          switch (await propActor.getPropertyOwner(natId)) {
-            case null        { return #err("Property not found") };
-            case (?owner) {
-              if (owner != homeowner)
-                return #err("Sensor homeowner does not match property owner");
-            };
-          };
+      let propActor = actor(propCanisterId) : actor {
+        getPropertyOwner : (Text) -> async ?Principal;
+      };
+      switch (await propActor.getPropertyOwner(propertyId)) {
+        case null     { return #err("Property not found") };
+        case (?owner) {
+          if (owner != homeowner)
+            return #err("Sensor homeowner does not match property owner");
         };
       };
     };
@@ -909,22 +899,12 @@ persistent actor Job {
     // Look up the property owner via cross-canister call (if property canister is wired).
     // Falls back to anonymous when not wired — useful in tests without a full deploy.
     let homeowner : Principal = if (Text.size(propCanisterId) > 0) {
-      switch (Nat.fromText(propertyId)) {
-        case null {
-          // propertyId is not a numeric string (e.g. "PROP_1" in tests) — fall back
-          // to the anonymous sentinel, same as the unset-propCanisterId path.
-          // In production, all propertyIds are Nat strings written by the property canister.
-          Principal.fromText("2vxsx-fae")
-        };
-        case (?natId)  {
-          let propActor = actor(propCanisterId) : actor {
-            getPropertyOwner : (Nat) -> async ?Principal;
-          };
-          switch (await propActor.getPropertyOwner(natId)) {
-            case null        { return #err(#InvalidInput("Property not found")) };
-            case (?owner)    { owner };
-          };
-        };
+      let propActor = actor(propCanisterId) : actor {
+        getPropertyOwner : (Text) -> async ?Principal;
+      };
+      switch (await propActor.getPropertyOwner(propertyId)) {
+        case null     { return #err(#InvalidInput("Property not found")) };
+        case (?owner) { owner };
       };
     } else {
       // Property canister not wired — for testability only.

--- a/backend/job/test.sh
+++ b/backend/job/test.sh
@@ -443,22 +443,40 @@ echo "$TRUSTED_AFTER" | grep -q "$SENSOR_TEST_PRINCIPAL" \
 
 HOMEOWNER_PRINCIPAL=$(dfx identity get-principal)
 
+# Register a fresh property so createJobProposal can resolve the owner via the property canister.
+# The deployer (homeowner) owns this property; contractor-test will submit proposals against it.
+echo ""
+echo "── [38-setup] Register property for proposal tests ─────────────────────"
+dfx canister call payment grantSubscription "(principal \"$HOMEOWNER_PRINCIPAL\", variant { Premium })" > /dev/null 2>&1 || true
+PROPOSAL_PROP_OUT=$(dfx canister call property registerProperty '(record {
+  address      = "77 Proposal Test Lane";
+  city         = "Houston";
+  state        = "TX";
+  zipCode      = "77001";
+  propertyType = variant { SingleFamily };
+  yearBuilt    = 2000;
+  squareFeet   = 1800;
+  tier         = variant { Premium };
+})')
+PROPOSAL_PROP_ID=$(echo "$PROPOSAL_PROP_OUT" | grep -oP 'id = "\K[^"]+' | head -1 || true)
+echo "  → Proposal property ID: $PROPOSAL_PROP_ID"
+
 echo ""
 echo "── [38] createJobProposal — contractor submits a proposal for homeowner approval ──"
 # Called by contractor identity; propertyId must belong to homeowner (looked up by property canister)
-PROPOSAL_OUT=$(dfx canister call $CANISTER createJobProposal '(
-  "PROP_1",
-  "HVAC Tune-Up",
+PROPOSAL_OUT=$(dfx canister call $CANISTER createJobProposal "(
+  \"$PROPOSAL_PROP_ID\",
+  \"HVAC Tune-Up\",
   variant { HVAC },
-  "Full HVAC tune-up and filter replacement at the property.",
-  opt "Cool Air Services",
+  \"Full HVAC tune-up and filter replacement at the property.\",
+  opt \"Cool Air Services\",
   45000,
   1718409600000000000,
   null,
   null
-)' --identity contractor-test)
+)" --identity contractor-test)
 echo "$PROPOSAL_OUT"
-PROPOSAL_ID=$(echo "$PROPOSAL_OUT" | grep -oP '"JOB_[0-9]+"' | head -1 | tr -d '"')
+PROPOSAL_ID=$(echo "$PROPOSAL_OUT" | grep -oP '"JOB_[0-9]+"' | head -1 | tr -d '"' || true)
 if echo "$PROPOSAL_OUT" | grep -q "PendingHomeownerApproval"; then
   echo "  ✓ Proposal created with PendingHomeownerApproval status"
 else
@@ -522,19 +540,19 @@ fi
 
 echo ""
 echo "── [43] createJobProposal for second proposal — to be rejected ──────────"
-REJECT_PROPOSAL_OUT=$(dfx canister call $CANISTER createJobProposal '(
-  "PROP_1",
-  "Roof Inspection",
+REJECT_PROPOSAL_OUT=$(dfx canister call $CANISTER createJobProposal "(
+  \"$PROPOSAL_PROP_ID\",
+  \"Roof Inspection\",
   variant { Roofing },
-  "Annual roof inspection.",
-  opt "Top Roof Co",
+  \"Annual roof inspection.\",
+  opt \"Top Roof Co\",
   25000,
   1718409600000000000,
   null,
   null
-)' --identity contractor-test)
+)" --identity contractor-test)
 echo "$REJECT_PROPOSAL_OUT"
-REJECT_PROPOSAL_ID=$(echo "$REJECT_PROPOSAL_OUT" | grep -oP '"JOB_[0-9]+"' | head -1 | tr -d '"')
+REJECT_PROPOSAL_ID=$(echo "$REJECT_PROPOSAL_OUT" | grep -oP '"JOB_[0-9]+"' | head -1 | tr -d '"' || true)
 echo "  → Reject-target proposal ID: $REJECT_PROPOSAL_ID"
 
 echo ""
@@ -572,17 +590,17 @@ dfx canister call $CANISTER rejectJobProposal "(\"$REJECT_PROPOSAL_ID\")" --iden
 echo ""
 echo "── [48] createJobProposal — homeowner cannot propose their own job ──────"
 # Caller must NOT be the property owner — proposals come from contractors
-dfx canister call $CANISTER createJobProposal '(
-  "PROP_1",
-  "Self-Proposal Test",
+dfx canister call $CANISTER createJobProposal "(
+  \"$PROPOSAL_PROP_ID\",
+  \"Self-Proposal Test\",
   variant { Painting },
-  "Homeowner trying to create a proposal for their own property.",
-  opt "Homeowner Inc",
+  \"Homeowner trying to create a proposal for their own property.\",
+  opt \"Homeowner Inc\",
   10000,
   1718409600000000000,
   null,
   null
-)' && echo "  ↳ ❌ Homeowner should not be able to propose on own property" \
+)" && echo "  ↳ ❌ Homeowner should not be able to propose on own property" \
   || echo "  ✓ Homeowner correctly blocked from self-proposing"
 
 echo ""
@@ -638,14 +656,14 @@ else
     tier         = variant { Pro };
   })')
   echo "$MGR_PROP_OUT"
-  MGR_PROP_ID=$(echo "$MGR_PROP_OUT" | grep -oP 'id = \K[0-9]+' | head -1)
+  MGR_PROP_ID=$(echo "$MGR_PROP_OUT" | grep -oP 'id = "\K[^"]+' | head -1 || true)
   echo "  → Property ID: $MGR_PROP_ID"
 
   # Invite manager via bearer token
   echo ""
   echo "── [MGR-2] Owner invites manager (Manager role) ─────────────────────────"
   INVITE_OUT=$(dfx canister call property inviteManager \
-    "($MGR_PROP_ID, variant { Manager }, \"Test Manager\")")
+    "(\"$MGR_PROP_ID\", variant { Manager }, \"Test Manager\")")
   echo "$INVITE_OUT"
   INVITE_TOKEN=$(echo "$INVITE_OUT" | grep -oP 'token = "\K[^"]+' | head -1)
   echo "  → Token: $INVITE_TOKEN"

--- a/backend/job/test.sh
+++ b/backend/job/test.sh
@@ -638,9 +638,11 @@ else
   MANAGER_PRINCIPAL=$(dfx identity get-principal --identity manager-test)
   echo "  Manager principal (Free tier): $MANAGER_PRINCIPAL"
 
-  # Ensure owner (default identity) has a Pro subscription
+  # Ensure owner (default identity) has a Premium subscription so that the
+  # MGR property registration succeeds even when parallel canister tests have
+  # already consumed the Pro limit (5 properties) for the deployer.
   MY_PRINCIPAL=$(dfx identity get-principal)
-  dfx canister call payment grantSubscription "(principal \"$MY_PRINCIPAL\", variant { Pro })"
+  dfx canister call payment grantSubscription "(principal \"$MY_PRINCIPAL\", variant { Premium })"
 
   # Register a fresh property as the owner
   echo ""
@@ -665,7 +667,7 @@ else
   INVITE_OUT=$(dfx canister call property inviteManager \
     "(\"$MGR_PROP_ID\", variant { Manager }, \"Test Manager\")")
   echo "$INVITE_OUT"
-  INVITE_TOKEN=$(echo "$INVITE_OUT" | grep -oP 'token = "\K[^"]+' | head -1)
+  INVITE_TOKEN=$(echo "$INVITE_OUT" | grep -oP 'token = "\K[^"]+' | head -1 || true)
   echo "  → Token: $INVITE_TOKEN"
 
   # Manager claims the role

--- a/backend/photo/main.mo
+++ b/backend/photo/main.mo
@@ -257,16 +257,11 @@ persistent actor Photo {
     // so managers don't need their own paid subscription.
     let effectivePrincipal : Principal = if (propCanisterId != "") {
       let propActor = actor(propCanisterId) : actor {
-        getPropertyOwner : (Nat) -> async ?Principal;
+        getPropertyOwner : (Text) -> async ?Principal;
       };
-      switch (Nat.fromText(propertyId)) {
-        case (?natId) {
-          switch (await propActor.getPropertyOwner(natId)) {
-            case (?owner) { if (owner != msg.caller) { owner } else { msg.caller } };
-            case null     { msg.caller };
-          }
-        };
-        case null { msg.caller };
+      switch (await propActor.getPropertyOwner(propertyId)) {
+        case (?owner) { if (owner != msg.caller) { owner } else { msg.caller } };
+        case null     { msg.caller };
       }
     } else { msg.caller };
     let callerTierRaw : SubscriptionTier = if (payCanisterId != "") {

--- a/backend/photo/test.sh
+++ b/backend/photo/test.sh
@@ -143,7 +143,7 @@ else
   echo "── [MGR-2] Owner invites manager; manager claims role ───────────────────"
   INVITE_OUT=$(dfx canister call property inviteManager \
     "(\"$MGR_PROP_ID\", variant { Manager }, \"Photo Manager\")")
-  INVITE_TOKEN=$(echo "$INVITE_OUT" | grep -oP 'token = "\K[^"]+' | head -1)
+  INVITE_TOKEN=$(echo "$INVITE_OUT" | grep -oP 'token = "\K[^"]+' | head -1 || true)
   dfx canister call property claimManagerRole \
     "(\"$INVITE_TOKEN\")" --identity manager-test
   echo "  ↳ Manager role granted ✓"

--- a/backend/photo/test.sh
+++ b/backend/photo/test.sh
@@ -135,14 +135,14 @@ else
     tier         = variant { Premium };
   })')
   echo "$MGR_PROP_OUT"
-  MGR_PROP_ID=$(echo "$MGR_PROP_OUT" | grep -oP 'id = \K[0-9]+' | head -1)
+  MGR_PROP_ID=$(echo "$MGR_PROP_OUT" | grep -oP 'id = "\K[^"]+' | head -1 || true)
   echo "  → Property ID: $MGR_PROP_ID"
 
   # Invite and claim manager role
   echo ""
   echo "── [MGR-2] Owner invites manager; manager claims role ───────────────────"
   INVITE_OUT=$(dfx canister call property inviteManager \
-    "($MGR_PROP_ID, variant { Manager }, \"Photo Manager\")")
+    "(\"$MGR_PROP_ID\", variant { Manager }, \"Photo Manager\")")
   INVITE_TOKEN=$(echo "$INVITE_OUT" | grep -oP 'token = "\K[^"]+' | head -1)
   dfx canister call property claimManagerRole \
     "(\"$INVITE_TOKEN\")" --identity manager-test

--- a/backend/property/main.mo
+++ b/backend/property/main.mo
@@ -29,12 +29,15 @@
  */
 
 import Array     "mo:core/Array";
+import Blob      "mo:core/Blob";
 import Map       "mo:core/Map";
 import Int       "mo:core/Int";
 import Iter      "mo:core/Iter";
 import Nat       "mo:core/Nat";
+import Nat8      "mo:core/Nat8";
 import Option    "mo:core/Option";
 import Principal "mo:core/Principal";
+import Random    "mo:core/Random";
 import Result    "mo:core/Result";
 import Text      "mo:core/Text";
 import Time      "mo:core/Time";
@@ -85,7 +88,7 @@ persistent actor Property {
   /// until the owner submits verification documents.  Making them optional
   /// keeps canister upgrades backward-compatible.
   public type Property = {
-    id                  : Nat;
+    id                  : Text;
     owner               : Principal;
     address             : Text;
     city                : Text;
@@ -129,7 +132,7 @@ persistent actor Property {
   };
 
   public type BulkImportResult = {
-    succeeded : [Nat];            // property IDs created
+    succeeded : [Text];           // property IDs created
     failed    : [BulkImportError];
   };
 
@@ -167,7 +170,7 @@ persistent actor Property {
 
   /// Pending manager invite — claimed by the invitee via bearer token.
   public type ManagerInvite = {
-    propertyId  : Nat;
+    propertyId  : Text;
     token       : Text;
     role        : ManagerRole;
     displayName : Text;       // pre-filled name the owner sets
@@ -191,7 +194,7 @@ persistent actor Property {
 
   /// Immutable record of a single ownership transfer event.
   public type TransferRecord = {
-    propertyId : Nat;
+    propertyId : Text;
     from       : Principal;
     to         : Principal;
     timestamp  : Time.Time;
@@ -206,7 +209,7 @@ persistent actor Property {
   /// Any principal that presents the token before expiresAt can claim
   /// the property — no prior knowledge of the buyer's principal needed.
   public type PendingTransfer = {
-    propertyId  : Nat;
+    propertyId  : Text;
     from        : Principal;
     token       : Text;        // bearer token embedded in the claim URL
     initiatedAt : Time.Time;
@@ -288,7 +291,6 @@ persistent actor Property {
   /// reading the local tierGrants map.
   private var payCanisterId            : Text        = "";
 
-  private var nextId             : Nat                            = 1;
   private var transferCounter        : Nat                            = 0;
 
   // Room state
@@ -297,37 +299,57 @@ persistent actor Property {
 
   // ─── Stable State ────────────────────────────────────────────────────────
 
-  private let properties      = Map.empty<Nat, Property>();
-  /// Address key → first-registered property ID.
-  private let addressIdx      = Map.empty<Text, Nat>();
+  private let properties      = Map.empty<Text, Property>();
+  /// Address key → property ID.
+  private let addressIdx      = Map.empty<Text, Text>();
   private let tierGrants      = Map.empty<Text, SubscriptionTier>();
+  /// Transfer history keyed by transferCounter (Nat).
   private let transfers        = Map.empty<Nat, TransferRecord>();
-  private let pendingTransfers = Map.empty<Nat, PendingTransfer>();
-  /// token (Text) → propertyId (Nat) — secondary index for O(1) claim lookup.
-  private let tokenIndex       = Map.empty<Text, Nat>();
+  private let pendingTransfers = Map.empty<Text, PendingTransfer>();
+  /// token (Text) → propertyId (Text) — secondary index for O(1) claim lookup.
+  private let tokenIndex       = Map.empty<Text, Text>();
   private let rooms            = Map.empty<Text, RoomRecord>();
 
   // ─── Manager delegation state ────────────────────────────────────────────
   /// propertyId → [PropertyManager]
-  private let managersMap      = Map.empty<Nat,  [PropertyManager]>();
+  private let managersMap      = Map.empty<Text, [PropertyManager]>();
   /// token → ManagerInvite (pending invites)
   private let managerInvites   = Map.empty<Text, ManagerInvite>();
   /// token → propertyId (fast invite lookup)
-  private let managerTokenIdx  = Map.empty<Text, Nat>();
+  private let managerTokenIdx  = Map.empty<Text, Text>();
   /// propertyId → [OwnerNotification]
-  private let ownerNotifs      = Map.empty<Nat,  [OwnerNotification]>();
+  private let ownerNotifs      = Map.empty<Text, [OwnerNotification]>();
   private var notifCounter     : Nat = 0;
 
   // ─── Private Helpers ──────────────────────────────────────────────────────
 
+  /// Convert a Blob to a lowercase hex string.
+  private func blobToHex(b : Blob) : Text {
+    let hex   = ['0','1','2','3','4','5','6','7','8','9','a','b','c','d','e','f'];
+    let bytes = Blob.toArray(b);
+    var result = "";
+    for (byte in bytes.vals()) {
+      let n = Nat8.toNat(byte);
+      result := result # Text.fromChar(hex[n / 16]) # Text.fromChar(hex[n % 16]);
+    };
+    result
+  };
+
+  /// Generate a cryptographically random property ID.
+  /// Uses IC certified randomness — IDs are unguessable and non-sequential.
+  private func nextPropertyId() : async Text {
+    let randBytes = await Random.blob();
+    "PROP_" # blobToHex(randBytes)
+  };
+
   /// Returns true if `caller` is the property owner OR an authorised manager.
   /// When `requireWrite` is true, a #Viewer manager is not sufficient.
-  private func checkAuthorized(propertyId: Nat, caller: Principal, requireWrite: Bool) : Bool {
-    switch (Map.get(properties, Nat.compare, propertyId)) {
+  private func checkAuthorized(propertyId: Text, caller: Principal, requireWrite: Bool) : Bool {
+    switch (Map.get(properties, Text.compare, propertyId)) {
       case null false;
       case (?prop) {
         if (prop.owner == caller) return true;
-        let mgrs = switch (Map.get(managersMap, Nat.compare, propertyId)) {
+        let mgrs = switch (Map.get(managersMap, Text.compare, propertyId)) {
           case null    [];
           case (?list) list;
         };
@@ -343,7 +365,7 @@ persistent actor Property {
   };
 
   /// Append a notification to the owner's queue for the given property.
-  private func pushNotification(propertyId: Nat, managerP: Principal, managerN: Text, desc: Text) {
+  private func pushNotification(propertyId: Text, managerP: Principal, managerN: Text, desc: Text) {
     notifCounter += 1;
     let notif : OwnerNotification = {
       id               = notifCounter;
@@ -353,11 +375,11 @@ persistent actor Property {
       timestamp        = Time.now();
       seen             = false;
     };
-    let existing = switch (Map.get(ownerNotifs, Nat.compare, propertyId)) {
+    let existing = switch (Map.get(ownerNotifs, Text.compare, propertyId)) {
       case null    [];
       case (?list) list;
     };
-    Map.add(ownerNotifs, Nat.compare, propertyId, Array.concat<OwnerNotification>(existing, [notif]));
+    Map.add(ownerNotifs, Text.compare, propertyId, Array.concat<OwnerNotification>(existing, [notif]));
   };
 
   // ─── Rate Limit (cycle-drain protection) ────────────────────────────────────
@@ -479,7 +501,7 @@ persistent actor Property {
     // ── Duplicate address check ──────────────────────────────────────────────
     switch (Map.get(addressIdx, Text.compare, key)) {
       case (?existingId) {
-        switch (Map.get(properties, Nat.compare, existingId)) {
+        switch (Map.get(properties, Text.compare, existingId)) {
           case (?existing) {
             if (existing.owner == caller) {
               // Same owner re-registering the same address — allow (idempotent).
@@ -543,8 +565,7 @@ persistent actor Property {
     };
 
     let now = Time.now();
-    let id  = nextId;
-    nextId += 1;
+    let id  = await nextPropertyId();
 
     let prop : Property = {
       id;
@@ -566,7 +587,7 @@ persistent actor Property {
       isActive            = true;
     };
 
-    Map.add(properties, Nat.compare, id, prop);
+    Map.add(properties, Text.compare, id, prop);
     Map.add(addressIdx, Text.compare, key, id);
     #ok(prop)
   };
@@ -582,7 +603,7 @@ persistent actor Property {
   /// documentHash: SHA-256 hex digest of the uploaded document (computed
   ///               client-side before upload to off-chain storage).
   public shared(msg) func submitVerification(
-    propertyId   : Nat,
+    propertyId   : Text,
     method       : Text,
     documentHash : Text
   ) : async Result.Result<Property, Error> {
@@ -591,7 +612,7 @@ persistent actor Property {
     if (Text.size(method)       == 0) return #err(#InvalidInput("method required"));
     if (Text.size(documentHash) == 0) return #err(#InvalidInput("documentHash required"));
 
-    switch (Map.get(properties, Nat.compare, propertyId)) {
+    switch (Map.get(properties, Text.compare, propertyId)) {
       case null { #err(#NotFound) };
       case (?existing) {
         if (existing.owner != msg.caller) return #err(#NotAuthorized);
@@ -619,7 +640,7 @@ persistent actor Property {
           updatedAt           = Time.now();
           isActive            = existing.isActive;
         };
-        Map.add(properties, Nat.compare, propertyId, updated);
+        Map.add(properties, Text.compare, propertyId, updated);
         #ok(updated)
       };
     }
@@ -634,13 +655,13 @@ persistent actor Property {
   /// method is optional — supply it to override the method the homeowner
   /// declared, or leave null to keep whatever they submitted.
   public shared(msg) func verifyProperty(
-    id     : Nat,
+    id     : Text,
     level  : VerificationLevel,
     method : ?Text
   ) : async Result.Result<Property, Error> {
     if (not isAdmin(msg.caller)) return #err(#NotAuthorized);
 
-    switch (Map.get(properties, Nat.compare, id)) {
+    switch (Map.get(properties, Text.compare, id)) {
       case null { #err(#NotFound) };
       case (?existing) {
         let now  = Time.now();
@@ -666,7 +687,7 @@ persistent actor Property {
           updatedAt           = now;
           isActive            = existing.isActive;
         };
-        Map.add(properties, Nat.compare, id, updated);
+        Map.add(properties, Text.compare, id, updated);
         #ok(updated)
       };
     }
@@ -694,8 +715,8 @@ persistent actor Property {
     )
   };
 
-  public query func getProperty(id: Nat) : async Result.Result<Property, Error> {
-    switch (Map.get(properties, Nat.compare, id)) {
+  public query func getProperty(id: Text) : async Result.Result<Property, Error> {
+    switch (Map.get(properties, Text.compare, id)) {
       case null  { #err(#NotFound) };
       case (?p)  { #ok(p) };
     }
@@ -707,8 +728,8 @@ persistent actor Property {
   /// Called cross-canister by the Report canister before issuing share links.
   /// Returns Text rather than VerificationLevel to keep the inter-canister
   /// interface simple and stable as new variants are added.
-  public query func getVerificationLevel(id: Nat) : async ?Text {
-    switch (Map.get(properties, Nat.compare, id)) {
+  public query func getVerificationLevel(id: Text) : async ?Text {
+    switch (Map.get(properties, Text.compare, id)) {
       case null  { null };
       case (?p)  {
         ?(switch (p.verificationLevel) {
@@ -725,8 +746,8 @@ persistent actor Property {
   /// Called cross-canister by the Job canister (14.2.1) to verify that
   /// the homeowner stored on a sensor device actually owns the property
   /// before auto-creating a sensor-triggered job.
-  public query func getPropertyOwner(id: Nat) : async ?Principal {
-    switch (Map.get(properties, Nat.compare, id)) {
+  public query func getPropertyOwner(id: Text) : async ?Principal {
+    switch (Map.get(properties, Text.compare, id)) {
       case null  { null };
       case (?p)  { ?p.owner };
     }
@@ -763,11 +784,11 @@ persistent actor Property {
   /// Step 1: seller generates a bearer token for this property.
   /// Overwrites any existing pending transfer (idempotent for re-sharing).
   public shared(msg) func initiateTransfer(
-    propertyId : Nat
+    propertyId : Text
   ) : async Result.Result<PendingTransfer, Error> {
     switch (requireActive(msg.caller)) { case (#err e) return #err e; case _ {} };
 
-    switch (Map.get(properties, Nat.compare, propertyId)) {
+    switch (Map.get(properties, Text.compare, propertyId)) {
       case null { #err(#NotFound) };
       case (?prop) {
         if (prop.owner != msg.caller) return #err(#NotAuthorized);
@@ -780,7 +801,7 @@ persistent actor Property {
         let token : Text = Int.toText(Int.abs(now)) # "-" # Nat.toText(transferCounter);
 
         // Remove previous token from secondary index if one existed
-        switch (Map.get(pendingTransfers, Nat.compare, propertyId)) {
+        switch (Map.get(pendingTransfers, Text.compare, propertyId)) {
           case (?old) { Map.remove(tokenIndex, Text.compare, old.token) };
           case null   {};
         };
@@ -792,7 +813,7 @@ persistent actor Property {
           initiatedAt = now;
           expiresAt   = now + NINETY_DAYS_NS;
         };
-        Map.add(pendingTransfers, Nat.compare, propertyId, pending);
+        Map.add(pendingTransfers, Text.compare, propertyId, pending);
         Map.add(tokenIndex,       Text.compare, token,      propertyId);
         #ok(pending)
       };
@@ -809,14 +830,14 @@ persistent actor Property {
     switch (Map.get(tokenIndex, Text.compare, token)) {
       case null { #err(#NotFound) };
       case (?propertyId) {
-        switch (Map.get(pendingTransfers, Nat.compare, propertyId)) {
+        switch (Map.get(pendingTransfers, Text.compare, propertyId)) {
           case null { #err(#NotFound) };
           case (?pending) {
             if (pending.token != token) return #err(#NotFound);
 
             if (Time.now() > pending.expiresAt) {
               // Expired — clean up and surface a clear error
-              Map.remove(pendingTransfers, Nat.compare, propertyId);
+              Map.remove(pendingTransfers, Text.compare, propertyId);
               Map.remove(tokenIndex,       Text.compare, token);
               return #err(#InvalidInput("Transfer link has expired. Ask the seller to generate a new one."));
             };
@@ -825,7 +846,7 @@ persistent actor Property {
               return #err(#InvalidInput("Cannot claim your own property transfer."));
             };
 
-            switch (Map.get(properties, Nat.compare, propertyId)) {
+            switch (Map.get(properties, Text.compare, propertyId)) {
               case null { #err(#NotFound) };
               case (?prop) {
                 let now = Time.now();
@@ -849,7 +870,7 @@ persistent actor Property {
                   updatedAt           = now;
                   isActive            = prop.isActive;
                 };
-                Map.add(properties, Nat.compare, propertyId, updated);
+                Map.add(properties, Text.compare, propertyId, updated);
 
                 // Append immutable record to ownership history
                 let record : TransferRecord = {
@@ -862,7 +883,7 @@ persistent actor Property {
                 Map.add(transfers, Nat.compare, transferCounter, record);
 
                 // Invalidate token
-                Map.remove(pendingTransfers, Nat.compare, propertyId);
+                Map.remove(pendingTransfers, Text.compare, propertyId);
                 Map.remove(tokenIndex,       Text.compare, token);
 
                 #ok(updated)
@@ -876,23 +897,23 @@ persistent actor Property {
 
   /// Seller (or admin) cancels a pending transfer and invalidates the token.
   public shared(msg) func cancelTransfer(
-    propertyId : Nat
+    propertyId : Text
   ) : async Result.Result<(), Error> {
-    switch (Map.get(pendingTransfers, Nat.compare, propertyId)) {
+    switch (Map.get(pendingTransfers, Text.compare, propertyId)) {
       case null { #err(#NotFound) };
       case (?pending) {
         if (pending.from != msg.caller and not isAdmin(msg.caller))
           return #err(#NotAuthorized);
         Map.remove(tokenIndex,       Text.compare, pending.token);
-        Map.remove(pendingTransfers, Nat.compare,  propertyId);
+        Map.remove(pendingTransfers, Text.compare, propertyId);
         #ok(())
       };
     }
   };
 
   /// Returns the pending transfer for a property, if any.
-  public query func getPendingTransfer(propertyId: Nat) : async ?PendingTransfer {
-    Map.get(pendingTransfers, Nat.compare, propertyId)
+  public query func getPendingTransfer(propertyId: Text) : async ?PendingTransfer {
+    Map.get(pendingTransfers, Text.compare, propertyId)
   };
 
   /// Looks up a pending transfer by its bearer token.
@@ -900,13 +921,13 @@ persistent actor Property {
   public query func getPendingTransferByToken(token: Text) : async ?PendingTransfer {
     switch (Map.get(tokenIndex, Text.compare, token)) {
       case null          null;
-      case (?propertyId) Map.get(pendingTransfers, Nat.compare, propertyId);
+      case (?propertyId) Map.get(pendingTransfers, Text.compare, propertyId);
     }
   };
 
   /// Public, unauthenticated ownership history for a property.
   /// Returns records sorted by timestamp ascending (oldest first).
-  public query func getOwnershipHistory(propertyId: Nat) : async [TransferRecord] {
+  public query func getOwnershipHistory(propertyId: Text) : async [TransferRecord] {
     let filtered = Iter.toArray(
       Iter.filter(Map.values(transfers), func(r: TransferRecord) : Bool {
         r.propertyId == propertyId
@@ -936,12 +957,12 @@ persistent actor Property {
   /// Step 1: owner generates a bearer-token invite for a manager.
   /// Overwrites any existing invite for the same property+role combination.
   public shared(msg) func inviteManager(
-    propertyId  : Nat,
+    propertyId  : Text,
     role        : ManagerRole,
     displayName : Text
   ) : async Result.Result<ManagerInvite, Error> {
     switch (requireActive(msg.caller)) { case (#err e) return #err e; case _ {} };
-    switch (Map.get(properties, Nat.compare, propertyId)) {
+    switch (Map.get(properties, Text.compare, propertyId)) {
       case null { #err(#NotFound) };
       case (?prop) {
         if (prop.owner != msg.caller) return #err(#NotAuthorized);
@@ -970,7 +991,7 @@ persistent actor Property {
   /// Step 2: invitee claims manager access using the bearer token.
   public shared(msg) func claimManagerRole(
     token : Text
-  ) : async Result.Result<{ propertyId: Nat; role: ManagerRole }, Error> {
+  ) : async Result.Result<{ propertyId: Text; role: ManagerRole }, Error> {
     switch (requireActive(msg.caller)) { case (#err e) return #err e; case _ {} };
 
     switch (Map.get(managerInvites, Text.compare, token)) {
@@ -981,14 +1002,14 @@ persistent actor Property {
           Map.remove(managerTokenIdx, Text.compare, token);
           return #err(#InvalidInput("Invite link has expired."));
         };
-        switch (Map.get(properties, Nat.compare, invite.propertyId)) {
+        switch (Map.get(properties, Text.compare, invite.propertyId)) {
           case null { #err(#NotFound) };
           case (?prop) {
             if (prop.owner == msg.caller) {
               return #err(#InvalidInput("You already own this property."));
             };
             // Prevent duplicates — remove existing entry for this principal if any
-            let existing = switch (Map.get(managersMap, Nat.compare, invite.propertyId)) {
+            let existing = switch (Map.get(managersMap, Text.compare, invite.propertyId)) {
               case null    [];
               case (?list) list;
             };
@@ -1001,7 +1022,7 @@ persistent actor Property {
               displayName = invite.displayName;
               addedAt     = Time.now();
             };
-            Map.add(managersMap, Nat.compare, invite.propertyId,
+            Map.add(managersMap, Text.compare, invite.propertyId,
               Array.concat<PropertyManager>(filtered, [newMgr]));
             // Consume the token
             Map.remove(managerInvites,  Text.compare, token);
@@ -1015,15 +1036,15 @@ persistent actor Property {
 
   /// Owner changes an existing manager's role (Viewer ↔ Manager).
   public shared(msg) func updateManagerRole(
-    propertyId       : Nat,
+    propertyId       : Text,
     managerPrincipal : Principal,
     newRole          : ManagerRole
   ) : async Result.Result<(), Error> {
-    switch (Map.get(properties, Nat.compare, propertyId)) {
+    switch (Map.get(properties, Text.compare, propertyId)) {
       case null { #err(#NotFound) };
       case (?prop) {
         if (prop.owner != msg.caller) return #err(#NotAuthorized);
-        let existing = switch (Map.get(managersMap, Nat.compare, propertyId)) {
+        let existing = switch (Map.get(managersMap, Text.compare, propertyId)) {
           case null    return #err(#NotFound);
           case (?list) list;
         };
@@ -1036,7 +1057,7 @@ persistent actor Property {
         let updated = Array.map<PropertyManager, PropertyManager>(existing, func(m) {
           if (m.principal == managerPrincipal) { { m with role = newRole } } else m
         });
-        Map.add(managersMap, Nat.compare, propertyId, updated);
+        Map.add(managersMap, Text.compare, propertyId, updated);
         #ok(())
       };
     }
@@ -1044,21 +1065,21 @@ persistent actor Property {
 
   /// Owner removes a manager from a property.
   public shared(msg) func removeManager(
-    propertyId       : Nat,
+    propertyId       : Text,
     managerPrincipal : Principal
   ) : async Result.Result<(), Error> {
-    switch (Map.get(properties, Nat.compare, propertyId)) {
+    switch (Map.get(properties, Text.compare, propertyId)) {
       case null { #err(#NotFound) };
       case (?prop) {
         if (prop.owner != msg.caller) return #err(#NotAuthorized);
-        let existing = switch (Map.get(managersMap, Nat.compare, propertyId)) {
+        let existing = switch (Map.get(managersMap, Text.compare, propertyId)) {
           case null    return #err(#NotFound);
           case (?list) list;
         };
         let filtered = Array.filter<PropertyManager>(existing, func(m) {
           m.principal != managerPrincipal
         });
-        Map.add(managersMap, Nat.compare, propertyId, filtered);
+        Map.add(managersMap, Text.compare, propertyId, filtered);
         #ok(())
       };
     }
@@ -1066,9 +1087,9 @@ persistent actor Property {
 
   /// Manager voluntarily removes themselves.
   public shared(msg) func resignAsManager(
-    propertyId : Nat
+    propertyId : Text
   ) : async Result.Result<(), Error> {
-    let existing = switch (Map.get(managersMap, Nat.compare, propertyId)) {
+    let existing = switch (Map.get(managersMap, Text.compare, propertyId)) {
       case null    return #err(#NotFound);
       case (?list) list;
     };
@@ -1076,7 +1097,7 @@ persistent actor Property {
       m.principal != msg.caller
     });
     if (filtered.size() == existing.size()) return #err(#NotFound);
-    Map.add(managersMap, Nat.compare, propertyId, filtered);
+    Map.add(managersMap, Text.compare, propertyId, filtered);
     #ok(())
   };
 
@@ -1086,7 +1107,7 @@ persistent actor Property {
     for ((propId, mgrs) in Map.entries(managersMap)) {
       for (m in mgrs.vals()) {
         if (m.principal == msg.caller) {
-          switch (Map.get(properties, Nat.compare, propId)) {
+          switch (Map.get(properties, Text.compare, propId)) {
             case null {};
             case (?prop) {
               result := Array.concat<{ property: Property; role: ManagerRole }>(result, [{ property = prop; role = m.role }]);
@@ -1100,12 +1121,12 @@ persistent actor Property {
 
   /// Returns the managers for a property.
   /// Only the owner may call this.
-  public query(msg) func getPropertyManagers(propertyId: Nat) : async Result.Result<[PropertyManager], Error> {
-    switch (Map.get(properties, Nat.compare, propertyId)) {
+  public query(msg) func getPropertyManagers(propertyId: Text) : async Result.Result<[PropertyManager], Error> {
+    switch (Map.get(properties, Text.compare, propertyId)) {
       case null { #err(#NotFound) };
       case (?prop) {
         if (prop.owner != msg.caller) return #err(#NotAuthorized);
-        let mgrs = switch (Map.get(managersMap, Nat.compare, propertyId)) {
+        let mgrs = switch (Map.get(managersMap, Text.compare, propertyId)) {
           case null    [];
           case (?list) list;
         };
@@ -1123,12 +1144,12 @@ persistent actor Property {
   /// Called by a Manager-role user (via the frontend) after completing a
   /// significant write action to notify the property owner.
   public shared(msg) func recordManagerActivity(
-    propertyId  : Nat,
+    propertyId  : Text,
     description : Text
   ) : async Result.Result<(), Error> {
     if (not checkAuthorized(propertyId, msg.caller, true)) return #err(#NotAuthorized);
     // Resolve manager's display name for the notification
-    let managerName : Text = switch (Map.get(managersMap, Nat.compare, propertyId)) {
+    let managerName : Text = switch (Map.get(managersMap, Text.compare, propertyId)) {
       case null "A manager";
       case (?mgrs) {
         var found = "A manager";
@@ -1145,13 +1166,13 @@ persistent actor Property {
   /// Returns unseen (and recently seen) owner notifications for a property.
   /// Newest first. Only the property owner may call this.
   public query(msg) func getOwnerNotifications(
-    propertyId : Nat
+    propertyId : Text
   ) : async Result.Result<[OwnerNotification], Error> {
-    switch (Map.get(properties, Nat.compare, propertyId)) {
+    switch (Map.get(properties, Text.compare, propertyId)) {
       case null { #err(#NotFound) };
       case (?prop) {
         if (prop.owner != msg.caller) return #err(#NotAuthorized);
-        let notifs = switch (Map.get(ownerNotifs, Nat.compare, propertyId)) {
+        let notifs = switch (Map.get(ownerNotifs, Text.compare, propertyId)) {
           case null    [];
           case (?list) list;
         };
@@ -1168,13 +1189,13 @@ persistent actor Property {
 
   /// Owner dismisses all notifications for a property (marks as seen + clears).
   public shared(msg) func dismissNotifications(
-    propertyId : Nat
+    propertyId : Text
   ) : async Result.Result<(), Error> {
-    switch (Map.get(properties, Nat.compare, propertyId)) {
+    switch (Map.get(properties, Text.compare, propertyId)) {
       case null { #err(#NotFound) };
       case (?prop) {
         if (prop.owner != msg.caller) return #err(#NotAuthorized);
-        Map.add(ownerNotifs, Nat.compare, propertyId, []);
+        Map.add(ownerNotifs, Text.compare, propertyId, []);
         #ok(())
       };
     }
@@ -1186,7 +1207,7 @@ persistent actor Property {
   // TODO: update job/photo/quote/maintenance canisters to call this instead of
   //       checking caller == owner directly.
   public query func isAuthorized(
-    propertyId  : Nat,
+    propertyId  : Text,
     caller      : Principal,
     requireWrite : Bool
   ) : async Bool {
@@ -1307,7 +1328,7 @@ persistent actor Property {
     if (isPaused)                  { return { succeeded = []; failed = [] } };
     if (not isAdmin(msg.caller))   { return { succeeded = []; failed = [] } };
 
-    var succeeded : [Nat]             = [];
+    var succeeded : [Text]            = [];
     var failed    : [BulkImportError] = [];
 
     var i = 0;
@@ -1323,9 +1344,8 @@ persistent actor Property {
       if (duplicate) {
         failed := Array.concat(failed, [{ index = i; reason = "DuplicateAddress" }]);
       } else {
-        let now = Time.now();
-        let newId = nextId;
-        nextId += 1;
+        let now   = Time.now();
+        let newId = await nextPropertyId();
         let prop : Property = {
           id                  = newId;
           owner               = msg.caller;
@@ -1345,7 +1365,7 @@ persistent actor Property {
           updatedAt           = now;
           isActive            = true;
         };
-        Map.add(properties, Nat.compare, newId, prop);
+        Map.add(properties, Text.compare, newId, prop);
         succeeded := Array.concat(succeeded, [newId]);
       };
       i += 1;
@@ -1370,15 +1390,8 @@ persistent actor Property {
   public shared(msg) func createRoom(args: CreateRoomArgs) : async Result.Result<RoomRecord, Error> {
     switch (requireActive(msg.caller)) { case (#err(e)) return #err(e); case _ {} };
 
-    if (Text.size(args.propertyId) == 0)   return #err(#InvalidInput("propertyId cannot be empty"));
-
-    // Verify caller owns or manages the property
-    switch (Nat.fromText(args.propertyId)) {
-      case null    { return #err(#InvalidInput("propertyId must be a numeric ID")) };
-      case (?pid)  {
-        if (not checkAuthorized(pid, msg.caller, true)) return #err(#NotAuthorized);
-      };
-    };
+    if (Text.size(args.propertyId) == 0) return #err(#InvalidInput("propertyId cannot be empty"));
+    if (not checkAuthorized(args.propertyId, msg.caller, true)) return #err(#NotAuthorized);
     if (Text.size(args.name)       == 0)   return #err(#InvalidInput("name cannot be empty"));
     if (Text.size(args.name)       > 100)  return #err(#InvalidInput("name exceeds 100 characters"));
     if (Text.size(args.floorName)  > 100)  return #err(#InvalidInput("floorName exceeds 100 characters"));

--- a/backend/property/test.sh
+++ b/backend/property/test.sh
@@ -46,7 +46,7 @@ dfx canister call $CANISTER getPropertyLimitForTier '(variant { ContractorPro })
 # ─── Register a property ──────────────────────────────────────────────────────
 echo ""
 echo "── [3] Register a property (Free tier) ─────────────────────────────────"
-dfx canister call $CANISTER registerProperty '(record {
+REG_OUT=$(dfx canister call $CANISTER registerProperty '(record {
   address      = "123 Main Street";
   city         = "Austin";
   state        = "TX";
@@ -55,7 +55,14 @@ dfx canister call $CANISTER registerProperty '(record {
   yearBuilt    = 1995;
   squareFeet   = 2000;
   tier         = variant { Free };
-})'
+})')
+echo "$REG_OUT"
+PROP_ID=$(echo "$REG_OUT" | grep -oP 'id = "\K[^"]+' | head -1 || true)
+if [ -z "$PROP_ID" ]; then
+  echo "❌ Failed to extract property ID from registerProperty output"
+  exit 1
+fi
+echo "  → Property ID: $PROP_ID"
 
 echo ""
 echo "── [4] Get my properties ────────────────────────────────────────────────"
@@ -63,11 +70,11 @@ dfx canister call $CANISTER getMyProperties
 
 echo ""
 echo "── [5] Get property by ID — expect Unverified ───────────────────────────"
-dfx canister call $CANISTER getProperty '(1)'
+dfx canister call $CANISTER getProperty "(\"$PROP_ID\")"
 
 echo ""
 echo "── [6] getVerificationLevel — expect Unverified ─────────────────────────"
-dfx canister call $CANISTER getVerificationLevel '(1)'
+dfx canister call $CANISTER getVerificationLevel "(\"$PROP_ID\")"
 
 # ─── Tier limit enforcement ───────────────────────────────────────────────────
 echo ""
@@ -86,69 +93,69 @@ dfx canister call $CANISTER registerProperty '(record {
 # ─── Verification state machine (12.4.2) ──────────────────────────────────────
 echo ""
 echo "── [8] submitVerification → expect PendingReview (12.4.2) ──────────────"
-dfx canister call $CANISTER submitVerification '(
-  1,
-  "UtilityBill",
-  "sha256:a3f2b9c8d1e4f7a0b3c6d9e2f5a8b1c4d7e0f3a6b9c2d5e8f1a4b7c0d3e6f9"
-)'
+dfx canister call $CANISTER submitVerification "(
+  \"$PROP_ID\",
+  \"UtilityBill\",
+  \"sha256:a3f2b9c8d1e4f7a0b3c6d9e2f5a8b1c4d7e0f3a6b9c2d5e8f1a4b7c0d3e6f9\"
+)"
 
 echo ""
 echo "── [9] getVerificationLevel — expect PendingReview ──────────────────────"
-dfx canister call $CANISTER getVerificationLevel '(1)'
+dfx canister call $CANISTER getVerificationLevel "(\"$PROP_ID\")"
 
 echo ""
-echo "── [10] getPendingVerifications — should contain property 1 ─────────────"
+echo "── [10] getPendingVerifications — should contain property ───────────────"
 dfx canister call $CANISTER getPendingVerifications
 
 echo ""
 echo "── [11] submitVerification again on PendingReview → expect error ─────────"
-dfx canister call $CANISTER submitVerification '(
-  1,
-  "Deed",
-  "sha256:b4a3c2d1e0f9a8b7c6d5e4f3a2b1c0d9e8f7a6b5c4d3e2f1a0b9c8d7e6f5a4"
-)' || echo "  ↳ Expected InvalidInput (already verified) — ✓"
+dfx canister call $CANISTER submitVerification "(
+  \"$PROP_ID\",
+  \"Deed\",
+  \"sha256:b4a3c2d1e0f9a8b7c6d5e4f3a2b1c0d9e8f7a6b5c4d3e2f1a0b9c8d7e6f5a4\"
+)" || echo "  ↳ Expected InvalidInput (already pending) — ✓"
 
 echo ""
 echo "── [12] Admin: verifyProperty → Basic (12.4.2) ──────────────────────────"
-dfx canister call $CANISTER verifyProperty '(1, variant { Basic }, null)'
+dfx canister call $CANISTER verifyProperty "(\"$PROP_ID\", variant { Basic }, null)"
 
 echo ""
 echo "── [13] getVerificationLevel — expect Basic ──────────────────────────────"
-dfx canister call $CANISTER getVerificationLevel '(1)'
+dfx canister call $CANISTER getVerificationLevel "(\"$PROP_ID\")"
 
 echo ""
 echo "── [14] Admin: verifyProperty → Premium (12.4.2) ────────────────────────"
-dfx canister call $CANISTER verifyProperty '(1, variant { Premium }, opt "TitleDeed")'
+dfx canister call $CANISTER verifyProperty "(\"$PROP_ID\", variant { Premium }, opt \"TitleDeed\")"
 
 echo ""
 echo "── [15] getVerificationLevel — expect Premium ───────────────────────────"
-dfx canister call $CANISTER getVerificationLevel '(1)'
+dfx canister call $CANISTER getVerificationLevel "(\"$PROP_ID\")"
 
 echo ""
 echo "── [16] getProperty — final state ───────────────────────────────────────"
-dfx canister call $CANISTER getProperty '(1)'
+dfx canister call $CANISTER getProperty "(\"$PROP_ID\")"
 
 # ─── Ownership transfer — 7-day conflict window (12.4.2) ──────────────────────
 echo ""
-echo "── [17] initiateTransfer to buyer principal ─────────────────────────────"
-dfx canister call $CANISTER initiateTransfer "(1, principal \"$BUYER_PRINCIPAL\")"
+echo "── [17] initiateTransfer ────────────────────────────────────────────────"
+dfx canister call $CANISTER initiateTransfer "(\"$PROP_ID\")"
 
 echo ""
 echo "── [18] getPendingTransfer ──────────────────────────────────────────────"
-dfx canister call $CANISTER getPendingTransfer '(1)'
+dfx canister call $CANISTER getPendingTransfer "(\"$PROP_ID\")"
 
 echo ""
 echo "── [19] cancelTransfer ──────────────────────────────────────────────────"
-dfx canister call $CANISTER cancelTransfer '(1)'
+dfx canister call $CANISTER cancelTransfer "(\"$PROP_ID\")"
 
 echo ""
 echo "── [20] getPendingTransfer after cancel — expect empty ──────────────────"
-dfx canister call $CANISTER getPendingTransfer '(1)'
+dfx canister call $CANISTER getPendingTransfer "(\"$PROP_ID\")"
 
 # ─── getOwnershipHistory ──────────────────────────────────────────────────────
 echo ""
 echo "── [21] getOwnershipHistory ─────────────────────────────────────────────"
-dfx canister call $CANISTER getOwnershipHistory '(1)'
+dfx canister call $CANISTER getOwnershipHistory "(\"$PROP_ID\")"
 
 # ─── Admin functions ──────────────────────────────────────────────────────────
 echo ""
@@ -207,9 +214,9 @@ echo ""
 echo "── [28] Trusted principal bypasses rate limit ───────────────────────────"
 dfx canister call $CANISTER setUpdateRateLimit "(2 : nat)"
 # caller-test is trusted — these calls should all pass despite limit=2
-dfx canister call $CANISTER getProperty '(1)' --identity canister-caller-test || true
-dfx canister call $CANISTER getProperty '(1)' --identity canister-caller-test || true
-dfx canister call $CANISTER getProperty '(1)' --identity canister-caller-test || true
+dfx canister call $CANISTER getProperty "(\"$PROP_ID\")" --identity canister-caller-test || true
+dfx canister call $CANISTER getProperty "(\"$PROP_ID\")" --identity canister-caller-test || true
+dfx canister call $CANISTER getProperty "(\"$PROP_ID\")" --identity canister-caller-test || true
 echo "  ↳ 3 query-style calls passed for trusted principal despite rate limit of 2 — ✓"
 dfx canister call $CANISTER setUpdateRateLimit "(30 : nat)"
 
@@ -250,8 +257,7 @@ else
   echo "  ↳ setPaymentCanisterId succeeded — ✓"
 
   echo ""
-  echo "── [EXP-2] On Free tier: second property → expect LimitReached ──────────"
-  # Grant Free to the tier-test identity (not the deployer)
+  echo "── [EXP-2] On Free tier: register property → expect LimitReached ────────"
   dfx canister call payment grantSubscription "(principal \"$PROP_TIER_PRINCIPAL\", variant { Free })"
   dfx canister call $CANISTER registerProperty '(record {
     address      = "999 Payment-Wired Street";
@@ -267,7 +273,7 @@ else
     || echo "  ↳ Free tier limit enforced via payment canister — ✓"
 
   echo ""
-  echo "── [EXP-3] Grant Pro via payment canister → second property succeeds ─────"
+  echo "── [EXP-3] Grant Pro via payment canister → property registration succeeds ─"
   dfx canister call payment grantSubscription "(principal \"$PROP_TIER_PRINCIPAL\", variant { Pro })"
   dfx canister call $CANISTER registerProperty '(record {
     address      = "999 Payment-Wired Street";
@@ -279,8 +285,8 @@ else
     squareFeet   = 1500;
     tier         = variant { Pro };
   })' --identity property-tier-test \
-    && echo "  ↳ Pro tier allows second property via payment canister — ✓" \
-    || echo "  ↳ ❌ Pro tier should allow second property"
+    && echo "  ↳ Pro tier allows property registration via payment canister — ✓" \
+    || echo "  ↳ ❌ Pro tier should allow property registration"
 
   echo ""
   echo "── [EXP-4] Downgrade back to Free → further registrations rejected ──────"

--- a/backend/quote/main.mo
+++ b/backend/quote/main.mo
@@ -311,16 +311,11 @@ persistent actor Quote {
     // so managers don't need their own paid subscription.
     let effectivePrincipal : Principal = if (propCanisterId != "") {
       let propActor = actor(propCanisterId) : actor {
-        getPropertyOwner : (Nat) -> async ?Principal;
+        getPropertyOwner : (Text) -> async ?Principal;
       };
-      switch (Nat.fromText(propertyId)) {
-        case (?natId) {
-          switch (await propActor.getPropertyOwner(natId)) {
-            case (?owner) { if (owner != msg.caller) { owner } else { msg.caller } };
-            case null     { msg.caller };
-          }
-        };
-        case null { msg.caller };
+      switch (await propActor.getPropertyOwner(propertyId)) {
+        case (?owner) { if (owner != msg.caller) { owner } else { msg.caller } };
+        case null     { msg.caller };
       }
     } else { msg.caller };
     let callerTier : SubscriptionTier = if (payCanisterId != "") {
@@ -582,16 +577,11 @@ persistent actor Quote {
 
     let effectivePrincipalSB : Principal = if (propCanisterId != "") {
       let propActor = actor(propCanisterId) : actor {
-        getPropertyOwner : (Nat) -> async ?Principal;
+        getPropertyOwner : (Text) -> async ?Principal;
       };
-      switch (Nat.fromText(propertyId)) {
-        case (?natId) {
-          switch (await propActor.getPropertyOwner(natId)) {
-            case (?owner) { if (owner != msg.caller) { owner } else { msg.caller } };
-            case null     { msg.caller };
-          }
-        };
-        case null { msg.caller };
+      switch (await propActor.getPropertyOwner(propertyId)) {
+        case (?owner) { if (owner != msg.caller) { owner } else { msg.caller } };
+        case null     { msg.caller };
       }
     } else { msg.caller };
     let callerTier : SubscriptionTier = if (payCanisterId != "") {

--- a/backend/quote/test.sh
+++ b/backend/quote/test.sh
@@ -332,14 +332,14 @@ else
     tier         = variant { Pro };
   })')
   echo "$MGR_PROP_OUT"
-  MGR_PROP_ID=$(echo "$MGR_PROP_OUT" | grep -oP 'id = \K[0-9]+' | head -1)
+  MGR_PROP_ID=$(echo "$MGR_PROP_OUT" | grep -oP 'id = "\K[^"]+' | head -1 || true)
   echo "  → Property ID: $MGR_PROP_ID"
 
   # Invite and claim manager role
   echo ""
   echo "── [MGR-2] Owner invites manager; manager claims role ───────────────────"
   INVITE_OUT=$(dfx canister call property inviteManager \
-    "($MGR_PROP_ID, variant { Manager }, \"Quote Manager\")")
+    "(\"$MGR_PROP_ID\", variant { Manager }, \"Quote Manager\")")
   INVITE_TOKEN=$(echo "$INVITE_OUT" | grep -oP 'token = "\K[^"]+' | head -1)
   dfx canister call property claimManagerRole \
     "(\"$INVITE_TOKEN\")" --identity manager-test

--- a/backend/report/main.mo
+++ b/backend/report/main.mo
@@ -389,21 +389,16 @@ persistent actor Report {
     // verification level — callers cannot spoof this by passing a fake level
     // in the PropertyInput.
     if (Text.size(propCanisterId) > 0) {
-      switch (Nat.fromText(propertyId)) {
-        case (?pid) {
-          let propActor = actor(propCanisterId) : actor {
-            getVerificationLevel : (Nat) -> async ?Text;
-          };
-          switch (await propActor.getVerificationLevel(pid)) {
-            case (?level) {
-              if (level == "Unverified" or level == "PendingReview") {
-                return #err(#UnverifiedProperty);
-              };
-            };
-            case null {};   // not found — proceed
+      let propActor = actor(propCanisterId) : actor {
+        getVerificationLevel : (Text) -> async ?Text;
+      };
+      switch (await propActor.getVerificationLevel(propertyId)) {
+        case (?level) {
+          if (level == "Unverified" or level == "PendingReview") {
+            return #err(#UnverifiedProperty);
           };
         };
-        case null {};   // propertyId is not a Nat — skip the check
+        case null {};   // not found — proceed
       };
     };
 


### PR DESCRIPTION
…random Text ID

Property IDs were sequential integers (1, 2, 3…) making all URLs enumerable. Any caller could walk getProperty(1), getProperty(2), etc. to harvest all owner principals, addresses, and verification levels without authentication.

Changes:
- Property.id: Nat → Text, generated via IC certified randomness (Random.blob) producing IDs of the form PROP_<32-byte-hex> — unguessable and non-sequential
- All internal maps rekeyed: Map<Nat,…> → Map<Text,…> with Text.compare
- Removed nextId counter; added blobToHex + nextPropertyId() async helpers (mirrors the pattern already used by the report canister for share tokens)
- ManagerInvite.propertyId, TransferRecord.propertyId, PendingTransfer.propertyId all updated to Text
- claimManagerRole return type { propertyId: Nat } → { propertyId: Text }
- BulkImportResult.succeeded: [Nat] → [Text]
- createRoom: removed Nat.fromText parse; checkAuthorized now takes Text directly
- property/test.sh: captures string ID from registerProperty output and threads it through all subsequent steps instead of hardcoding '(1)'

Cross-canister callers updated (all used Nat.fromText + getPropertyOwner(natId)):
- job/main.mo: 3 call sites — createJob, createSensorJob, createJobProposal
- quote/main.mo: 2 call sites — createQuoteRequest, createSealedBidRequest
- photo/main.mo: 1 call site — uploadPhoto
- report/main.mo: 1 call site — generateReport (getVerificationLevel)

Closes #115

## Summary
<!-- What does this PR do? -->

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [ ] Backend tests pass (`make test`)
- [ ] Frontend builds (`cd frontend && npm run build`)
- [ ] Tested locally with dfx

## Checklist
- [ ] Code follows project conventions
- [ ] Self-review completed
- [ ] No sensitive data committed
