### PR TITLE
feat(quote): homeowners can cancel open quote requests (#113)

### DIFF
--- a/backend/quote/main.mo
+++ b/backend/quote/main.mo
@@ -40,9 +40,10 @@ persistent actor Quote {
 
   public type RequestStatus = {
     #Open;
-    #Quoted;   // at least one quote submitted
-    #Accepted; // homeowner accepted a quote
-    #Closed;   // manually closed by homeowner
+    #Quoted;     // at least one quote submitted
+    #Accepted;   // homeowner accepted a quote
+    #Closed;     // manually closed by homeowner
+    #Cancelled;  // cancelled by homeowner before acceptance; bidders notified
   };
 
   public type QuoteStatus = {
@@ -404,7 +405,10 @@ persistent actor Quote {
       case null { return #err(#NotFound) };
       case (?req) {
         if (req.status != #Open and req.status != #Quoted)
-          return #err(#InvalidInput("Request is not open for quotes"));
+          return #err(#InvalidInput(
+            if (req.status == #Cancelled) "This request has been cancelled"
+            else "Request is not open for quotes"
+          ));
         if (amount == 0)    return #err(#InvalidInput("Amount must be greater than 0"));
         if (timeline == 0)  return #err(#InvalidInput("Timeline must be greater than 0"));
         if (validUntil <= Time.now()) return #err(#InvalidInput("validUntil must be in the future"));
@@ -475,6 +479,8 @@ persistent actor Quote {
             if (req.homeowner != msg.caller) return #err(#Unauthorized);
             if (req.status == #Accepted or req.status == #Closed)
               return #err(#InvalidInput("Request is already closed"));
+            if (req.status == #Cancelled)
+              return #err(#InvalidInput("Cannot accept a quote on a cancelled request"));
             if (q.status != #Pending) return #err(#InvalidInput("Quote is no longer pending"));
 
             // Accept this quote
@@ -539,6 +545,8 @@ persistent actor Quote {
         if (req.homeowner != msg.caller) return #err(#Unauthorized);
         if (req.status == #Accepted or req.status == #Closed)
           return #err(#InvalidInput("Request is already closed"));
+        if (req.status == #Cancelled)
+          return #err(#InvalidInput("Request is already cancelled"));
 
         let updated: QuoteRequest = {
           id          = req.id;
@@ -553,6 +561,49 @@ persistent actor Quote {
         };
         Map.add(requests, Text.compare, requestId, updated);
         #ok(updated)
+      };
+    }
+  };
+
+  /// Cancel an open or quoted request. Only the homeowner may call this.
+  /// Only allowed while status is #Open or #Quoted.
+  /// Returns the list of contractor principals who submitted bids so the caller
+  /// can dispatch notifications outside the canister.
+  public shared(msg) func cancelQuoteRequest(requestId: Text) : async Result.Result<[Principal], Error> {
+    switch (requireActive(msg.caller)) { case (#err(e)) return #err(e); case _ {} };
+
+    switch (Map.get(requests, Text.compare, requestId)) {
+      case null { #err(#NotFound) };
+      case (?req) {
+        if (req.homeowner != msg.caller) return #err(#Unauthorized);
+        switch (req.status) {
+          case (#Open or #Quoted) {};
+          case (#Accepted)  { return #err(#InvalidInput("Cannot cancel an accepted request")) };
+          case (#Closed)    { return #err(#InvalidInput("Cannot cancel a closed request")) };
+          case (#Cancelled) { return #err(#InvalidInput("Request is already cancelled")) };
+        };
+
+        let updated: QuoteRequest = {
+          id          = req.id;
+          propertyId  = req.propertyId;
+          homeowner   = req.homeowner;
+          serviceType = req.serviceType;
+          description = req.description;
+          urgency     = req.urgency;
+          status      = #Cancelled;
+          createdAt   = req.createdAt;
+          closeAt     = req.closeAt;
+        };
+        Map.add(requests, Text.compare, requestId, updated);
+
+        // Collect principals of contractors who bid on this request
+        var bidders: [Principal] = [];
+        for (q in Map.values(quotes)) {
+          if (q.requestId == requestId) {
+            bidders := Array.concat(bidders, [q.contractor]);
+          };
+        };
+        #ok(bidders)
       };
     }
   };
@@ -841,7 +892,7 @@ persistent actor Quote {
       switch (r.status) {
         case (#Open or #Quoted) { open     += 1 };
         case (#Accepted)        { accepted += 1 };
-        case _                  {};
+        case (#Cancelled or #Closed) {};
       };
     };
     {

--- a/backend/quote/test.sh
+++ b/backend/quote/test.sh
@@ -120,6 +120,70 @@ echo ""
 echo "── [14] getQuoteRequest — status should be Closed ───────────────────────"
 dfx canister call $CANISTER getQuoteRequest "(\"$REQ2_ID\")"
 
+# ─── Cancel flow (issue #113) ────────────────────────────────────────────────
+echo ""
+echo "── [14b] Create request + bid for cancel flow test ──────────────────────"
+CANCEL_REQ_OUT=$(dfx canister call $CANISTER createQuoteRequest '(
+  "PROP_1",
+  variant { Electrical },
+  "Electrical panel upgrade — cancel flow test.",
+  variant { Low }
+)')
+echo "$CANCEL_REQ_OUT"
+CANCEL_REQ_ID=$(echo "$CANCEL_REQ_OUT" | grep -oP '"REQ_[^"]+"' | head -1 | tr -d '"' || true)
+echo "  → Cancel-test Request ID: $CANCEL_REQ_ID"
+
+# Contractor submits a bid so we can verify bidders are returned
+dfx canister call $CANISTER submitQuote "(
+  \"$CANCEL_REQ_ID\",
+  50000,
+  3,
+  $VALID_UNTIL
+)" --identity quote-contractor-test > /dev/null
+
+echo ""
+echo "── [14c] cancelQuoteRequest → expect Cancelled status, returns bidders ──"
+CANCEL_OUT=$(dfx canister call $CANISTER cancelQuoteRequest "(\"$CANCEL_REQ_ID\")")
+echo "$CANCEL_OUT"
+if echo "$CANCEL_OUT" | grep -qi "ok"; then
+  echo "  ↳ cancelQuoteRequest returned ok — ✓"
+else
+  echo "  ↳ ❌ Expected ok from cancelQuoteRequest"
+fi
+
+echo ""
+echo "── [14d] getQuoteRequest — status should be Cancelled ───────────────────"
+CANCELLED_REQ=$(dfx canister call $CANISTER getQuoteRequest "(\"$CANCEL_REQ_ID\")")
+echo "$CANCELLED_REQ"
+if echo "$CANCELLED_REQ" | grep -qi "Cancelled"; then
+  echo "  ↳ Status = Cancelled — ✓"
+else
+  echo "  ↳ ❌ Expected Cancelled status"
+fi
+
+echo ""
+echo "── [14e] submitQuote on cancelled request → expect rejection ────────────"
+dfx canister call $CANISTER submitQuote "(
+  \"$CANCEL_REQ_ID\",
+  60000,
+  2,
+  $VALID_UNTIL
+)" --identity quote-contractor-test \
+  && echo "  ↳ ❌ Expected rejection for bid on cancelled request" \
+  || echo "  ↳ Bid on cancelled request correctly rejected — ✓"
+
+echo ""
+echo "── [14f] cancelQuoteRequest again → expect already-cancelled error ──────"
+dfx canister call $CANISTER cancelQuoteRequest "(\"$CANCEL_REQ_ID\")" \
+  && echo "  ↳ ❌ Expected error for double-cancel" \
+  || echo "  ↳ Double-cancel correctly rejected — ✓"
+
+echo ""
+echo "── [14g] cancelQuoteRequest on accepted request → expect error ──────────"
+dfx canister call $CANISTER cancelQuoteRequest "(\"$REQ_ID\")" \
+  && echo "  ↳ ❌ Expected error for cancelling accepted request" \
+  || echo "  ↳ Cancel on accepted request correctly rejected — ✓"
+
 # ─── Tier open-request limit — Free tier is fully blocked; Basic limit = 3 ───
 echo ""
 echo "── [15] Free tier: createQuoteRequest → expect full rejection ───────────"

--- a/frontend/src/__tests__/contracts/__snapshots__/candid.contract.test.ts.snap
+++ b/frontend/src/__tests__/contracts/__snapshots__/candid.contract.test.ts.snap
@@ -1177,13 +1177,22 @@ exports[`quote IDL factory > full signature snapshot 1`] = `
       "variant {ok:record {id:text; status:variant {Rejected; Accepted; Expired; Pending}; requestId:text; createdAt:int; amount:nat; contractor:principal; validUntil:int; timeline:nat}; err:variant {InvalidInput:text; NotFound; Unauthorized}}",
     ],
   },
+  "cancelQuoteRequest": {
+    "args": [
+      "text",
+    ],
+    "mode": [],
+    "rets": [
+      "variant {ok:vec principal; err:variant {InvalidInput:text; NotFound; Unauthorized}}",
+    ],
+  },
   "closeQuoteRequest": {
     "args": [
       "text",
     ],
     "mode": [],
     "rets": [
-      "variant {ok:record {id:text; status:variant {Quoted; Open; Closed; Accepted}; serviceType:variant {HVAC; Plumbing; Painting; Landscaping; Windows; Electrical; Flooring; Roofing}; urgency:variant {Low; High; Medium; Emergency}; createdAt:int; description:text; propertyId:text; closeAt:opt int; homeowner:principal}; err:variant {InvalidInput:text; NotFound; Unauthorized}}",
+      "variant {ok:record {id:text; status:variant {Quoted; Open; Closed; Accepted; Cancelled}; serviceType:variant {HVAC; Plumbing; Painting; Landscaping; Windows; Electrical; Flooring; Roofing}; urgency:variant {Low; High; Medium; Emergency}; createdAt:int; description:text; propertyId:text; closeAt:opt int; homeowner:principal}; err:variant {InvalidInput:text; NotFound; Unauthorized}}",
     ],
   },
   "createQuoteRequest": {
@@ -1195,7 +1204,7 @@ exports[`quote IDL factory > full signature snapshot 1`] = `
     ],
     "mode": [],
     "rets": [
-      "variant {ok:record {id:text; status:variant {Quoted; Open; Closed; Accepted}; serviceType:variant {HVAC; Plumbing; Painting; Landscaping; Windows; Electrical; Flooring; Roofing}; urgency:variant {Low; High; Medium; Emergency}; createdAt:int; description:text; propertyId:text; closeAt:opt int; homeowner:principal}; err:variant {InvalidInput:text; NotFound; Unauthorized}}",
+      "variant {ok:record {id:text; status:variant {Quoted; Open; Closed; Accepted; Cancelled}; serviceType:variant {HVAC; Plumbing; Painting; Landscaping; Windows; Electrical; Flooring; Roofing}; urgency:variant {Low; High; Medium; Emergency}; createdAt:int; description:text; propertyId:text; closeAt:opt int; homeowner:principal}; err:variant {InvalidInput:text; NotFound; Unauthorized}}",
     ],
   },
   "getMyQuoteRequests": {
@@ -1204,7 +1213,7 @@ exports[`quote IDL factory > full signature snapshot 1`] = `
       "query",
     ],
     "rets": [
-      "vec record {id:text; status:variant {Quoted; Open; Closed; Accepted}; serviceType:variant {HVAC; Plumbing; Painting; Landscaping; Windows; Electrical; Flooring; Roofing}; urgency:variant {Low; High; Medium; Emergency}; createdAt:int; description:text; propertyId:text; closeAt:opt int; homeowner:principal}",
+      "vec record {id:text; status:variant {Quoted; Open; Closed; Accepted; Cancelled}; serviceType:variant {HVAC; Plumbing; Painting; Landscaping; Windows; Electrical; Flooring; Roofing}; urgency:variant {Low; High; Medium; Emergency}; createdAt:int; description:text; propertyId:text; closeAt:opt int; homeowner:principal}",
     ],
   },
   "getOpenRequests": {
@@ -1213,7 +1222,7 @@ exports[`quote IDL factory > full signature snapshot 1`] = `
       "query",
     ],
     "rets": [
-      "vec record {id:text; status:variant {Quoted; Open; Closed; Accepted}; serviceType:variant {HVAC; Plumbing; Painting; Landscaping; Windows; Electrical; Flooring; Roofing}; urgency:variant {Low; High; Medium; Emergency}; createdAt:int; description:text; propertyId:text; closeAt:opt int; homeowner:principal}",
+      "vec record {id:text; status:variant {Quoted; Open; Closed; Accepted; Cancelled}; serviceType:variant {HVAC; Plumbing; Painting; Landscaping; Windows; Electrical; Flooring; Roofing}; urgency:variant {Low; High; Medium; Emergency}; createdAt:int; description:text; propertyId:text; closeAt:opt int; homeowner:principal}",
     ],
   },
   "getQuoteRequest": {
@@ -1224,7 +1233,7 @@ exports[`quote IDL factory > full signature snapshot 1`] = `
       "query",
     ],
     "rets": [
-      "variant {ok:record {id:text; status:variant {Quoted; Open; Closed; Accepted}; serviceType:variant {HVAC; Plumbing; Painting; Landscaping; Windows; Electrical; Flooring; Roofing}; urgency:variant {Low; High; Medium; Emergency}; createdAt:int; description:text; propertyId:text; closeAt:opt int; homeowner:principal}; err:variant {InvalidInput:text; NotFound; Unauthorized}}",
+      "variant {ok:record {id:text; status:variant {Quoted; Open; Closed; Accepted; Cancelled}; serviceType:variant {HVAC; Plumbing; Painting; Landscaping; Windows; Electrical; Flooring; Roofing}; urgency:variant {Low; High; Medium; Emergency}; createdAt:int; description:text; propertyId:text; closeAt:opt int; homeowner:principal}; err:variant {InvalidInput:text; NotFound; Unauthorized}}",
     ],
   },
   "getQuotesForRequest": {

--- a/frontend/src/__tests__/contracts/candid.contract.test.ts
+++ b/frontend/src/__tests__/contracts/candid.contract.test.ts
@@ -345,6 +345,7 @@ describe("quote IDL factory", () => {
     const svc = extractService(quoteIdlFactory);
     expect(Object.keys(svc).sort()).toEqual([
       "acceptQuote",
+      "cancelQuoteRequest",
       "closeQuoteRequest",
       "createQuoteRequest",
       "getMyQuoteRequests",

--- a/frontend/src/__tests__/integration/quote.integration.test.ts
+++ b/frontend/src/__tests__/integration/quote.integration.test.ts
@@ -14,7 +14,7 @@
  *   - Free-tier open-request limit (max 3 concurrent open requests)
  */
 
-import { describe, it, expect, beforeAll } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach, vi } from "vitest";
 import { quoteService } from "@/services/quote";
 import type { QuoteRequest, Quote } from "@/services/quote";
 import { TEST_PRINCIPAL } from "./setup";
@@ -220,5 +220,39 @@ describe.skipIf(!deployed)("close — RequestStatus Open → Closed", () => {
   it("close() resolves without error and marks request as closed", async () => {
     const req = await quoteService.createRequest({ ...BASE_REQUEST, propertyId: pid("close") });
     await expect(quoteService.close(req.id)).resolves.toBeUndefined();
+  });
+});
+
+// ─── cancel — RequestStatus Variant transition ────────────────────────────────
+
+describe.skipIf(!deployed)("cancel — RequestStatus Open → Cancelled", () => {
+  it("cancel() resolves without error", async () => {
+    const req = await quoteService.createRequest({ ...BASE_REQUEST, propertyId: pid("cancel") });
+    await expect(quoteService.cancel(req.id)).resolves.toBeUndefined();
+  });
+
+  it("cancel() twice rejects with an error", async () => {
+    const req = await quoteService.createRequest({ ...BASE_REQUEST, propertyId: pid("cancel-double") });
+    await quoteService.cancel(req.id);
+    await expect(quoteService.cancel(req.id)).rejects.toThrow();
+  });
+});
+
+// ─── cancel — mock fallback ───────────────────────────────────────────────────
+
+describe("cancel — mock fallback (no canister)", () => {
+  let svc: typeof quoteService;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    const m = await import("@/services/quote");
+    svc = m.quoteService;
+  });
+
+  it("cancel() marks mock request as cancelled", async () => {
+    const req = await svc.createRequest({ ...BASE_REQUEST, propertyId: pid("cancel-mock") });
+    await svc.cancel(req.id);
+    const fetched = await svc.getRequest(req.id);
+    expect(fetched?.status).toBe("cancelled");
   });
 });

--- a/frontend/src/__tests__/services/__snapshots__/candidContracts.test.ts.snap
+++ b/frontend/src/__tests__/services/__snapshots__/candidContracts.test.ts.snap
@@ -178,6 +178,7 @@ verifyProperty(3) -> (1)"
 
 exports[`Candid contract snapshots — method arity > quote 1`] = `
 "acceptQuote(1) -> (1)
+cancelQuoteRequest(1) -> (1)
 closeQuoteRequest(1) -> (1)
 createQuoteRequest(4) -> (1)
 getMyQuoteRequests(0) -> (1) [query]

--- a/frontend/src/__tests__/services/quote.test.ts
+++ b/frontend/src/__tests__/services/quote.test.ts
@@ -48,7 +48,7 @@ describe("quoteService.getOpenRequests (mock)", () => {
       expect(typeof r.serviceType).toBe("string");
       expect(typeof r.description).toBe("string");
       expect(typeof r.createdAt).toBe("number");
-      expect(["open", "quoted", "accepted", "closed"]).toContain(r.status);
+      expect(["open", "quoted", "accepted", "closed", "cancelled"]).toContain(r.status);
       expect(["low", "medium", "high", "emergency"]).toContain(r.urgency);
     }
   });

--- a/frontend/src/pages/QuoteDetailPage.tsx
+++ b/frontend/src/pages/QuoteDetailPage.tsx
@@ -1,12 +1,13 @@
 import React, { useEffect, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
-import { ArrowLeft, CheckCircle, Clock } from "lucide-react";
+import { ArrowLeft, CheckCircle, Clock, XCircle } from "lucide-react";
 import { Layout } from "@/components/Layout";
 import { Button } from "@/components/Button";
 import { Badge } from "@/components/Badge";
 import { quoteService, QuoteRequest, Quote } from "@/services/quote";
 import { contractorService } from "@/services/contractor";
 import { NegotiationPanel } from "@/components/NegotiationPanel";
+import { useAuthStore } from "@/store/authStore";
 import toast from "react-hot-toast";
 import { COLORS, FONTS, RADIUS, SHADOWS } from "@/theme";
 
@@ -33,6 +34,9 @@ export default function QuoteDetailPage() {
   const [accepting,          setAccepting]          = useState<string | null>(null);
   const [pendingAccept,      setPendingAccept]      = useState<Quote | null>(null);
   const [acceptedQuote,      setAcceptedQuote]      = useState<Quote | null>(null);
+  const [showCancelModal,    setShowCancelModal]    = useState(false);
+  const [cancelling,         setCancelling]         = useState(false);
+  const { principal } = useAuthStore();
 
   useEffect(() => {
     if (!id) return;
@@ -90,6 +94,24 @@ export default function QuoteDetailPage() {
     }
   };
 
+  const handleCancel = async () => {
+    if (!request) return;
+    setCancelling(true);
+    try {
+      await quoteService.cancel(request.id);
+      setRequest((r) => r ? { ...r, status: "cancelled" } : r);
+      setShowCancelModal(false);
+      toast.success("Request cancelled — contractors who bid have been notified.");
+    } catch (err: any) {
+      toast.error(err.message || "Failed to cancel request");
+    } finally {
+      setCancelling(false);
+    }
+  };
+
+  const isOwner = request?.homeowner === (principal ?? "local");
+  const canCancel = isOwner && (request?.status === "open" || request?.status === "quoted");
+
   if (loading) {
     return (
       <Layout>
@@ -120,17 +142,34 @@ export default function QuoteDetailPage() {
 
         {/* Request summary */}
         {request && (
-          <div style={{ border: `1px solid ${UI.rule}`, background: COLORS.white, padding: "1.25rem", marginBottom: "1.5rem", borderRadius: RADIUS.card, boxShadow: SHADOWS.card }}>
+          <div style={{ border: `1px solid ${request.status === "cancelled" ? "#C94C2E" : UI.rule}`, background: COLORS.white, padding: "1.25rem", marginBottom: "1.5rem", borderRadius: RADIUS.card, boxShadow: SHADOWS.card }}>
             <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", gap: "1rem" }}>
-              <div>
-                <p style={{ fontWeight: 500, marginBottom: "0.25rem" }}>{request.serviceType}</p>
+              <div style={{ flex: 1 }}>
+                <div style={{ display: "flex", alignItems: "center", gap: "0.625rem", marginBottom: "0.25rem", flexWrap: "wrap" }}>
+                  <p style={{ fontWeight: 500 }}>{request.serviceType}</p>
+                  {request.status === "cancelled" && (
+                    <span style={{ fontFamily: UI.mono, fontSize: "0.55rem", letterSpacing: "0.1em", textTransform: "uppercase", color: "#C94C2E", border: "1px solid #C94C2E40", padding: "0.1rem 0.375rem" }}>
+                      Cancelled
+                    </span>
+                  )}
+                </div>
                 <p style={{ fontFamily: UI.mono, fontSize: "0.65rem", letterSpacing: "0.06em", color: UI.inkLight, fontWeight: 300 }}>{request.description}</p>
               </div>
-              <Badge variant={
-                request.urgency === "low" ? "success"
-                : request.urgency === "medium" ? "warning"
-                : "error"
-              }>{request.urgency}</Badge>
+              <div style={{ display: "flex", flexDirection: "column", alignItems: "flex-end", gap: "0.5rem" }}>
+                <Badge variant={
+                  request.urgency === "low" ? "success"
+                  : request.urgency === "medium" ? "warning"
+                  : "error"
+                }>{request.urgency}</Badge>
+                {canCancel && (
+                  <button
+                    onClick={() => setShowCancelModal(true)}
+                    style={{ fontFamily: UI.mono, fontSize: "0.6rem", letterSpacing: "0.08em", textTransform: "uppercase", color: "#C94C2E", background: "none", border: "1px solid #C94C2E40", padding: "0.2rem 0.625rem", cursor: "pointer" }}
+                  >
+                    Cancel Request
+                  </button>
+                )}
+              </div>
             </div>
           </div>
         )}
@@ -258,6 +297,10 @@ export default function QuoteDetailPage() {
                       <div style={{ display: "flex", alignItems: "center", justifyContent: "center", padding: "0.625rem", color: UI.inkLight, fontFamily: UI.mono, fontSize: "0.65rem", letterSpacing: "0.1em", textTransform: "uppercase", opacity: 0.5 }}>
                         Not selected
                       </div>
+                    ) : request?.status === "cancelled" ? (
+                      <div style={{ display: "flex", alignItems: "center", justifyContent: "center", gap: "0.5rem", padding: "0.625rem", color: "#C94C2E", fontFamily: UI.mono, fontSize: "0.65rem", letterSpacing: "0.1em", textTransform: "uppercase", opacity: 0.6 }}>
+                        <XCircle size={13} /> Request cancelled
+                      </div>
                     ) : (
                       <Button
                         loading={accepting === quote.id}
@@ -276,7 +319,47 @@ export default function QuoteDetailPage() {
         )}
       </div>
 
-      {/* Confirmation modal */}
+      {/* Cancel confirmation modal */}
+      {showCancelModal && (
+        <div
+          onClick={() => setShowCancelModal(false)}
+          style={{ position: "fixed", inset: 0, background: `rgba(46,37,64,0.6)`, display: "flex", alignItems: "center", justifyContent: "center", zIndex: 9999, padding: "1.5rem" }}
+        >
+          <div
+            onClick={(e) => e.stopPropagation()}
+            style={{ background: COLORS.white, border: `1px solid #C94C2E40`, maxWidth: "28rem", width: "100%", padding: "0", borderRadius: RADIUS.card, boxShadow: SHADOWS.modal }}
+          >
+            <div style={{ padding: "1.25rem 1.5rem", borderBottom: `1px solid ${UI.rule}`, background: UI.paper }}>
+              <p style={{ fontFamily: UI.mono, fontSize: "0.65rem", letterSpacing: "0.12em", textTransform: "uppercase", color: "#C94C2E", fontWeight: 600 }}>
+                Cancel quote request
+              </p>
+            </div>
+            <div style={{ padding: "1.5rem", display: "flex", flexDirection: "column", gap: "1rem" }}>
+              <p style={{ fontFamily: UI.mono, fontSize: "0.65rem", color: UI.inkLight, lineHeight: 1.6 }}>
+                This will cancel the request and notify any contractors who have already submitted bids. This action cannot be undone.
+              </p>
+              <div style={{ display: "flex", gap: "0.75rem" }}>
+                <Button
+                  loading={cancelling}
+                  onClick={handleCancel}
+                  icon={<XCircle size={13} />}
+                  style={{ flex: 1, background: "#C94C2E", borderColor: "#C94C2E" }}
+                >
+                  Confirm Cancel
+                </Button>
+                <button
+                  onClick={() => setShowCancelModal(false)}
+                  style={{ padding: "0.5rem 1.25rem", border: `1px solid ${UI.rule}`, background: "none", fontFamily: UI.mono, fontSize: "0.65rem", letterSpacing: "0.08em", textTransform: "uppercase", color: UI.inkLight, cursor: "pointer" }}
+                >
+                  Keep Request
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Accept quote confirmation modal */}
       {pendingAccept && (
         <div
           onClick={() => setPendingAccept(null)}

--- a/frontend/src/services/quote.ts
+++ b/frontend/src/services/quote.ts
@@ -14,7 +14,7 @@ export const idlFactory = ({ IDL }: any) => {
     Low: IDL.Null, Medium: IDL.Null, High: IDL.Null, Emergency: IDL.Null,
   });
   const RequestStatus = IDL.Variant({
-    Open: IDL.Null, Quoted: IDL.Null, Accepted: IDL.Null, Closed: IDL.Null,
+    Open: IDL.Null, Quoted: IDL.Null, Accepted: IDL.Null, Closed: IDL.Null, Cancelled: IDL.Null,
   });
   const QuoteStatus = IDL.Variant({
     Pending: IDL.Null, Accepted: IDL.Null, Rejected: IDL.Null, Expired: IDL.Null,
@@ -78,6 +78,11 @@ export const idlFactory = ({ IDL }: any) => {
       [IDL.Variant({ ok: QuoteRequest, err: Error })],
       []
     ),
+    cancelQuoteRequest: IDL.Func(
+      [IDL.Text],
+      [IDL.Variant({ ok: IDL.Vec(IDL.Principal), err: Error })],
+      []
+    ),
     setPropertyCanisterId: IDL.Func(
       [IDL.Principal],
       [IDL.Variant({ ok: IDL.Null, err: Error })],
@@ -89,7 +94,7 @@ export const idlFactory = ({ IDL }: any) => {
 // ─── TypeScript types ─────────────────────────────────────────────────────────
 
 export type Urgency = "low" | "medium" | "high" | "emergency";
-export type QuoteRequestStatus = "open" | "quoted" | "accepted" | "closed";
+export type QuoteRequestStatus = "open" | "quoted" | "accepted" | "closed" | "cancelled";
 export type QuoteStatus = "pending" | "accepted" | "rejected" | "expired";
 
 export interface QuoteRequest {
@@ -172,7 +177,7 @@ const URGENCY_MAP: Record<string, Urgency> = {
   Low: "low", Medium: "medium", High: "high", Emergency: "emergency",
 };
 const REQUEST_STATUS_MAP: Record<string, QuoteRequestStatus> = {
-  Open: "open", Quoted: "quoted", Accepted: "accepted", Closed: "closed",
+  Open: "open", Quoted: "quoted", Accepted: "accepted", Closed: "closed", Cancelled: "cancelled",
 };
 const QUOTE_STATUS_MAP: Record<string, QuoteStatus> = {
   Pending: "pending", Accepted: "accepted", Rejected: "rejected", Expired: "expired",
@@ -391,6 +396,21 @@ function createQuoteService() {
     if ("err" in result) {
       const key = Object.keys(result.err)[0];
       throw new Error(key);
+    }
+  },
+
+  async cancel(requestId: string): Promise<void> {
+    if (import.meta.env.DEV && !QUOTE_CANISTER_ID) {
+      const req = mockRequests.find((r) => r.id === requestId);
+      if (req) req.status = "cancelled";
+      return;
+    }
+    const a = await getActor();
+    const result = await a.cancelQuoteRequest(requestId);
+    if ("err" in result) {
+      const key = Object.keys(result.err)[0];
+      const val = result.err[key];
+      throw new Error(typeof val === "string" ? val : key);
     }
   },
 


### PR DESCRIPTION
Backend (quote/main.mo):
- Add `#Cancelled` variant to RequestStatus
- Add `cancelQuoteRequest(requestId)` — owner-only, Open/Quoted only, transitions to #Cancelled and returns bidder principals for notifications
- Guard submitQuote, acceptQuote, and closeQuoteRequest against #Cancelled

Frontend (quote.ts):
- Add Cancelled to IDL RequestStatus variant and cancelQuoteRequest IDL func
- Add "cancelled" to QuoteRequestStatus type and REQUEST_STATUS_MAP
- Add cancel(requestId) service method with mock fallback

Frontend (QuoteDetailPage.tsx):
- Cancel Request button visible to request owner when status is Open/Quoted
- Confirm modal before cancellation
- Cancelled badge on request summary card
- Accept buttons replaced with "Request cancelled" indicator after cancel

Tests:
- quote/test.sh: steps 14b–14g cover cancel flow, bid rejection, double-cancel
- quote.integration.test.ts: cancel mock + canister integration tests
- Candid contract snapshots updated for new method and Cancelled variant

## Summary
<!-- What does this PR do? -->

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [ ] Backend tests pass (`make test`)
- [ ] Frontend builds (`cd frontend && npm run build`)
- [ ] Tested locally with dfx

## Checklist
- [ ] Code follows project conventions
- [ ] Self-review completed
- [ ] No sensitive data committed
