### PR TITLE
fix(assets): add .ic-assets.json5 with standard security policy

### DIFF
--- a/frontend/public/.ic-assets.json5
+++ b/frontend/public/.ic-assets.json5
@@ -1,0 +1,6 @@
+[
+  {
+    "match": "**/*",
+    "security_policy": "standard"
+  }
+]


### PR DESCRIPTION
## Summary

- Adds `frontend/public/.ic-assets.json5` so Vite copies it into `frontend/dist/` at build time, where dfx reads it when uploading assets to the frontend canister
- Applies the `standard` security policy to all assets (`**/*`), which sets the recommended HTTP security headers (CSP, X-Frame-Options, etc.) on every served file
- Eliminates the dfx deployment warning about missing security policy configuration

## Test plan

- [ ] Run `make deploy` locally — verify no security policy warnings in dfx output
- [ ] Confirm `frontend/dist/.ic-assets.json5` exists after `npm run build`

Closes #110

🤖 Generated with [Claude Code](https://claude.ai/claude-code)