### PR TITLE
feat: remove mock seed data from service layer; add scripts/seed.sh (…

### DIFF
--- a/frontend/src/__tests__/services/quote.test.ts
+++ b/frontend/src/__tests__/services/quote.test.ts
@@ -31,16 +31,19 @@ describe("quoteService.getQuotaForTier", () => {
   });
 });
 
-// ─── getOpenRequests (fixed mock data) ───────────────────────────────────────
+// ─── getOpenRequests (mock — starts empty, populated by createRequest) ───────
 
 describe("quoteService.getOpenRequests (mock)", () => {
-  it("returns a non-empty list", async () => {
+  it("starts empty when no canister is deployed and no E2E data injected", async () => {
     const reqs = await quoteService.getOpenRequests();
-    expect(reqs.length).toBeGreaterThan(0);
+    expect(Array.isArray(reqs)).toBe(true);
   });
 
-  it("every request has required fields", async () => {
-    const reqs = await quoteService.getOpenRequests();
+  it("every request in the list has required fields", async () => {
+    // Use the stateful mock — create a request so we have something to validate
+    const svc = (await import("@/services/quote")).quoteService;
+    await svc.createRequest({ propertyId: "p", serviceType: "Electrical", urgency: "medium", description: "test" });
+    const reqs = await svc.getRequests(); // getOpenRequests uses a separate in-memory list
     for (const r of reqs) {
       expect(typeof r.id).toBe("string");
       expect(typeof r.propertyId).toBe("string");
@@ -58,11 +61,6 @@ describe("quoteService.getOpenRequests (mock)", () => {
     const b = await quoteService.getOpenRequests();
     expect(a).not.toBe(b);
     expect(a).toEqual(b);
-  });
-
-  it("contains at least one 'open' request", async () => {
-    const reqs = await quoteService.getOpenRequests();
-    expect(reqs.some((r) => r.status === "open")).toBe(true);
   });
 });
 
@@ -138,26 +136,24 @@ describe("quoteService mock — getRequests", () => {
     svc = m.quoteService;
   });
 
-  it("starts with the 3 pre-seeded demo requests", async () => {
+  it("starts empty when no seed data is present", async () => {
     const reqs = await svc.getRequests();
-    expect(reqs).toHaveLength(3);
-    expect(reqs.map((r) => r.id)).toContain("MY_REQ_1");
+    expect(reqs).toHaveLength(0);
   });
 
-  it("returns all pre-seeded + created requests", async () => {
+  it("returns created requests", async () => {
     await svc.createRequest({ propertyId: "p1", serviceType: "HVAC",    urgency: "high",   description: "d1" });
     await svc.createRequest({ propertyId: "p1", serviceType: "Roofing", urgency: "medium", description: "d2" });
     const reqs = await svc.getRequests();
-    expect(reqs).toHaveLength(5); // 3 pre-seeded + 2 created
+    expect(reqs).toHaveLength(2);
   });
 
   it("returns a copy — mutating result does not affect service state", async () => {
-    const before = (await svc.getRequests()).length; // 3 pre-seeded
     await svc.createRequest({ propertyId: "p1", serviceType: "HVAC", urgency: "high", description: "d1" });
     const first = await svc.getRequests();
     first.pop();
     const second = await svc.getRequests();
-    expect(second).toHaveLength(before + 1); // pop on copy doesn't affect internal state
+    expect(second).toHaveLength(1); // pop on copy doesn't affect internal state
   });
 });
 
@@ -354,14 +350,12 @@ describe("quoteService.sortByUrgency (12.2.3)", () => {
     expect(input.map((r) => r.urgency)).toEqual(original);
   });
 
-  it("emergency open request from seed data appears before lower-urgency ones when sorted", async () => {
-    const open = await quoteService.getOpenRequests();
-    const sorted = quoteService.sortByUrgency(open);
+  it("emergency request appears before high-urgency ones when sorted", () => {
+    const requests = [makeReq("high"), makeReq("emergency"), makeReq("medium")];
+    const sorted = quoteService.sortByUrgency(requests);
     const emergIdx = sorted.findIndex((r) => r.urgency === "emergency");
     const highIdx  = sorted.findIndex((r) => r.urgency === "high");
-    if (emergIdx !== -1 && highIdx !== -1) {
-      expect(emergIdx).toBeLessThan(highIdx);
-    }
+    expect(emergIdx).toBeLessThan(highIdx);
   });
 
   it("two requests with same urgency preserve relative order (stable sort)", () => {
@@ -382,49 +376,45 @@ describe("quoteService mock — tier quota enforcement (12.2.3)", () => {
     vi.resetModules();
     const m = await import("@/services/quote");
     svc = m.quoteService;
-    // Pre-seeded state: MY_REQ_1 (quoted), MY_REQ_2 (open), MY_REQ_3 (accepted)
-    // → 1 open request at start
+    // No pre-seeded state — mock starts empty after SEED data removal
   });
 
-  it("Free tier: 3rd open request succeeds", async () => {
-    // 1 pre-seeded open + 1 more = 2 open; add 1 more → 3 → should succeed
-    await svc.createRequest({ propertyId: "p", serviceType: "HVAC",    urgency: "low", description: "d" }, "Free");
+  it("Free tier: 3rd open request succeeds (limit = 3)", async () => {
+    await svc.createRequest({ propertyId: "p", serviceType: "HVAC",    urgency: "low", description: "d1" }, "Free");
+    await svc.createRequest({ propertyId: "p", serviceType: "Roofing", urgency: "low", description: "d2" }, "Free");
     await expect(
-      svc.createRequest({ propertyId: "p", serviceType: "Roofing", urgency: "low", description: "d" }, "Free")
+      svc.createRequest({ propertyId: "p", serviceType: "Plumbing", urgency: "low", description: "d3" }, "Free")
     ).resolves.toBeDefined();
   });
 
   it("Free tier: 4th open request throws QuotaExceeded", async () => {
-    // 1 pre-seeded open + 2 created = 3 open; next should be blocked
-    await svc.createRequest({ propertyId: "p", serviceType: "HVAC",    urgency: "low", description: "d" }, "Free");
-    await svc.createRequest({ propertyId: "p", serviceType: "Roofing", urgency: "low", description: "d" }, "Free");
+    for (let i = 0; i < 3; i++) {
+      await svc.createRequest({ propertyId: "p", serviceType: "HVAC", urgency: "low", description: `d${i}` }, "Free");
+    }
     await expect(
-      svc.createRequest({ propertyId: "p", serviceType: "Plumbing", urgency: "low", description: "d" }, "Free")
+      svc.createRequest({ propertyId: "p", serviceType: "Plumbing", urgency: "low", description: "d4" }, "Free")
     ).rejects.toThrow(/quota|limit reached/i);
   });
 
-  it("Pro tier: 10th open request succeeds", async () => {
-    // 1 pre-seeded + 8 created = 9; one more → 10, should succeed
-    for (let i = 0; i < 8; i++) {
-      await svc.createRequest({ propertyId: "p", serviceType: "HVAC", urgency: "low", description: `d${i}` }, "Pro");
-    }
-    await expect(
-      svc.createRequest({ propertyId: "p", serviceType: "Roofing", urgency: "low", description: "d9" }, "Pro")
-    ).resolves.toBeDefined();
-  });
-
-  it("Pro tier: 11th open request throws QuotaExceeded", async () => {
-    // 1 pre-seeded + 9 created = 10; next should be blocked
+  it("Pro tier: 10th open request succeeds (limit = 10)", async () => {
     for (let i = 0; i < 9; i++) {
       await svc.createRequest({ propertyId: "p", serviceType: "HVAC", urgency: "low", description: `d${i}` }, "Pro");
     }
     await expect(
-      svc.createRequest({ propertyId: "p", serviceType: "Plumbing", urgency: "low", description: "d10" }, "Pro")
+      svc.createRequest({ propertyId: "p", serviceType: "Roofing", urgency: "low", description: "d10" }, "Pro")
+    ).resolves.toBeDefined();
+  });
+
+  it("Pro tier: 11th open request throws QuotaExceeded", async () => {
+    for (let i = 0; i < 10; i++) {
+      await svc.createRequest({ propertyId: "p", serviceType: "HVAC", urgency: "low", description: `d${i}` }, "Pro");
+    }
+    await expect(
+      svc.createRequest({ propertyId: "p", serviceType: "Plumbing", urgency: "low", description: "d11" }, "Pro")
     ).rejects.toThrow(/quota|limit reached/i);
   });
 
   it("no tier argument → no quota check (backwards compat)", async () => {
-    // Create well past the Free quota of 3
     for (let i = 0; i < 5; i++) {
       await svc.createRequest({ propertyId: "p", serviceType: "HVAC", urgency: "low", description: `d${i}` });
     }
@@ -433,12 +423,19 @@ describe("quoteService mock — tier quota enforcement (12.2.3)", () => {
     ).resolves.toBeDefined();
   });
 
-  it("closed/accepted/quoted requests do not count toward the open quota", async () => {
-    // Pre-seed has 1 quoted + 1 accepted — they must NOT count toward the Free quota of 3
-    // 1 open pre-seeded; add 2 → 3 open; should still succeed (not blocked by 2 non-open seed items)
-    await svc.createRequest({ propertyId: "p", serviceType: "HVAC",    urgency: "low", description: "d1" }, "Free");
+  it("cancelled requests do not count toward the open quota", async () => {
+    // Create 2 requests, cancel them (mock cancel() updates status to "cancelled"),
+    // then verify a fresh Free quota of 3 is available.
+    const r1 = await svc.createRequest({ propertyId: "p", serviceType: "HVAC",    urgency: "low", description: "will cancel" });
+    const r2 = await svc.createRequest({ propertyId: "p", serviceType: "Roofing", urgency: "low", description: "will cancel" });
+    await svc.cancel(r1.id);
+    await svc.cancel(r2.id);
+    // 0 open — can now create 3 under Free quota
+    for (let i = 0; i < 3; i++) {
+      await svc.createRequest({ propertyId: "p", serviceType: "Plumbing",   urgency: "low", description: `open${i}` }, "Free");
+    }
     await expect(
-      svc.createRequest({ propertyId: "p", serviceType: "Roofing", urgency: "low", description: "d2" }, "Free")
-    ).resolves.toBeDefined();
+      svc.createRequest({ propertyId: "p", serviceType: "Electrical", urgency: "low", description: "4th" }, "Free")
+    ).rejects.toThrow(/quota|limit reached/i);
   });
 });

--- a/frontend/src/services/quote.ts
+++ b/frontend/src/services/quote.ts
@@ -120,57 +120,6 @@ export interface Quote {
   createdAt:  number;  // ms
 }
 
-// ─── Mock seed data (static fixtures for UI display) ─────────────────────────
-
-const SEED_MY_REQUESTS: QuoteRequest[] = [
-  { id: "MY_REQ_1", propertyId: "prop_1", homeowner: "local", serviceType: "HVAC",     urgency: "high",   description: "AC unit not cooling. 12-year-old unit — needs diagnosis.", status: "quoted",   createdAt: Date.now() - 86400000 * 3 },
-  { id: "MY_REQ_2", propertyId: "prop_1", homeowner: "local", serviceType: "Roofing",  urgency: "medium", description: "Several shingles missing after last storm. Small attic leak.", status: "open",     createdAt: Date.now() - 86400000 * 8 },
-  { id: "MY_REQ_3", propertyId: "prop_1", homeowner: "local", serviceType: "Plumbing", urgency: "low",    description: "Slow drain in master bathroom. Snaking hasn't resolved it.", status: "accepted", createdAt: Date.now() - 86400000 * 14 },
-];
-
-const SEED_MY_BIDS: Quote[] = [
-  { id: "QUOTE_101", requestId: "REQ_101", contractor: "local", amount: 185000, timeline: 3,  validUntil: Date.now() - 86400000 * 30, status: "accepted",  createdAt: Date.now() - 86400000 * 90 },
-  { id: "QUOTE_102", requestId: "REQ_102", contractor: "local", amount: 320000, timeline: 5,  validUntil: Date.now() - 86400000 * 20, status: "rejected",  createdAt: Date.now() - 86400000 * 75 },
-  { id: "QUOTE_103", requestId: "REQ_103", contractor: "local", amount: 95000,  timeline: 2,  validUntil: Date.now() - 86400000 * 10, status: "accepted",  createdAt: Date.now() - 86400000 * 60 },
-  { id: "QUOTE_104", requestId: "REQ_104", contractor: "local", amount: 440000, timeline: 7,  validUntil: Date.now() - 86400000 * 5,  status: "rejected",  createdAt: Date.now() - 86400000 * 45 },
-  { id: "QUOTE_105", requestId: "REQ_105", contractor: "local", amount: 210000, timeline: 4,  validUntil: Date.now() - 86400000 * 2,  status: "accepted",  createdAt: Date.now() - 86400000 * 30 },
-  { id: "QUOTE_106", requestId: "REQ_106", contractor: "local", amount: 75000,  timeline: 1,  validUntil: Date.now() + 86400000 * 10, status: "pending",   createdAt: Date.now() - 86400000 * 5  },
-  { id: "QUOTE_107", requestId: "REQ_107", contractor: "local", amount: 560000, timeline: 10, validUntil: Date.now() + 86400000 * 20, status: "pending",   createdAt: Date.now() - 86400000 * 2  },
-];
-
-const SEED_OPEN_REQUESTS: QuoteRequest[] = [
-  {
-    id: "REQ_1", propertyId: "prop_1", homeowner: "owner-principal-1",
-    serviceType: "HVAC", urgency: "high",
-    description: "AC unit stopped cooling last week. Unit is 12 years old. Needs diagnosis and likely refrigerant recharge or compressor inspection.",
-    status: "open", createdAt: Date.now() - 1000 * 60 * 60 * 3,
-  },
-  {
-    id: "REQ_2", propertyId: "prop_2", homeowner: "owner-principal-2",
-    serviceType: "Roofing", urgency: "medium",
-    description: "Several shingles missing after last storm. Small leak visible in attic near chimney flashing. Need repair estimate before next rain.",
-    status: "open", createdAt: Date.now() - 1000 * 60 * 60 * 18,
-  },
-  {
-    id: "REQ_3", propertyId: "prop_3", homeowner: "owner-principal-3",
-    serviceType: "Plumbing", urgency: "emergency",
-    description: "Pipe burst under kitchen sink — water shut off at main. Need emergency repair ASAP. 1960s copper piping throughout.",
-    status: "quoted", createdAt: Date.now() - 1000 * 60 * 30,
-  },
-  {
-    id: "REQ_4", propertyId: "prop_4", homeowner: "owner-principal-4",
-    serviceType: "Electrical", urgency: "medium",
-    description: "Breaker keeps tripping on kitchen circuit. GFCIs installed but issue persists. 200A panel, house built 1998.",
-    status: "open", createdAt: Date.now() - 1000 * 60 * 60 * 48,
-  },
-  {
-    id: "REQ_5", propertyId: "prop_5", homeowner: "owner-principal-5",
-    serviceType: "Flooring", urgency: "low",
-    description: "Refinish 900 sq ft of original hardwood oak floors. Some boards need replacement. Looking for quotes before scheduling.",
-    status: "open", createdAt: Date.now() - 1000 * 60 * 60 * 72,
-  },
-];
-
 // ─── Converters ───────────────────────────────────────────────────────────────
 
 const URGENCY_MAP: Record<string, Urgency> = {
@@ -224,9 +173,10 @@ function unwrapRequest(result: any): QuoteRequest {
 
 function createQuoteService() {
   let _actor: any = null;
-  const mockRequests: QuoteRequest[] = [...SEED_MY_REQUESTS];
-  const mockMyBids: Quote[]          = [...SEED_MY_BIDS];
-  const mockOpenRequests: QuoteRequest[] = [...SEED_OPEN_REQUESTS];
+  // E2E-only mock state — only populated via window.__e2e_* injection from Playwright
+  const mockRequests: QuoteRequest[] = [];
+  const mockMyBids: Quote[]          = [];
+  const mockOpenRequests: QuoteRequest[] = [];
   const mockQuotesByRequest = new Map<string, Quote[]>();
 
   async function getActor() {
@@ -274,7 +224,7 @@ function createQuoteService() {
 
   async getRequests(): Promise<QuoteRequest[]> {
     if (import.meta.env.DEV && !QUOTE_CANISTER_ID) {
-      // E2E override: replace seed data with injected fixture requests
+      // E2E: use Playwright-injected fixture requests when available
       const e2e = typeof window !== "undefined" && (window as any).__e2e_quote_requests;
       return e2e ? (e2e as QuoteRequest[]) : [...mockRequests];
     }
@@ -435,11 +385,8 @@ function createQuoteService() {
   reset() {
     _actor = null;
     mockRequests.length = 0;
-    mockRequests.push(...SEED_MY_REQUESTS);
     mockMyBids.length = 0;
-    mockMyBids.push(...SEED_MY_BIDS);
     mockOpenRequests.length = 0;
-    mockOpenRequests.push(...SEED_OPEN_REQUESTS);
     mockQuotesByRequest.clear();
   },
   };

--- a/scripts/seed.sh
+++ b/scripts/seed.sh
@@ -1,0 +1,384 @@
+#!/usr/bin/env bash
+# HomeGentic — Developer Seed Script
+#
+# Populates a freshly deployed set of canisters with realistic records so
+# developers can explore the app without having to create everything by hand.
+#
+# Usage:
+#   bash scripts/seed.sh                   # target local replica (default)
+#   bash scripts/seed.sh --network testnet # target deployed testnet
+#   bash scripts/seed.sh --network ic      # target mainnet (requires confirmation)
+#
+# Prerequisites:
+#   • dfx is running:  dfx start --background
+#   • Canisters deployed: bash scripts/deploy.sh
+set -euo pipefail
+
+# ─── Network ──────────────────────────────────────────────────────────────────
+
+NETWORK="local"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --network) NETWORK="${2:-local}"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+
+if [ "$NETWORK" = "ic" ]; then
+  echo ""
+  echo "⚠️  You are about to seed MAINNET (network: ic)."
+  read -rp "Type 'yes' to confirm: " CONFIRM
+  [ "$CONFIRM" = "yes" ] || { echo "Aborted."; exit 0; }
+fi
+
+NET_FLAG="--network $NETWORK"
+[ "$NETWORK" = "local" ] && NET_FLAG=""
+
+echo "============================================"
+echo "  HomeGentic — Seed Script ($NETWORK)"
+echo "============================================"
+
+if ! dfx ping $NET_FLAG 2>/dev/null; then
+  echo "❌ dfx is not reachable (network: $NETWORK)."
+  echo "   Run: dfx start --background  (for local)"
+  exit 1
+fi
+
+# ─── Identity helpers ─────────────────────────────────────────────────────────
+
+DEPLOYER_PRINCIPAL=$(dfx identity get-principal $NET_FLAG)
+echo "Deployer principal: $DEPLOYER_PRINCIPAL"
+
+# Create seed identities if they don't exist (local only — on ic/testnet use deployer)
+if [ "$NETWORK" = "local" ]; then
+  for ID in seed-homeowner-2 seed-contractor-1 seed-contractor-2 seed-realtor-1; do
+    dfx identity list 2>/dev/null | grep -q "^${ID}$" \
+      || dfx identity new "$ID" --disable-encryption 2>/dev/null || true
+  done
+fi
+
+get_principal() {
+  if [ "$NETWORK" = "local" ]; then
+    dfx identity get-principal --identity "$1"
+  else
+    dfx identity get-principal
+  fi
+}
+
+HO2_PRINCIPAL=$(get_principal seed-homeowner-2)
+C1_PRINCIPAL=$(get_principal seed-contractor-1)
+C2_PRINCIPAL=$(get_principal seed-contractor-2)
+RE_PRINCIPAL=$(get_principal seed-realtor-1)
+
+call() { dfx canister call $NET_FLAG "$@"; }
+if [ "$NETWORK" = "local" ]; then
+  call_as() { local id="$1"; shift; dfx canister call $NET_FLAG --identity "$id" "$@"; }
+else
+  # Non-local: ignore the identity argument, use active identity
+  call_as() { shift; dfx canister call $NET_FLAG "$@"; }
+fi
+
+# ─── §1  Auth — register profiles ─────────────────────────────────────────────
+
+echo ""
+echo "── [1] Auth — register profiles ────────────────────────────────────────"
+
+call auth register '(record { role = variant { Homeowner }; email = "alice@homegentic.dev"; phone = "512-555-0101" })' \
+  2>/dev/null || echo "  ↳ Deployer already registered (ok)"
+
+if [ "$NETWORK" = "local" ]; then
+  call_as seed-homeowner-2 auth register \
+    '(record { role = variant { Homeowner }; email = "bob@homegentic.dev"; phone = "512-555-0202" })' \
+    2>/dev/null || echo "  ↳ seed-homeowner-2 already registered (ok)"
+
+  call_as seed-contractor-1 auth register \
+    '(record { role = variant { Contractor }; email = "carlos@homegentic.dev"; phone = "512-555-0303" })' \
+    2>/dev/null || echo "  ↳ seed-contractor-1 already registered (ok)"
+
+  call_as seed-contractor-2 auth register \
+    '(record { role = variant { Contractor }; email = "diana@homegentic.dev"; phone = "512-555-0404" })' \
+    2>/dev/null || echo "  ↳ seed-contractor-2 already registered (ok)"
+
+  call_as seed-realtor-1 auth register \
+    '(record { role = variant { Realtor }; email = "ethan@homegentic.dev"; phone = "512-555-0505" })' \
+    2>/dev/null || echo "  ↳ seed-realtor-1 already registered (ok)"
+fi
+echo "  ↳ Auth profiles registered ✓"
+
+# ─── §2  Payment — grant Pro to deployer ──────────────────────────────────────
+
+echo ""
+echo "── [2] Payment — grant Pro to deployer ─────────────────────────────────"
+call payment grantSubscription "(principal \"$DEPLOYER_PRINCIPAL\", variant { Pro })"
+echo "  ↳ Deployer granted Pro ✓"
+
+# ─── §3  Property — register 3 properties ─────────────────────────────────────
+
+echo ""
+echo "── [3] Property — register properties ─────────────────────────────────"
+PROP1_OUT=$(call property registerProperty '(record {
+  address      = "123 Maple Street";
+  city         = "Austin";
+  state        = "TX";
+  zipCode      = "78701";
+  propertyType = variant { SingleFamily };
+  yearBuilt    = 2001;
+  squareFeet   = 2400;
+  tier         = variant { Pro };
+})')
+echo "$PROP1_OUT"
+PROP1_ID=$(echo "$PROP1_OUT" | grep -oP 'id = "\K[^"]+' | head -1 || true)
+echo "  → Property 1 (SingleFamily Austin): $PROP1_ID"
+
+PROP2_OUT=$(call property registerProperty '(record {
+  address      = "456 Oak Avenue";
+  city         = "Dallas";
+  state        = "TX";
+  zipCode      = "75201";
+  propertyType = variant { Condo };
+  yearBuilt    = 2015;
+  squareFeet   = 1100;
+  tier         = variant { Basic };
+})')
+echo "$PROP2_OUT"
+PROP2_ID=$(echo "$PROP2_OUT" | grep -oP 'id = "\K[^"]+' | head -1 || true)
+echo "  → Property 2 (Condo Dallas): $PROP2_ID"
+
+PROP3_OUT=$(call property registerProperty '(record {
+  address      = "789 Cedar Lane";
+  city         = "Houston";
+  state        = "TX";
+  zipCode      = "77001";
+  propertyType = variant { Townhouse };
+  yearBuilt    = 1998;
+  squareFeet   = 1800;
+  tier         = variant { Free };
+})')
+echo "$PROP3_OUT"
+PROP3_ID=$(echo "$PROP3_OUT" | grep -oP 'id = "\K[^"]+' | head -1 || true)
+echo "  → Property 3 (Townhouse Houston): $PROP3_ID"
+
+# ─── §4  Contractor — register profiles ───────────────────────────────────────
+
+echo ""
+echo "── [4] Contractor — register profiles ──────────────────────────────────"
+
+if [ "$NETWORK" = "local" ]; then
+  call_as seed-contractor-1 contractor register '(record {
+    name        = "Carlos Ramirez HVAC";
+    specialties = vec { variant { HVAC }; variant { Plumbing } };
+    email       = "carlos@homegentic.dev";
+    phone       = "512-555-0303";
+  })' 2>/dev/null || echo "  ↳ contractor-1 already registered (ok)"
+
+  call_as seed-contractor-2 contractor register '(record {
+    name        = "Diana Park Roofing";
+    specialties = vec { variant { Roofing }; variant { Gutters }; variant { Windows } };
+    email       = "diana@homegentic.dev";
+    phone       = "512-555-0404";
+  })' 2>/dev/null || echo "  ↳ contractor-2 already registered (ok)"
+  echo "  ↳ Contractor profiles registered ✓"
+else
+  echo "  ↳ Skipping separate contractor identities on non-local network"
+fi
+
+# ─── §5  Jobs — create sample job history ─────────────────────────────────────
+# completedDate uses Unix timestamp in nanoseconds.  These are past dates.
+
+echo ""
+echo "── [5] Jobs — create sample history ───────────────────────────────────"
+
+# Skip if no property was registered (e.g. Pro limit already hit on re-run)
+if [ -n "$PROP1_ID" ]; then
+  # 2024-03-15  HVAC replacement  — verified DIY-false
+  PAST_90=$(python3 -c "import time; print(int((time.time()-90*86400)*1e9))" 2>/dev/null \
+    || node -e "process.stdout.write(String(BigInt(Math.floor((Date.now()-90*86400000))*1000000)))" 2>/dev/null \
+    || echo "1710460800000000000")
+
+  # 2024-06-20  Roof repair
+  PAST_60=$(python3 -c "import time; print(int((time.time()-60*86400)*1e9))" 2>/dev/null \
+    || node -e "process.stdout.write(String(BigInt(Math.floor((Date.now()-60*86400000))*1000000)))" 2>/dev/null \
+    || echo "1718841600000000000")
+
+  # 2024-08-10  Plumbing — DIY
+  PAST_30=$(python3 -c "import time; print(int((time.time()-30*86400)*1e9))" 2>/dev/null \
+    || node -e "process.stdout.write(String(BigInt(Math.floor((Date.now()-30*86400000))*1000000)))" 2>/dev/null \
+    || echo "1722816000000000000")
+
+  # 2024-09-01  Painting — recent
+  PAST_7=$(python3 -c "import time; print(int((time.time()-7*86400)*1e9))" 2>/dev/null \
+    || node -e "process.stdout.write(String(BigInt(Math.floor((Date.now()-7*86400000))*1000000)))" 2>/dev/null \
+    || echo "1725148800000000000")
+
+  call job createJob "(
+    \"$PROP1_ID\",
+    \"HVAC System Replacement\",
+    variant { HVAC },
+    \"Full HVAC system replacement — old unit failed after 18 years. New Carrier 5-ton unit installed.\",
+    opt \"Carlos Ramirez HVAC\",
+    240000,
+    $PAST_90,
+    null,
+    opt 24,
+    false,
+    null
+  )" 2>/dev/null || echo "  ↳ Job 1 skipped (ok)"
+
+  call job createJob "(
+    \"$PROP1_ID\",
+    \"Roof Repair — Storm Damage\",
+    variant { Roofing },
+    \"Replaced 12 damaged shingles and repaired flashing around chimney after hail storm.\",
+    opt \"Diana Park Roofing\",
+    85000,
+    $PAST_60,
+    null,
+    opt 12,
+    false,
+    null
+  )" 2>/dev/null || echo "  ↳ Job 2 skipped (ok)"
+
+  call job createJob "(
+    \"$PROP1_ID\",
+    \"Kitchen Sink Plumbing Fix\",
+    variant { Plumbing },
+    \"Replaced P-trap and supply lines under kitchen sink. Resolved slow drain.\",
+    null,
+    0,
+    $PAST_30,
+    null,
+    null,
+    true,
+    null
+  )" 2>/dev/null || echo "  ↳ Job 3 (DIY) skipped (ok)"
+
+  call job createJob "(
+    \"$PROP1_ID\",
+    \"Interior Painting — Living Room\",
+    variant { Painting },
+    \"Repainted living room and hallway. Two coats Sherwin-Williams Alabaster.\",
+    null,
+    0,
+    $PAST_7,
+    null,
+    null,
+    true,
+    null
+  )" 2>/dev/null || echo "  ↳ Job 4 (DIY) skipped (ok)"
+
+  echo "  ↳ Jobs created ✓"
+else
+  echo "  ↳ No PROP1_ID — skipping job creation"
+fi
+
+# ─── §6  Quote — open requests + a sample bid ─────────────────────────────────
+
+echo ""
+echo "── [6] Quote — open requests + bid ────────────────────────────────────"
+
+if [ -n "$PROP1_ID" ]; then
+  REQ_OUT=$(call quote createQuoteRequest "(
+    \"$PROP1_ID\",
+    variant { Electrical },
+    \"Breaker keeps tripping on kitchen circuit. GFCIs installed but issue persists. 200A panel, house built 1998.\",
+    variant { Medium }
+  )" 2>/dev/null || echo "")
+  echo "$REQ_OUT"
+  REQ1_ID=$(echo "$REQ_OUT" | grep -oP '"REQ_[^"]+"' | head -1 | tr -d '"' || true)
+  echo "  → Quote request 1: $REQ1_ID"
+
+  if [ -n "$PROP2_ID" ]; then
+    call quote createQuoteRequest "(
+      \"$PROP2_ID\",
+      variant { Plumbing },
+      \"Slow drain in master bathroom. Snaking has not resolved it — may need hydro-jetting.\",
+      variant { Low }
+    )" 2>/dev/null || echo "  ↳ Quote request 2 skipped (ok)"
+  fi
+
+  # Contractor submits a bid (local only — needs separate identity)
+  if [ "$NETWORK" = "local" ] && [ -n "$REQ1_ID" ]; then
+    VALID_UNTIL=$(python3 -c "import time; print(int((time.time()+30*86400)*1e9))" 2>/dev/null \
+      || node -e "process.stdout.write(String(BigInt(Math.floor((Date.now()+30*86400000))*1000000)))" 2>/dev/null \
+      || echo "1893456000000000000")
+    call_as seed-contractor-1 quote submitQuote "(
+      \"$REQ1_ID\",
+      38000,
+      2,
+      $VALID_UNTIL
+    )" 2>/dev/null && echo "  ↳ Contractor bid submitted ✓" || echo "  ↳ Bid submission skipped (ok)"
+  fi
+  echo "  ↳ Quote requests created ✓"
+else
+  echo "  ↳ No PROP1_ID — skipping quote creation"
+fi
+
+# ─── §7  Listing — FSBO listing ───────────────────────────────────────────────
+
+echo ""
+echo "── [7] Listing — FSBO bid request ─────────────────────────────────────"
+
+LISTING_CANISTER=$(dfx canister id listing $NET_FLAG 2>/dev/null || echo "")
+if [ -z "$LISTING_CANISTER" ]; then
+  echo "  ↳ listing canister not deployed — skipping"
+elif [ -n "$PROP3_ID" ]; then
+  DEADLINE=$(python3 -c "import time; print(int((time.time()+14*86400)*1e9))" 2>/dev/null \
+    || node -e "process.stdout.write(String(BigInt(Math.floor((Date.now()+14*86400000))*1000000)))" 2>/dev/null \
+    || echo "1727308800000000000")
+  TARGET_LIST=$(python3 -c "import time; print(int((time.time()+60*86400)*1e9))" 2>/dev/null \
+    || node -e "process.stdout.write(String(BigInt(Math.floor((Date.now()+60*86400000))*1000000)))" 2>/dev/null \
+    || echo "1735862400000000000")
+
+  call listing createBidRequest "(
+    \"$PROP3_ID\",
+    $TARGET_LIST,
+    opt (32500000 : nat),
+    \"3BR/2BA townhouse in Midtown Houston. Updated kitchen, new roof 2022. Looking for experienced agents.\",
+    $DEADLINE
+  )" 2>/dev/null && echo "  ↳ FSBO bid request created ✓" || echo "  ↳ Listing creation skipped (ok)"
+else
+  echo "  ↳ No PROP3_ID — skipping listing creation"
+fi
+
+# ─── §8  Recurring — sample service contracts ─────────────────────────────────
+
+echo ""
+echo "── [8] Recurring — service contracts ──────────────────────────────────"
+
+RECURRING_CANISTER=$(dfx canister id recurring $NET_FLAG 2>/dev/null || echo "")
+if [ -z "$RECURRING_CANISTER" ]; then
+  echo "  ↳ recurring canister not deployed — skipping"
+elif [ -n "$PROP1_ID" ]; then
+  call recurring createRecurringService "(
+    \"$PROP1_ID\",
+    variant { LawnCare },
+    \"Green Thumb Lawns\",
+    null,
+    \"512-555-0600\",
+    variant { Monthly },
+    \"2025-01-01\",
+    opt \"2025-12-31\",
+    opt \"Monthly mow + edge trim\"
+  )" 2>/dev/null && echo "  ↳ Recurring LawnCare created ✓" || echo "  ↳ Recurring creation skipped (ok)"
+else
+  echo "  ↳ No PROP1_ID — skipping recurring creation"
+fi
+
+# ─── Done ─────────────────────────────────────────────────────────────────────
+
+echo ""
+echo "============================================"
+echo "  ✅ Seed complete!"
+echo "============================================"
+echo ""
+echo "Records created:"
+echo "  • Auth:       1–5 user profiles"
+echo "  • Payment:    Pro subscription for deployer"
+echo "  • Property:   3 properties ($PROP1_ID, $PROP2_ID, $PROP3_ID)"
+echo "  • Jobs:       4 jobs (2 contractor, 2 DIY)"
+echo "  • Contractor: 2 profiles"
+echo "  • Quote:      2 open requests + 1 bid"
+echo "  • Listing:    1 FSBO bid request"
+echo "  • Recurring:  1 service contract"
+echo ""
+echo "To reset and re-seed: make clean && make deploy && bash scripts/seed.sh"


### PR DESCRIPTION
…#117)

Part 1 — Remove mock data:
- Drop SEED_MY_REQUESTS, SEED_MY_BIDS, SEED_OPEN_REQUESTS from quote.ts (3 arrays, ~20 hardcoded records that shipped to production builds)
- Mock state now starts empty; populated only via window.__e2e_* injection (Playwright E2E tests) or by user actions in dev mode
- reset() no longer re-seeds from static constants

Part 2 — Developer seed script:
- Add scripts/seed.sh: single command to populate a fresh local deployment with realistic homeowner/contractor profiles, 3 properties, 4 jobs (2 DIY), 2 contractor profiles, 2 quote requests + 1 bid, 1 FSBO listing, 1 recurring service
- Supports --network local|testnet|ic (ic requires explicit confirmation)

Part 3 — Update tests:
- quote.test.ts: rewrite tests that assumed 3 pre-seeded requests existed; tier quota tests now use correct counts against empty initial state; sortByUrgency seed-data test replaced with inline data

## Summary
<!-- What does this PR do? -->

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [ ] Backend tests pass (`make test`)
- [ ] Frontend builds (`cd frontend && npm run build`)
- [ ] Tested locally with dfx

## Checklist
- [ ] Code follows project conventions
- [ ] Self-review completed
- [ ] No sensitive data committed
