### PR TITLE
fix(deploy): export DFX_NETWORK before frontend build

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -477,6 +477,7 @@ echo "============================================"
 # gen-ic-assets.mjs which substitutes VITE_VOICE_AGENT_URL into the CSP header
 # written to dist/.ic-assets.json5 — that file must exist before the next step.
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+export DFX_NETWORK="$NETWORK"
 echo "▶ npm run build (frontend)..."
 if (cd "$REPO_ROOT/frontend" && npm run build); then
   echo "  ✓ Frontend built (dist/ + .ic-assets.json5 ready)"


### PR DESCRIPTION
## Summary
- Exports `DFX_NETWORK="$NETWORK"` immediately before `npm run build` in `scripts/deploy.sh`
- Fixes the silent failure where testnet deploys baked in `"local"` network assumptions because `DFX_NETWORK` was unset when Vite ran

Closes #100

## Test plan
- [ ] `bash scripts/deploy.sh local` — `DFX_NETWORK=local` visible in build output, no regression
- [ ] `bash scripts/deploy.sh testnet` — `DFX_NETWORK=testnet` propagated to Vite, canister IDs reference testnet network

🤖 Generated with [Claude Code](https://claude.com/claude-code)