### PR TITLE
refactor(auth): adopt centralized isAuthorized() across cross-canister callers

### DIFF
--- a/backend/job/main.mo
+++ b/backend/job/main.mo
@@ -191,6 +191,19 @@ persistent actor Job {
     #ok(())
   };
 
+  /// Delegate property-ownership check to the property canister.
+  /// Falls back to direct principal comparison when propCanisterId is unset (local dev).
+  private func checkPropertyAuth(propertyId: Text, owner: Principal, caller: Principal, requireWrite: Bool) : async Bool {
+    if (Text.size(propCanisterId) > 0) {
+      let propActor = actor(propCanisterId) : actor {
+        isAuthorized : (Text, Principal, Bool) -> async Bool;
+      };
+      await propActor.isAuthorized(propertyId, caller, requireWrite)
+    } else {
+      caller == owner
+    }
+  };
+
   private func nextJobId() : Text {
     jobCounter += 1;
     "JOB_" # Nat.toText(jobCounter)
@@ -331,8 +344,10 @@ persistent actor Job {
       case null { #err(#NotFound) };
       case (?existing) {
         if (existing.verified) return #err(#AlreadyVerified);
-        if (existing.homeowner != msg.caller and not isAdmin(msg.caller))
-          return #err(#Unauthorized);
+        if (not isAdmin(msg.caller)) {
+          let ok = await checkPropertyAuth(existing.propertyId, existing.homeowner, msg.caller, true);
+          if (not ok) return #err(#Unauthorized);
+        };
 
         let updated: Job = {
           id               = existing.id;
@@ -370,7 +385,8 @@ persistent actor Job {
       case null { #err(#NotFound) };
       case (?existing) {
         if (existing.verified) return #err(#AlreadyVerified);
-        if (existing.homeowner != msg.caller) return #err(#Unauthorized);
+        let authOk = await checkPropertyAuth(existing.propertyId, existing.homeowner, msg.caller, true);
+        if (not authOk) return #err(#Unauthorized);
         if (existing.isDiy) return #err(#InvalidInput("Cannot link contractor to a DIY job"));
 
         let updated: Job = {
@@ -414,10 +430,12 @@ persistent actor Job {
         if (existing.verified) return #err(#AlreadyVerified);
 
         let caller       = msg.caller;
-        let isHomeowner  = caller == existing.homeowner;
         let isContractor = switch (existing.contractor) {
           case null    { false };
           case (?con)  { caller == con };
+        };
+        let isHomeowner = if (isContractor) false else {
+          await checkPropertyAuth(existing.propertyId, existing.homeowner, caller, true)
         };
 
         if (not isHomeowner and not isContractor) return #err(#Unauthorized);
@@ -755,7 +773,8 @@ persistent actor Job {
       case (?j)    { j };
     };
 
-    if (job.homeowner != msg.caller) return #err(#Unauthorized);
+    let invOk = await checkPropertyAuth(job.propertyId, job.homeowner, msg.caller, true);
+    if (not invOk) return #err(#Unauthorized);
     if (job.isDiy)                   return #err(#InvalidInput("DIY jobs do not require contractor signature"));
     if (job.contractorSigned)        return #err(#InvalidInput("Contractor has already signed this job"));
 
@@ -965,7 +984,8 @@ persistent actor Job {
       case (?j)    { j };
     };
 
-    if (existing.homeowner != msg.caller) return #err(#Unauthorized);
+    let approveOk = await checkPropertyAuth(existing.propertyId, existing.homeowner, msg.caller, true);
+    if (not approveOk) return #err(#Unauthorized);
     if (existing.status != #PendingHomeownerApproval) return #err(#InvalidInput("Job is not pending approval"));
 
     let updated : Job = {
@@ -1003,7 +1023,8 @@ persistent actor Job {
       case (?j)    { j };
     };
 
-    if (existing.homeowner != msg.caller) return #err(#Unauthorized);
+    let rejectOk = await checkPropertyAuth(existing.propertyId, existing.homeowner, msg.caller, true);
+    if (not rejectOk) return #err(#Unauthorized);
     if (existing.status != #PendingHomeownerApproval) return #err(#InvalidInput("Job is not pending approval"));
 
     Map.remove(jobs, Text.compare, jobId);

--- a/backend/job/test.sh
+++ b/backend/job/test.sh
@@ -27,6 +27,38 @@ fi
 CONTRACTOR_PRINCIPAL=$(dfx identity get-principal --identity contractor-test)
 echo "Contractor test principal: $CONTRACTOR_PRINCIPAL"
 
+# ── Register a test property so cross-canister auth checks have a real target ─
+# When the job canister has propCanisterId wired (e.g. after deploy.sh), calls
+# like verifyJob/linkContractor/createInviteToken delegate to
+# property.isAuthorized(propertyId, ...).  The property must exist and be owned
+# by the caller, otherwise the check returns false → Unauthorized.
+PROPERTY_CANISTER_ID=$(dfx canister id property 2>/dev/null || echo "")
+if [ -n "$PROPERTY_CANISTER_ID" ]; then
+  MY_PRINCIPAL=$(dfx identity get-principal)
+  dfx canister call payment grantSubscription \
+    "(principal \"$MY_PRINCIPAL\", variant { Premium })" > /dev/null 2>&1 || true
+  SETUP_PROP_OUT=$(dfx canister call property registerProperty '(record {
+    address      = "1 Job Test Drive";
+    city         = "Austin";
+    state        = "TX";
+    zipCode      = "78701";
+    propertyType = variant { SingleFamily };
+    yearBuilt    = 2000;
+    squareFeet   = 2000;
+    tier         = variant { Premium };
+  })')
+  TEST_PROP_ID=$(echo "$SETUP_PROP_OUT" | grep -oP 'id = "\K[^"]+' | head -1 || echo "")
+  if [ -z "$TEST_PROP_ID" ]; then
+    echo "  ↳ ❌ Could not register test property — auth-dependent tests may fail"
+    TEST_PROP_ID="PROP_1"
+  else
+    echo "  → Test property registered: $TEST_PROP_ID"
+  fi
+else
+  # Property canister not deployed — job canister falls back to caller == owner
+  TEST_PROP_ID="PROP_1"
+fi
+
 # ─── Metrics (initial state) ──────────────────────────────────────────────────
 echo ""
 echo "── [1] Get metrics (initial state) ─────────────────────────────────────"
@@ -35,19 +67,19 @@ dfx canister call $CANISTER getMetrics
 # ─── Create a contractor job ──────────────────────────────────────────────────
 echo ""
 echo "── [2] Create contractor job (HVAC) ────────────────────────────────────"
-JOB_OUT=$(dfx canister call $CANISTER createJob '(
-  "PROP_1",
-  "HVAC Replacement",
+JOB_OUT=$(dfx canister call $CANISTER createJob "(
+  \"$TEST_PROP_ID\",
+  \"HVAC Replacement\",
   variant { HVAC },
-  "Full HVAC system replacement — 3-ton Carrier unit.",
-  opt "Cool Air Services",
+  \"Full HVAC system replacement — 3-ton Carrier unit.\",
+  opt \"Cool Air Services\",
   240000,
   1718409600000000000,
-  opt "HVAC-2024-0412",
+  opt \"HVAC-2024-0412\",
   opt 120,
   false,
   null
-)')
+)")
 echo "$JOB_OUT"
 JOB_ID=$(echo "$JOB_OUT" | grep -oP '"JOB_[0-9]+"' | head -1 | tr -d '"')
 echo "  → Job ID: $JOB_ID"
@@ -55,11 +87,11 @@ echo "  → Job ID: $JOB_ID"
 # ─── Create a DIY job ─────────────────────────────────────────────────────────
 echo ""
 echo "── [3] Create DIY job (Painting) ───────────────────────────────────────"
-DIY_OUT=$(dfx canister call $CANISTER createJob '(
-  "PROP_1",
-  "Interior Painting",
+DIY_OUT=$(dfx canister call $CANISTER createJob "(
+  \"$TEST_PROP_ID\",
+  \"Interior Painting\",
   variant { Painting },
-  "Living room and hallway — Benjamin Moore Chantilly Lace.",
+  \"Living room and hallway — Benjamin Moore Chantilly Lace.\",
   null,
   0,
   1722816000000000000,
@@ -67,7 +99,7 @@ DIY_OUT=$(dfx canister call $CANISTER createJob '(
   null,
   true,
   null
-)')
+)")
 echo "$DIY_OUT"
 DIY_ID=$(echo "$DIY_OUT" | grep -oP '"JOB_[0-9]+"' | head -1 | tr -d '"')
 echo "  → DIY Job ID: $DIY_ID"
@@ -75,32 +107,32 @@ echo "  → DIY Job ID: $DIY_ID"
 # ─── Create additional jobs for multi-job listing test (12.4.3) ───────────────
 echo ""
 echo "── [4] Create additional jobs for listing test (12.4.3) ─────────────────"
-dfx canister call $CANISTER createJob '(
-  "PROP_1",
-  "Roof Inspection",
+dfx canister call $CANISTER createJob "(
+  \"$TEST_PROP_ID\",
+  \"Roof Inspection\",
   variant { Roofing },
-  "Annual roof inspection after storm season.",
-  opt "Top Roof Co",
+  \"Annual roof inspection after storm season.\",
+  opt \"Top Roof Co\",
   85000,
   1714521600000000000,
   null,
   opt 24,
   false,
   null
-)' > /dev/null
-dfx canister call $CANISTER createJob '(
-  "PROP_1",
-  "Plumbing Repair",
+)" > /dev/null
+dfx canister call $CANISTER createJob "(
+  \"$TEST_PROP_ID\",
+  \"Plumbing Repair\",
   variant { Plumbing },
-  "Fixed leaking pipe under kitchen sink.",
-  opt "Flow Masters",
+  \"Fixed leaking pipe under kitchen sink.\",
+  opt \"Flow Masters\",
   45000,
   1716249600000000000,
   null,
   null,
   false,
   null
-)' > /dev/null
+)" > /dev/null
 echo "  → 2 additional jobs created"
 
 # ─── Get job by ID ────────────────────────────────────────────────────────────
@@ -111,7 +143,7 @@ dfx canister call $CANISTER getJob "(\"$JOB_ID\")"
 # ─── Get all jobs for property — should list all 4 (12.4.3) ──────────────────
 echo ""
 echo "── [6] getJobsForProperty — expect 4 jobs (12.4.3) ─────────────────────"
-PROP_JOBS=$(dfx canister call $CANISTER getJobsForProperty '("PROP_1")')
+PROP_JOBS=$(dfx canister call $CANISTER getJobsForProperty "(\"$TEST_PROP_ID\")")
 echo "$PROP_JOBS"
 JOB_COUNT=$(echo "$PROP_JOBS" | grep -c 'JOB_' || true)
 echo "  → Found $JOB_COUNT job entries"
@@ -205,19 +237,19 @@ dfx canister call $CANISTER createJob "(
 # $JOB_ID is already fully signed by step [13] — createInviteToken rejects signed jobs.
 echo ""
 echo "── [18-setup] Create fresh unsigned contractor job for invite token flow ──"
-INVITE_JOB_OUT=$(dfx canister call $CANISTER createJob '(
-  "PROP_1",
-  "Electrical panel upgrade",
+INVITE_JOB_OUT=$(dfx canister call $CANISTER createJob "(
+  \"$TEST_PROP_ID\",
+  \"Electrical panel upgrade\",
   variant { Electrical },
-  "Replace 100A panel with 200A service.",
-  opt "Invite Flow Electric",
+  \"Replace 100A panel with 200A service.\",
+  opt \"Invite Flow Electric\",
   75000,
   1700000000000000000,
   null,
   null,
   false,
   null
-)')
+)")
 echo "$INVITE_JOB_OUT"
 INVITE_JOB_ID=$(echo "$INVITE_JOB_OUT" | grep -oP '"JOB_[0-9]+"' | head -1 | tr -d '"')
 echo "  → Fresh job ID: $INVITE_JOB_ID"
@@ -708,19 +740,19 @@ else
   # Manager (Free tier) tries to create a job for a property they do NOT manage → SHOULD FAIL
   echo ""
   echo "── [MGR-5] Manager creates job for unrelated property → expect TierLimitReached ─"
-  UNAUTH_OUT=$(dfx canister call $CANISTER createJob '(
-    "PROP_1",
-    "Unauthorized job",
+  UNAUTH_OUT=$(dfx canister call $CANISTER createJob "(
+    \"$TEST_PROP_ID\",
+    \"Unauthorized job\",
     variant { Plumbing },
-    "Manager should be blocked on a property they do not manage.",
-    opt "Random Co",
+    \"Manager should be blocked on a property they do not manage.\",
+    opt \"Random Co\",
     10000,
     1718409600000000000,
     null,
     null,
     false,
     null
-  )' --identity manager-test)
+  )" --identity manager-test)
   echo "$UNAUTH_OUT"
   if echo "$UNAUTH_OUT" | grep -qiE "TierLimitReached|err"; then
     echo "  ✓ Free-tier manager blocked on unrelated property (tier check applies)"

--- a/backend/maintenance/main.mo
+++ b/backend/maintenance/main.mo
@@ -127,6 +127,8 @@ persistent actor Maintenance {
   private var isPaused: Bool = false;
   private var pauseExpiryNs: ?Int = null;
   private var adminListEntries: [Principal] = [];
+  /// Property canister ID — set post-deploy via setPropertyCanisterId().
+  private var propCanisterId: Text = "";
   // ─── Stable State ────────────────────────────────────────────────────────────
 
   private let schedule = Map.empty<Text, ScheduleEntry>();
@@ -170,6 +172,19 @@ persistent actor Maintenance {
       return #err(#InvalidInput("Rate limit exceeded. Max " # Nat.toText(maxUpdatesPerMin) # " update calls per minute per principal."))
     };
     #ok(())
+  };
+
+  /// Delegate property-ownership check to the property canister.
+  /// Falls back to direct principal comparison when propCanisterId is unset (local dev).
+  private func checkPropertyAuth(propertyId: Text, owner: Principal, caller: Principal, requireWrite: Bool) : async Bool {
+    if (Text.size(propCanisterId) > 0) {
+      let propActor = actor(propCanisterId) : actor {
+        isAuthorized : (Text, Principal, Bool) -> async Bool;
+      };
+      await propActor.isAuthorized(propertyId, caller, requireWrite)
+    } else {
+      caller == owner
+    }
   };
 
   private func currentYear() : Nat {
@@ -323,8 +338,10 @@ persistent actor Maintenance {
     switch (Map.get(schedule, Text.compare, entryId)) {
       case null { #err(#NotFound) };
       case (?entry) {
-        if (entry.createdBy != msg.caller and not isAdmin(msg.caller))
-          return #err(#Unauthorized);
+        if (not isAdmin(msg.caller)) {
+          let authOk = await checkPropertyAuth(entry.propertyId, entry.createdBy, msg.caller, true);
+          if (not authOk) return #err(#Unauthorized);
+        };
         let updated : ScheduleEntry = {
           id                 = entry.id;
           propertyId         = entry.propertyId;
@@ -344,6 +361,14 @@ persistent actor Maintenance {
   };
 
   // ─── Admin Functions ──────────────────────────────────────────────────────────
+
+  /// Wire the property canister for centralized ownership checks.
+  /// Must be called once after deploy by an admin.
+  public shared(msg) func setPropertyCanisterId(id: Principal) : async Result.Result<(), Error> {
+    if (not isAdmin(msg.caller)) return #err(#Unauthorized);
+    propCanisterId := Principal.toText(id);
+    #ok(())
+  };
 
   /// Set the update-call rate limit (admin only). Pass 0 to disable enforcement.
   public shared(msg) func setUpdateRateLimit(n: Nat) : async Result.Result<(), Error> {

--- a/backend/photo/main.mo
+++ b/backend/photo/main.mo
@@ -153,6 +153,19 @@ persistent actor Photo {
     #ok(())
   };
 
+  /// Delegate property-ownership check to the property canister.
+  /// Falls back to direct principal comparison when propCanisterId is unset (local dev).
+  private func checkPropertyAuth(propertyId: Text, owner: Principal, caller: Principal, requireWrite: Bool) : async Bool {
+    if (Text.size(propCanisterId) > 0) {
+      let propActor = actor(propCanisterId) : actor {
+        isAuthorized : (Text, Principal, Bool) -> async Bool;
+      };
+      await propActor.isAuthorized(propertyId, caller, requireWrite)
+    } else {
+      caller == owner
+    }
+  };
+
   private func nextPhotoId() : Text {
     photoCounter += 1;
     "PHOTO_" # Nat.toText(photoCounter)
@@ -331,8 +344,10 @@ persistent actor Photo {
     switch (Map.get(photos, Text.compare, photoId)) {
       case null  { #err(#NotFound) };
       case (?p)  {
-        if (p.owner != msg.caller and not isAdmin(msg.caller))
-          return #err(#Unauthorized);
+        if (not isAdmin(msg.caller)) {
+          let authOk = await checkPropertyAuth(p.propertyId, p.owner, msg.caller, false);
+          if (not authOk) return #err(#Unauthorized);
+        };
         #ok(p)
       };
     }
@@ -344,8 +359,10 @@ persistent actor Photo {
     switch (Map.get(photos, Text.compare, photoId)) {
       case null  { #err(#NotFound) };
       case (?p)  {
-        if (p.owner != msg.caller and not isAdmin(msg.caller))
-          return #err(#Unauthorized);
+        if (not isAdmin(msg.caller)) {
+          let authOk = await checkPropertyAuth(p.propertyId, p.owner, msg.caller, false);
+          if (not authOk) return #err(#Unauthorized);
+        };
         #ok(p.data)
       };
     }
@@ -398,8 +415,10 @@ persistent actor Photo {
     switch (Map.get(photos, Text.compare, photoId)) {
       case null { #err(#NotFound) };
       case (?existing) {
-        if (existing.owner != msg.caller and not isAdmin(msg.caller))
-          return #err(#Unauthorized);
+        if (not isAdmin(msg.caller)) {
+          let authOk = await checkPropertyAuth(existing.propertyId, existing.owner, msg.caller, true);
+          if (not authOk) return #err(#Unauthorized);
+        };
 
         let alreadyApproved = Option.isSome(
           Array.find<Principal>(existing.approvals, func(a) { a == msg.caller })
@@ -433,8 +452,10 @@ persistent actor Photo {
     switch (Map.get(photos, Text.compare, photoId)) {
       case null { #err(#NotFound) };
       case (?existing) {
-        if (existing.owner != msg.caller and not isAdmin(msg.caller))
-          return #err(#Unauthorized);
+        if (not isAdmin(msg.caller)) {
+          let authOk = await checkPropertyAuth(existing.propertyId, existing.owner, msg.caller, true);
+          if (not authOk) return #err(#Unauthorized);
+        };
         Map.remove(photos, Text.compare, photoId);
         Map.remove(hashIndex, Text.compare, existing.hash);
         #ok(())

--- a/backend/property/main.mo
+++ b/backend/property/main.mo
@@ -1203,9 +1203,7 @@ persistent actor Property {
 
   /// Public query: returns true if `caller` is the owner OR an authorised manager.
   /// `requireWrite` = true means #Viewer role is not sufficient.
-  /// Called cross-canister by job, photo, quote, etc. canisters for auth checks.
-  // TODO: update job/photo/quote/maintenance canisters to call this instead of
-  //       checking caller == owner directly.
+  /// Called cross-canister by job, photo, quote, and maintenance canisters for auth checks.
   public query func isAuthorized(
     propertyId  : Text,
     caller      : Principal,

--- a/backend/quote/main.mo
+++ b/backend/quote/main.mo
@@ -195,6 +195,19 @@ persistent actor Quote {
     #ok(())
   };
 
+  /// Delegate property-ownership check to the property canister.
+  /// Falls back to direct principal comparison when propCanisterId is unset (local dev).
+  private func checkPropertyAuth(propertyId: Text, owner: Principal, caller: Principal, requireWrite: Bool) : async Bool {
+    if (Text.size(propCanisterId) > 0) {
+      let propActor = actor(propCanisterId) : actor {
+        isAuthorized : (Text, Principal, Bool) -> async Bool;
+      };
+      await propActor.isAuthorized(propertyId, caller, requireWrite)
+    } else {
+      caller == owner
+    }
+  };
+
   private func nextReqId() : Text {
     reqCounter += 1;
     "REQ_" # Nat.toText(reqCounter)
@@ -476,7 +489,8 @@ persistent actor Quote {
         switch (Map.get(requests, Text.compare, q.requestId)) {
           case null { return #err(#NotFound) };
           case (?req) {
-            if (req.homeowner != msg.caller) return #err(#Unauthorized);
+            let acceptOk = await checkPropertyAuth(req.propertyId, req.homeowner, msg.caller, true);
+            if (not acceptOk) return #err(#Unauthorized);
             if (req.status == #Accepted or req.status == #Closed)
               return #err(#InvalidInput("Request is already closed"));
             if (req.status == #Cancelled)
@@ -542,7 +556,8 @@ persistent actor Quote {
     switch (Map.get(requests, Text.compare, requestId)) {
       case null { #err(#NotFound) };
       case (?req) {
-        if (req.homeowner != msg.caller) return #err(#Unauthorized);
+        let closeOk = await checkPropertyAuth(req.propertyId, req.homeowner, msg.caller, true);
+        if (not closeOk) return #err(#Unauthorized);
         if (req.status == #Accepted or req.status == #Closed)
           return #err(#InvalidInput("Request is already closed"));
         if (req.status == #Cancelled)
@@ -575,7 +590,8 @@ persistent actor Quote {
     switch (Map.get(requests, Text.compare, requestId)) {
       case null { #err(#NotFound) };
       case (?req) {
-        if (req.homeowner != msg.caller) return #err(#Unauthorized);
+        let cancelOk = await checkPropertyAuth(req.propertyId, req.homeowner, msg.caller, true);
+        if (not cancelOk) return #err(#Unauthorized);
         switch (req.status) {
           case (#Open or #Quoted) {};
           case (#Accepted)  { return #err(#InvalidInput("Cannot cancel an accepted request")) };
@@ -750,7 +766,8 @@ persistent actor Quote {
     switch (Map.get(requests, Text.compare, requestId)) {
       case null { return #err(#NotFound) };
       case (?req) {
-        if (req.homeowner != msg.caller) return #err(#Unauthorized);
+        let revealOk = await checkPropertyAuth(req.propertyId, req.homeowner, msg.caller, true);
+        if (not revealOk) return #err(#Unauthorized);
 
         // Enforce: window must be closed before reveal
         switch (req.closeAt) {

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -332,6 +332,11 @@ if [ -n "$QUOTE_ID" ]    && [ -n "$PROPERTY_ID" ];   then
   echo "  Wiring property -> quote..."
   dfx canister call quote    setPropertyCanisterId   "(principal \"$PROPERTY_ID\")" --network "$NETWORK" &
 fi
+MAINTENANCE_ID=$(dfx canister id maintenance --network "$NETWORK" 2>/dev/null || echo "")
+if [ -n "$MAINTENANCE_ID" ] && [ -n "$PROPERTY_ID" ]; then
+  echo "  Wiring property -> maintenance..."
+  dfx canister call maintenance setPropertyCanisterId "(principal \"$PROPERTY_ID\")" --network "$NETWORK" &
+fi
 
 wait   # wait for all wiring calls before reading IDs in the trusted-canister section
 


### PR DESCRIPTION
## Summary
- Replaces inline `caller == owner` checks in **job**, **photo**, **quote**, and **maintenance** canisters with calls to `property.isAuthorized(propertyId, caller, requireWrite)` — the single source of truth for property ownership and delegated-manager access
- Adds `propCanisterId` + `setPropertyCanisterId()` to **maintenance** (the only canister that hadn't been wired yet)
- Removes the now-fulfilled `TODO` comment from `property/main.mo:isAuthorized()`
- Wires `maintenance → property` in `scripts/deploy.sh`

All four canisters retain a dev-mode fallback (`caller == owner`) when `propCanisterId` is unset, so unit tests continue to work without a deployed property canister.

Closes #95

## Affected functions
| Canister | Functions updated |
|---|---|
| job | `updateJobStatus`, `linkContractor`, `verifyJob` (homeowner leg), `createInviteToken`, `approveJobProposal`, `rejectJobProposal` |
| photo | `getPhoto`, `getPhotoData`, `verifyPhoto`, `deletePhoto` |
| quote | `acceptQuote`, `closeQuoteRequest`, `cancelQuoteRequest`, `revealBids` |
| maintenance | `markCompleted` |

## Test plan
- [ ] `make deploy` on local replica — verify `setPropertyCanisterId` wiring for maintenance completes without error
- [ ] Backend canister tests still pass: `make test`
- [ ] Property delegation: add a manager principal to a property via `addManager`, confirm that manager can call `updateJobStatus` / `acceptQuote` / `deletePhoto` / `markCompleted` on records for that property
- [ ] Non-owner is still rejected: call any of the updated functions from an unrelated principal, confirm `#Unauthorized` is returned

🤖 Generated with [Claude Code](https://claude.com/claude-code)