### PR TITLE
refactor(services): remove import.meta.env.DEV guards from service la…

### DIFF
--- a/frontend/src/__tests__/security/fetchRootKey1445.test.ts
+++ b/frontend/src/__tests__/security/fetchRootKey1445.test.ts
@@ -69,7 +69,8 @@ describe("14.4.5: fetchRootKey production safety", () => {
   });
 
   it("loginWithLocalIdentity() is hard-blocked in production", () => {
-    expect(actor).toMatch(/if\s*\(!import\.meta\.env\.DEV\)/);
+    // Guard uses IS_LOCAL (DFX_NETWORK-based) rather than import.meta.env.DEV
+    expect(actor).toMatch(/if\s*\(!IS_LOCAL\)/);
     expect(actor).toMatch(/throw new Error/);
   });
 

--- a/frontend/src/services/actor.ts
+++ b/frontend/src/services/actor.ts
@@ -53,8 +53,8 @@ export function setAgentForTesting(agent: HttpAgent): void {
  * Returns the principal text so callers can update auth state.
  */
 export async function loginWithLocalIdentity(): Promise<string> {
-  // 14.2.2 — hard-block in production builds; Vite dead-code-eliminates this
-  if (!import.meta.env.DEV) {
+  // Hard-block on IC mainnet — this function is only valid on a local replica
+  if (!IS_LOCAL) {
     throw new Error("loginWithLocalIdentity() must not be called in production");
   }
   // Fixed seed → same principal every time, survives hot-reload

--- a/frontend/src/services/agent.ts
+++ b/frontend/src/services/agent.ts
@@ -196,7 +196,7 @@ function createAgentService() {
     },
 
     async createProfile(input: CreateAgentProfileInput): Promise<AgentOnChainProfile> {
-      if (import.meta.env.DEV && !AGENT_CANISTER_ID) {
+      if (!AGENT_CANISTER_ID) {
         if (_profiles.find((p) => p.id === _myId)) throw new Error("Profile already exists");
         const profile: AgentOnChainProfile = {
           id:                      _myId,
@@ -228,7 +228,7 @@ function createAgentService() {
     },
 
     async getMyProfile(): Promise<AgentOnChainProfile | null> {
-      if (import.meta.env.DEV && !AGENT_CANISTER_ID) {
+      if (!AGENT_CANISTER_ID) {
         return _profiles.find((p) => p.id === _myId) ?? null;
       }
       const actor = await getActor();
@@ -238,7 +238,7 @@ function createAgentService() {
     },
 
     async getPublicProfile(id: string): Promise<AgentOnChainProfile | null> {
-      if (import.meta.env.DEV && !AGENT_CANISTER_ID) {
+      if (!AGENT_CANISTER_ID) {
         return _profiles.find((p) => p.id === id) ?? null;
       }
       const { Principal } = await import("@icp-sdk/core/principal");
@@ -249,14 +249,14 @@ function createAgentService() {
     },
 
     async getAllProfiles(): Promise<AgentOnChainProfile[]> {
-      if (import.meta.env.DEV && !AGENT_CANISTER_ID) return [..._profiles];
+      if (!AGENT_CANISTER_ID) return [..._profiles];
       const actor = await getActor();
       const raw = await actor.getAllProfiles();
       return raw.map(fromRawProfile);
     },
 
     async updateProfile(input: CreateAgentProfileInput): Promise<AgentOnChainProfile> {
-      if (import.meta.env.DEV && !AGENT_CANISTER_ID) {
+      if (!AGENT_CANISTER_ID) {
         const idx = _profiles.findIndex((p) => p.id === _myId);
         if (idx === -1) throw new Error("Profile not found");
         const updated: AgentOnChainProfile = {
@@ -283,7 +283,7 @@ function createAgentService() {
     },
 
     async addReview(input: AddReviewInput): Promise<AgentReview> {
-      if (import.meta.env.DEV && !AGENT_CANISTER_ID) {
+      if (!AGENT_CANISTER_ID) {
         if (!_profiles.find((p) => p.id === input.agentId)) throw new Error(`Agent ${input.agentId} not found`);
         if (input.rating < 1 || input.rating > 5) throw new Error("rating must be 1–5");
         const compositeKey = `local|${input.transactionId}`;
@@ -314,7 +314,7 @@ function createAgentService() {
     },
 
     async getReviews(agentId: string): Promise<AgentReview[]> {
-      if (import.meta.env.DEV && !AGENT_CANISTER_ID) {
+      if (!AGENT_CANISTER_ID) {
         return _reviews.filter((r) => r.agentId === agentId);
       }
       const { Principal } = await import("@icp-sdk/core/principal");

--- a/frontend/src/services/aiProxy.ts
+++ b/frontend/src/services/aiProxy.ts
@@ -85,7 +85,7 @@ let _actor: any | null = null;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 async function getActor(): Promise<any | null> {
-  if (import.meta.env.DEV && !AI_PROXY_CANISTER_ID) return null;
+  if (!AI_PROXY_CANISTER_ID) return null;
   if (_actor) return _actor;
   const ag = await getAgent();
   _actor = Actor.createActor(idlFactory, { agent: ag, canisterId: AI_PROXY_CANISTER_ID });

--- a/frontend/src/services/billService.ts
+++ b/frontend/src/services/billService.ts
@@ -237,7 +237,7 @@ function toRecord(raw: any): BillRecord {
 export const billService = {
   /** Store a confirmed bill record in the canister. */
   async addBill(args: AddBillArgs): Promise<BillRecord> {
-    if (import.meta.env.DEV && !BILLS_CANISTER_ID) {
+    if (!BILLS_CANISTER_ID) {
       if (countUploadsThisMonth() >= FREE_TIER_MONTHLY_LIMIT) {
         throw new TierLimitReachedError(
           "Bill uploads require an active subscription. Subscribe to Basic ($10/mo) to get started."
@@ -261,7 +261,7 @@ export const billService = {
 
   /** Fetch all bill records for a property. */
   async getBillsForProperty(propertyId: string): Promise<BillRecord[]> {
-    if (import.meta.env.DEV && !BILLS_CANISTER_ID) {
+    if (!BILLS_CANISTER_ID) {
       return _mockBills.filter((b) => b.propertyId === propertyId);
     }
     const actor = await getBillsActor();
@@ -272,7 +272,7 @@ export const billService = {
 
   /** Delete a bill record. */
   async deleteBill(id: string): Promise<void> {
-    if (import.meta.env.DEV && !BILLS_CANISTER_ID) {
+    if (!BILLS_CANISTER_ID) {
       _mockBills = _mockBills.filter((b) => b.id !== id);
       return;
     }

--- a/frontend/src/services/cert.ts
+++ b/frontend/src/services/cert.ts
@@ -61,7 +61,7 @@ function createCertService() {
      * Returns { certId, token } — token is safe to embed in a URL.
      */
     async issueCert(propertyId: string, payload: CertPayload): Promise<IssuedCert> {
-      if (import.meta.env.DEV && !REPORT_CANISTER_ID) {
+      if (!REPORT_CANISTER_ID) {
         counter++;
         const certId = `CERT-${counter}`;
         store.set(certId, payload);
@@ -79,7 +79,7 @@ function createCertService() {
     async verifyCert(certId: string): Promise<CertPayload | null> {
       if (!certId) return null;
 
-      if (import.meta.env.DEV && !REPORT_CANISTER_ID) {
+      if (!REPORT_CANISTER_ID) {
         return store.get(certId) ?? null;
       }
       const a      = await getActor();

--- a/frontend/src/services/contractor.ts
+++ b/frontend/src/services/contractor.ts
@@ -202,8 +202,8 @@ function createContractorService() {
 
   return {
   async search(specialty?: string): Promise<ContractorProfile[]> {
-    if (import.meta.env.DEV && !CONTRACTOR_CANISTER_ID) {
-      const e2e = import.meta.env.DEV && typeof window !== "undefined" && (window as any).__e2e_contractors;
+    if (!CONTRACTOR_CANISTER_ID) {
+      const e2e = typeof window !== "undefined" && (window as any).__e2e_contractors;
       const source: ContractorProfile[] = e2e ? (e2e as ContractorProfile[]) : mockContractors;
       return specialty ? source.filter((c) => c.specialties.includes(specialty)) : [...source];
     }
@@ -213,8 +213,8 @@ function createContractorService() {
   },
 
   async getTopRated(): Promise<ContractorProfile[]> {
-    if (import.meta.env.DEV && !CONTRACTOR_CANISTER_ID) {
-      const e2e = import.meta.env.DEV && typeof window !== "undefined" && (window as any).__e2e_contractors;
+    if (!CONTRACTOR_CANISTER_ID) {
+      const e2e = typeof window !== "undefined" && (window as any).__e2e_contractors;
       const source: ContractorProfile[] = e2e ? (e2e as ContractorProfile[]) : mockContractors;
       return [...source].sort((a, b) => b.trustScore - a.trustScore);
     }
@@ -224,8 +224,8 @@ function createContractorService() {
   },
 
   async getMyProfile(): Promise<ContractorProfile | null> {
-    if (import.meta.env.DEV && !CONTRACTOR_CANISTER_ID) {
-      const e2e = import.meta.env.DEV && typeof window !== "undefined" && (window as any).__e2e_contractors;
+    if (!CONTRACTOR_CANISTER_ID) {
+      const e2e = typeof window !== "undefined" && (window as any).__e2e_contractors;
       if (e2e) return (e2e as ContractorProfile[])[0] ?? null;
       return mockContractors[0] ?? null;
     }
@@ -236,11 +236,11 @@ function createContractorService() {
   },
 
   async getContractor(principalText: string): Promise<ContractorProfile | null> {
-    if (import.meta.env.DEV && !CONTRACTOR_CANISTER_ID) {
+    if (!CONTRACTOR_CANISTER_ID) {
       const fromMock = mockContractors.find((c) => c.id === principalText);
       if (fromMock) return fromMock;
       // Playwright e2e injection
-      const e2eContractors = import.meta.env.DEV && typeof window !== "undefined" && (window as any).__e2e_contractors;
+      const e2eContractors = typeof window !== "undefined" && (window as any).__e2e_contractors;
       if (e2eContractors) {
         const raw = (e2eContractors as any[]).find((c) => c.principal === principalText);
         if (raw) return {
@@ -291,7 +291,7 @@ function createContractorService() {
   },
 
   async submitReview(contractorPrincipalText: string, rating: number, comment: string, jobId: string): Promise<void> {
-    if (import.meta.env.DEV && !CONTRACTOR_CANISTER_ID) {
+    if (!CONTRACTOR_CANISTER_ID) {
       // Mock: no-op in dev
       return;
     }
@@ -306,7 +306,7 @@ function createContractorService() {
   },
 
   async getCredentials(contractorPrincipalText: string): Promise<JobCredential[]> {
-    if (import.meta.env.DEV && !CONTRACTOR_CANISTER_ID) {
+    if (!CONTRACTOR_CANISTER_ID) {
       // Mock: return empty portfolio in dev
       return [];
     }
@@ -324,7 +324,7 @@ function createContractorService() {
   },
 
   async getBySpecialty(specialty: string): Promise<ContractorProfile[]> {
-    if (import.meta.env.DEV && !CONTRACTOR_CANISTER_ID) {
+    if (!CONTRACTOR_CANISTER_ID) {
       return mockContractors.filter((c) => c.specialties.includes(specialty));
     }
     const a = await getActor();

--- a/frontend/src/services/job.ts
+++ b/frontend/src/services/job.ts
@@ -285,7 +285,7 @@ function unwrapJob(result: any): Job {
 function createJobService() {
   // Seed from Playwright test globals if present (window.__e2e_jobs set by addInitScript)
   const mockJobs: Job[] =
-    import.meta.env.DEV && typeof window !== "undefined" && (window as any).__e2e_jobs
+    typeof window !== "undefined" && (window as any).__e2e_jobs
       ? [...(window as any).__e2e_jobs]
       : [];
 
@@ -301,7 +301,7 @@ function createJobService() {
 
   return {
   async getByProperty(propertyId: string): Promise<Job[]> {
-    if (import.meta.env.DEV && !JOB_CANISTER_ID) {
+    if (!JOB_CANISTER_ID) {
       return mockJobs.filter((j) => j.propertyId === propertyId);
     }
     const a = await getActor();
@@ -311,17 +311,17 @@ function createJobService() {
   },
 
   async getAll(): Promise<Job[]> {
-    if (import.meta.env.DEV && !JOB_CANISTER_ID) return [...mockJobs];
+    if (!JOB_CANISTER_ID) return [...mockJobs];
     // No canister equivalent for getAll — callers should use getByProperty
     return [];
   },
 
   async create(job: Omit<Job, "id" | "createdAt" | "status" | "photos" | "verified" | "homeownerSigned" | "contractorSigned" | "homeowner" | "contractor">): Promise<Job> {
-    if (import.meta.env.DEV && !JOB_CANISTER_ID) {
+    if (!JOB_CANISTER_ID) {
       const newJob: Job = {
         ...job,
         id: String(Date.now()),
-        homeowner: (import.meta.env.DEV && typeof window !== "undefined" && (window as any).__e2e_principal) || "mock-principal",
+        homeowner: (typeof window !== "undefined" && (window as any).__e2e_principal) || "mock-principal",
         contractor: undefined,
         status: "pending",
         verified: false,
@@ -352,7 +352,7 @@ function createJobService() {
   },
 
   async updateJob(jobId: string, updates: Partial<Pick<Job, "serviceType" | "contractorName" | "amount" | "date" | "description" | "permitNumber" | "warrantyMonths" | "isDiy">>): Promise<Job> {
-    if (import.meta.env.DEV && !JOB_CANISTER_ID) {
+    if (!JOB_CANISTER_ID) {
       const idx = mockJobs.findIndex((j) => j.id === jobId);
       if (idx === -1) throw new Error(`Job not found in mock store (id: ${jobId})`);
       mockJobs[idx] = { ...mockJobs[idx], ...updates };
@@ -363,7 +363,7 @@ function createJobService() {
   },
 
   async updateJobStatus(jobId: string, status: JobStatus): Promise<Job> {
-    if (import.meta.env.DEV && !JOB_CANISTER_ID) {
+    if (!JOB_CANISTER_ID) {
       const idx = mockJobs.findIndex((j) => j.id === jobId);
       if (idx === -1) throw new Error(`Job not found in mock store (id: ${jobId})`);
       mockJobs[idx] = { ...mockJobs[idx], status };
@@ -383,7 +383,7 @@ function createJobService() {
   },
 
   async verifyJob(jobId: string): Promise<Job> {
-    if (import.meta.env.DEV && !JOB_CANISTER_ID) {
+    if (!JOB_CANISTER_ID) {
       const idx = mockJobs.findIndex((j) => j.id === jobId);
       if (idx === -1) throw new Error(`Job not found in mock store (id: ${jobId})`);
       const job = mockJobs[idx];
@@ -405,7 +405,7 @@ function createJobService() {
   },
 
   async linkContractor(jobId: string, contractorPrincipal: string): Promise<Job> {
-    if (import.meta.env.DEV && !JOB_CANISTER_ID) {
+    if (!JOB_CANISTER_ID) {
       const idx = mockJobs.findIndex((j) => j.id === jobId);
       if (idx === -1) throw new Error(`Job not found in mock store (id: ${jobId})`);
       mockJobs[idx] = { ...mockJobs[idx], contractor: contractorPrincipal };
@@ -418,14 +418,14 @@ function createJobService() {
   },
 
   async getJobsPendingMySignature(): Promise<Job[]> {
-    if (import.meta.env.DEV && !JOB_CANISTER_ID) return [];
+    if (!JOB_CANISTER_ID) return [];
     const a = await getActor();
     const result = await a.getJobsPendingMySignature();
     return (result as any[]).map(fromJob);
   },
 
   async getCertificationData(propertyId: string): Promise<{ verifiedJobCount: number; verifiedKeySystems: string[]; meetsStructural: boolean }> {
-    if (import.meta.env.DEV && !JOB_CANISTER_ID) {
+    if (!JOB_CANISTER_ID) {
       const KEY_SYSTEMS = ["HVAC", "Roofing", "Plumbing", "Electrical"];
       const propertyJobs = mockJobs.filter((j) => j.propertyId === propertyId && j.verified);
       const systems = [...new Set(propertyJobs.map((j) => j.serviceType).filter((s) => KEY_SYSTEMS.includes(s)))];
@@ -457,7 +457,7 @@ function createJobService() {
   },
 
   async createInviteToken(jobId: string, propertyAddress: string): Promise<string> {
-    if (import.meta.env.DEV && !JOB_CANISTER_ID) return `MOCK_INV_${jobId}`;
+    if (!JOB_CANISTER_ID) return `MOCK_INV_${jobId}`;
     const a = await getActor();
     const result = await a.createInviteToken(jobId, propertyAddress);
     if ("ok" in result) return result.ok as string;
@@ -467,7 +467,7 @@ function createJobService() {
   },
 
   async getJobByInviteToken(token: string): Promise<InvitePreview> {
-    if (import.meta.env.DEV && !JOB_CANISTER_ID) {
+    if (!JOB_CANISTER_ID) {
       // Mock preview for development
       return {
         jobId:           "MOCK_JOB",
@@ -505,7 +505,7 @@ function createJobService() {
   },
 
   async redeemInviteToken(token: string): Promise<Job> {
-    if (import.meta.env.DEV && !JOB_CANISTER_ID) {
+    if (!JOB_CANISTER_ID) {
       return {
         id: "MOCK_JOB", propertyId: "1", homeowner: "mock",
         serviceType: "HVAC", amount: 25000,
@@ -523,7 +523,7 @@ function createJobService() {
 
   /** Admin: return all jobs sourced via a HomeGentic quote request (referral fee pipeline). */
   async getReferralJobs(): Promise<Job[]> {
-    if (import.meta.env.DEV && !JOB_CANISTER_ID) return [];
+    if (!JOB_CANISTER_ID) return [];
     const a = await getActor();
     const raw: any[] = await a.getReferralJobs();
     return raw.map(fromJob);
@@ -541,12 +541,12 @@ function createJobService() {
     permitNumber?:  string;
     warrantyMonths?: number;
   }): Promise<Job> {
-    if (import.meta.env.DEV && !JOB_CANISTER_ID) {
+    if (!JOB_CANISTER_ID) {
       const proposal: Job = {
         id:               `PROPOSAL_${Date.now()}`,
         propertyId:       input.propertyId,
         homeowner:        "mock-homeowner",
-        contractor:       (import.meta.env.DEV && typeof window !== "undefined" && (window as any).__e2e_principal) || "mock-contractor",
+        contractor:       (typeof window !== "undefined" && (window as any).__e2e_principal) || "mock-contractor",
         serviceType:      input.serviceType,
         contractorName:   input.contractorName,
         amount:           input.amountCents,
@@ -582,8 +582,8 @@ function createJobService() {
   },
 
   async getPendingProposals(): Promise<Job[]> {
-    if (import.meta.env.DEV && !JOB_CANISTER_ID) {
-      const pending = import.meta.env.DEV && typeof window !== "undefined" && (window as any).__e2e_pending_proposals;
+    if (!JOB_CANISTER_ID) {
+      const pending = typeof window !== "undefined" && (window as any).__e2e_pending_proposals;
       if (pending) return pending as Job[];
       return mockJobs.filter((j) => j.status === "pending_homeowner_approval");
     }
@@ -593,14 +593,14 @@ function createJobService() {
   },
 
   async approveJobProposal(jobId: string): Promise<Job> {
-    if (import.meta.env.DEV && !JOB_CANISTER_ID) {
+    if (!JOB_CANISTER_ID) {
       const idx = mockJobs.findIndex((j) => j.id === jobId);
       if (idx !== -1) {
         mockJobs[idx] = { ...mockJobs[idx], homeownerSigned: true, status: "pending" };
         return mockJobs[idx];
       }
       // Also check __e2e_pending_proposals mock
-      const pending: Job[] = (import.meta.env.DEV && typeof window !== "undefined" && (window as any).__e2e_pending_proposals) || [];
+      const pending: Job[] = (typeof window !== "undefined" && (window as any).__e2e_pending_proposals) || [];
       const pidx = pending.findIndex((j) => j.id === jobId);
       if (pidx !== -1) {
         const approved = { ...pending[pidx], homeownerSigned: true, status: "pending" as JobStatus };
@@ -616,10 +616,10 @@ function createJobService() {
   },
 
   async rejectJobProposal(jobId: string): Promise<void> {
-    if (import.meta.env.DEV && !JOB_CANISTER_ID) {
+    if (!JOB_CANISTER_ID) {
       const idx = mockJobs.findIndex((j) => j.id === jobId);
       if (idx !== -1) { mockJobs.splice(idx, 1); return; }
-      const pending: Job[] = (import.meta.env.DEV && typeof window !== "undefined" && (window as any).__e2e_pending_proposals) || [];
+      const pending: Job[] = (typeof window !== "undefined" && (window as any).__e2e_pending_proposals) || [];
       const pidx = pending.findIndex((j) => j.id === jobId);
       if (pidx !== -1) { pending.splice(pidx, 1); return; }
       throw new Error(`Job proposal not found in mock store or e2e pending list (id: ${jobId})`);

--- a/frontend/src/services/listing.ts
+++ b/frontend/src/services/listing.ts
@@ -425,7 +425,7 @@ function createListingService() {
 
   // ── createBidRequest ────────────────────────────────────────────────────────
   async createBidRequest(input: CreateBidRequestInput): Promise<ListingBidRequest> {
-    if (import.meta.env.DEV && !LISTING_CANISTER_ID) {
+    if (!LISTING_CANISTER_ID) {
       const req: ListingBidRequest = {
         id:               `BID_${++_reqSeq}`,
         propertyId:       input.propertyId,
@@ -457,7 +457,7 @@ function createListingService() {
 
   // ── getMyBidRequests ────────────────────────────────────────────────────────
   async getMyBidRequests(): Promise<ListingBidRequest[]> {
-    if (import.meta.env.DEV && !LISTING_CANISTER_ID) {
+    if (!LISTING_CANISTER_ID) {
       return [...requests];
     }
     const actor = await getActor();
@@ -467,7 +467,7 @@ function createListingService() {
 
   // ── getBidRequest ───────────────────────────────────────────────────────────
   async getBidRequest(id: string): Promise<ListingBidRequest | null> {
-    if (import.meta.env.DEV && !LISTING_CANISTER_ID) {
+    if (!LISTING_CANISTER_ID) {
       return requests.find(r => r.id === id) ?? null;
     }
     const actor = await getActor();
@@ -478,7 +478,7 @@ function createListingService() {
 
   // ── cancelBidRequest ────────────────────────────────────────────────────────
   async cancelBidRequest(id: string): Promise<void> {
-    if (import.meta.env.DEV && !LISTING_CANISTER_ID) {
+    if (!LISTING_CANISTER_ID) {
       const req = requests.find(r => r.id === id);
       if (!req) throw new Error(`BidRequest ${id} not found`);
       if (req.status !== "Open") throw new Error(`BidRequest ${id} is not Open (status: ${req.status})`);
@@ -493,7 +493,7 @@ function createListingService() {
   // ── getOpenBidRequests (agent view) ─────────────────────────────────────────
   // 9.2.4: inviteOnly requests are hidden from the general marketplace.
   async getOpenBidRequests(callerAgentId = "local"): Promise<ListingBidRequest[]> {
-    if (import.meta.env.DEV && !LISTING_CANISTER_ID) {
+    if (!LISTING_CANISTER_ID) {
       return requests.filter(
         r => r.status === "Open"
           && !isDeadlinePassed(r.bidDeadline)
@@ -507,7 +507,7 @@ function createListingService() {
 
   // ── submitProposal ──────────────────────────────────────────────────────────
   async submitProposal(requestId: string, input: SubmitProposalInput): Promise<ListingProposal> {
-    if (import.meta.env.DEV && !LISTING_CANISTER_ID) {
+    if (!LISTING_CANISTER_ID) {
       const req = requests.find(r => r.id === requestId);
       if (!req) throw new Error(`BidRequest ${requestId} not found`);
       if (req.status !== "Open") throw new Error(`BidRequest ${requestId} is not accepting proposals (status: ${req.status})`);
@@ -556,7 +556,7 @@ function createListingService() {
   // ── getProposalsForRequest ───────────────────────────────────────────────────
   // Sealed-bid: proposals are hidden until the request's bidDeadline has passed.
   async getProposalsForRequest(requestId: string): Promise<ListingProposal[]> {
-    if (import.meta.env.DEV && !LISTING_CANISTER_ID) {
+    if (!LISTING_CANISTER_ID) {
       const req = requests.find(r => r.id === requestId);
       if (!req) return [];
       if (!isDeadlinePassed(req.bidDeadline)) return []; // still sealed
@@ -569,7 +569,7 @@ function createListingService() {
 
   // ── getMyProposals (agent view) ──────────────────────────────────────────────
   async getMyProposals(): Promise<ListingProposal[]> {
-    if (import.meta.env.DEV && !LISTING_CANISTER_ID) {
+    if (!LISTING_CANISTER_ID) {
       return [...proposals];
     }
     const actor = await getActor();
@@ -579,7 +579,7 @@ function createListingService() {
 
   // ── acceptProposal ───────────────────────────────────────────────────────────
   async acceptProposal(proposalId: string): Promise<void> {
-    if (import.meta.env.DEV && !LISTING_CANISTER_ID) {
+    if (!LISTING_CANISTER_ID) {
       const proposal = proposals.find(p => p.id === proposalId);
       if (!proposal) throw new Error(`Proposal ${proposalId} not found`);
 
@@ -604,7 +604,7 @@ function createListingService() {
 
   // ── uploadContract (9.4.5) ───────────────────────────────────────────────────
   async uploadContract(requestId: string, fileName: string): Promise<void> {
-    if (import.meta.env.DEV && !LISTING_CANISTER_ID) {
+    if (!LISTING_CANISTER_ID) {
       const req = requests.find((r) => r.id === requestId);
       if (!req) throw new Error(`BidRequest ${requestId} not found`);
       req.contractFile = { name: fileName, uploadedAt: Date.now() };
@@ -616,7 +616,7 @@ function createListingService() {
 
   // ── counterProposal (9.4.6) ──────────────────────────────────────────────────
   async counterProposal(proposalId: string, input: CounterProposalInput): Promise<CounterProposal> {
-    if (import.meta.env.DEV && !LISTING_CANISTER_ID) {
+    if (!LISTING_CANISTER_ID) {
       const proposal = proposals.find((p) => p.id === proposalId);
       if (!proposal) throw new Error(`Proposal ${proposalId} not found`);
       const counter: CounterProposal = {
@@ -637,7 +637,7 @@ function createListingService() {
 
   // ── respondToCounter (9.4.6) — agent accepts/rejects ────────────────────────
   async respondToCounter(counterId: string, response: "accept" | "reject"): Promise<void> {
-    if (import.meta.env.DEV && !LISTING_CANISTER_ID) {
+    if (!LISTING_CANISTER_ID) {
       const counter = counters.find((c) => c.id === counterId);
       if (!counter) throw new Error(`Counter ${counterId} not found`);
       counter.status = response === "accept" ? "Accepted" : "Rejected";
@@ -648,7 +648,7 @@ function createListingService() {
 
   // ── getCountersForProposal (9.4.6) ───────────────────────────────────────────
   async getCountersForProposal(proposalId: string): Promise<CounterProposal[]> {
-    if (import.meta.env.DEV && !LISTING_CANISTER_ID) {
+    if (!LISTING_CANISTER_ID) {
       return counters.filter((c) => c.proposalId === proposalId);
     }
     throw new Error("getCountersForProposal requires deployed canister");
@@ -656,7 +656,7 @@ function createListingService() {
 
   // ── getMyCounters (9.4.6) — agent views counters on their proposals ──────────
   async getMyCounters(): Promise<CounterProposal[]> {
-    if (import.meta.env.DEV && !LISTING_CANISTER_ID) {
+    if (!LISTING_CANISTER_ID) {
       const myProposalIds = new Set(proposals.map((p) => p.id));
       return counters.filter((c) => myProposalIds.has(c.proposalId));
     }
@@ -669,7 +669,7 @@ function createListingService() {
     key: MilestoneKey,
     completedBy: "homeowner" | "agent",
   ): Promise<ListingBidRequest> {
-    if (import.meta.env.DEV && !LISTING_CANISTER_ID) {
+    if (!LISTING_CANISTER_ID) {
       const req = requests.find((r) => r.id === requestId);
       if (!req) throw new Error(`BidRequest ${requestId} not found`);
       if (!req.milestones) req.milestones = initMilestones();
@@ -682,7 +682,7 @@ function createListingService() {
 
   // ── logOffer (9.5.2) ─────────────────────────────────────────────────────────
   async logOffer(requestId: string, input: LogOfferInput): Promise<OfferEntry> {
-    if (import.meta.env.DEV && !LISTING_CANISTER_ID) {
+    if (!LISTING_CANISTER_ID) {
       const req = requests.find((r) => r.id === requestId);
       if (!req) throw new Error(`BidRequest ${requestId} not found`);
       const { deltaFromListingPriceCents, deltaFromHomeGenticEstimateCents } = computeOfferDeltas(
@@ -709,7 +709,7 @@ function createListingService() {
 
   // ── logClose (9.5.3) ─────────────────────────────────────────────────────────
   async logClose(requestId: string, input: LogCloseInput): Promise<TransactionClose> {
-    if (import.meta.env.DEV && !LISTING_CANISTER_ID) {
+    if (!LISTING_CANISTER_ID) {
       const req = requests.find((r) => r.id === requestId);
       if (!req) throw new Error(`BidRequest ${requestId} not found`);
       const close: TransactionClose = {
@@ -732,7 +732,7 @@ function createListingService() {
 
   // ── logAgentPerformance (9.5.4) ───────────────────────────────────────────────
   async logAgentPerformance(requestId: string, input: LogAgentPerformanceInput): Promise<AgentPerformanceRecord> {
-    if (import.meta.env.DEV && !LISTING_CANISTER_ID) {
+    if (!LISTING_CANISTER_ID) {
       const req = requests.find((r) => r.id === requestId);
       if (!req) throw new Error(`BidRequest ${requestId} not found`);
       if (!req.closedData) throw new Error("Cannot log performance before close is recorded");
@@ -767,7 +767,7 @@ function createListingService() {
 
   // ── getAgentPerformanceRecords (9.5.4) — for AgentPublicPage ─────────────────
   async getAgentPerformanceRecords(agentId: string): Promise<AgentPerformanceRecord[]> {
-    if (import.meta.env.DEV && !LISTING_CANISTER_ID) {
+    if (!LISTING_CANISTER_ID) {
       return perfRecords.filter((r) => r.agentId === agentId);
     }
     throw new Error("getAgentPerformanceRecords requires deployed canister");
@@ -775,7 +775,7 @@ function createListingService() {
 
   // ── createDirectInvite (9.6.2) — homeowner invites specific agent ─────────────
   async createDirectInvite(agentId: string, propertyId: string): Promise<ListingBidRequest> {
-    if (import.meta.env.DEV && !LISTING_CANISTER_ID) {
+    if (!LISTING_CANISTER_ID) {
       const id = `BID_DIRECT_${++_reqSeq}`;
       const req: ListingBidRequest = {
         id,

--- a/frontend/src/services/maintenance.ts
+++ b/frontend/src/services/maintenance.ts
@@ -447,7 +447,7 @@ function createMaintenanceService() {
     plannedMonth?:      number,
     estimatedCostCents?: number
   ): Promise<ScheduleEntry> {
-    if (import.meta.env.DEV && !MAINTENANCE_CANISTER_ID) {
+    if (!MAINTENANCE_CANISTER_ID) {
       scheduleCounter += 1;
       const entry: ScheduleEntry = {
         id: `SCH_${scheduleCounter}`,
@@ -473,7 +473,7 @@ function createMaintenanceService() {
   },
 
   async getScheduleByProperty(propertyId: string): Promise<ScheduleEntry[]> {
-    if (import.meta.env.DEV && !MAINTENANCE_CANISTER_ID) {
+    if (!MAINTENANCE_CANISTER_ID) {
       return Array.from(scheduleStore.values()).filter((e) => e.propertyId === propertyId);
     }
     const a = await getActor();
@@ -481,7 +481,7 @@ function createMaintenanceService() {
   },
 
   async markCompleted(entryId: string): Promise<ScheduleEntry | null> {
-    if (import.meta.env.DEV && !MAINTENANCE_CANISTER_ID) {
+    if (!MAINTENANCE_CANISTER_ID) {
       const entry = scheduleStore.get(entryId);
       if (!entry) return null;
       const updated = { ...entry, isCompleted: true };

--- a/frontend/src/services/market.ts
+++ b/frontend/src/services/market.ts
@@ -102,7 +102,7 @@ export async function submitScore(
   yearBuilt: number,
   zipCode:   string,
 ): Promise<StoredScore> {
-  if (import.meta.env.DEV && !MARKET_CANISTER_ID) {
+  if (!MARKET_CANISTER_ID) {
     return { score: 0, zipCode, updatedAt: BigInt(0) };
   }
   const actor = await getNeighbourhoodActor();
@@ -117,7 +117,7 @@ export async function submitScore(
 
 /** Public zip-level aggregate — no individual data. */
 export async function getZipStats(zipCode: string): Promise<ZipStats | null> {
-  if (import.meta.env.DEV && !MARKET_CANISTER_ID) return null;
+  if (!MARKET_CANISTER_ID) return null;
   const actor = await getNeighbourhoodActor();
   const result = await actor.getZipStats(zipCode);
   if ("err" in result) return null;
@@ -132,7 +132,7 @@ export async function getZipStats(zipCode: string): Promise<ZipStats | null> {
 
 /** Returns the canister's vetKeys public key for the neighbourhood score context. */
 export async function getNeighborhoodPublicKey(): Promise<Uint8Array> {
-  if (import.meta.env.DEV && !MARKET_CANISTER_ID) return new Uint8Array();
+  if (!MARKET_CANISTER_ID) return new Uint8Array();
   const actor = await getNeighbourhoodActor();
   const bytes = await actor.getNeighborhoodPublicKey();
   return new Uint8Array(bytes);
@@ -142,7 +142,7 @@ export async function getNeighborhoodPublicKey(): Promise<Uint8Array> {
 export async function getMyScoreEncrypted(
   transportPublicKey: Uint8Array,
 ): Promise<ScoreEnvelope> {
-  if (import.meta.env.DEV && !MARKET_CANISTER_ID) {
+  if (!MARKET_CANISTER_ID) {
     return { encryptedKey: new Uint8Array(), score: 0, zipCode: "", updatedAt: BigInt(0) };
   }
   const actor = await getNeighbourhoodActor();

--- a/frontend/src/services/monitoringService.ts
+++ b/frontend/src/services/monitoringService.ts
@@ -146,7 +146,7 @@ function createMonitoringService() {
 
   return {
     async getAllCanisterMetrics(): Promise<CanisterMetrics[]> {
-      if (import.meta.env.DEV && !MONITORING_CANISTER_ID) return [];
+      if (!MONITORING_CANISTER_ID) return [];
       const a = await getActor();
       const raw = await a.getAllCanisterMetrics() as any[];
       return raw.map((r: any) => ({
@@ -163,7 +163,7 @@ function createMonitoringService() {
     },
 
     async checkCycleLevels(): Promise<CycleLevelResult[]> {
-      if (import.meta.env.DEV && !MONITORING_CANISTER_ID) return [];
+      if (!MONITORING_CANISTER_ID) return [];
       const a = await getActor();
       const raw = await a.checkCycleLevels() as any[];
       return raw.map((r: any) => ({
@@ -176,14 +176,14 @@ function createMonitoringService() {
     },
 
     async getTrackedCanisters(): Promise<TrackedCanister[]> {
-      if (import.meta.env.DEV && !MONITORING_CANISTER_ID) return [];
+      if (!MONITORING_CANISTER_ID) return [];
       const a = await getActor();
       const raw = await a.getTrackedCanisters() as any[];
       return raw.map((r: any) => ({ id: r.id.toText(), name: r.name }));
     },
 
     async getMetrics(): Promise<MonitoringMetrics> {
-      if (import.meta.env.DEV && !MONITORING_CANISTER_ID) {
+      if (!MONITORING_CANISTER_ID) {
         return {
           totalCanisters: 13,
           activeAlerts:   0,

--- a/frontend/src/services/payment.ts
+++ b/frontend/src/services/payment.ts
@@ -3,9 +3,10 @@ import { getAgent, getPrincipal } from "./actor";
 
 const PAYMENT_CANISTER_ID = (process.env as any).PAYMENT_CANISTER_ID || "";
 const VOICE_AGENT_URL     = (import.meta as any).env?.VITE_VOICE_AGENT_URL ?? "http://localhost:3001";
-// Local dfx replica doesn't forward custom HTTP headers in outcalls correctly.
-// In dev, route Stripe checkout through the Express voice server instead.
-const USE_EXPRESS_CHECKOUT = (import.meta as any).env?.DEV === true;
+// Local dfx replica doesn't forward custom HTTP headers in outcalls correctly,
+// so Stripe checkout is routed through the Express voice server on non-IC networks.
+const DFX_NETWORK         = (process.env as any).DFX_NETWORK || "local";
+const USE_EXPRESS_CHECKOUT = DFX_NETWORK !== "ic";
 
 // ─── IDL ──────────────────────────────────────────────────────────────────────
 
@@ -205,7 +206,7 @@ export const paymentService = {
     tier: PlanTier,
     onStep?: (step: "quoting" | "approving" | "confirming") => void,
   ): Promise<void> {
-    if (import.meta.env.DEV && !PAYMENT_CANISTER_ID) return;
+    if (!PAYMENT_CANISTER_ID) return;
     const a = await getActor();
 
     if (tier !== "Free") {
@@ -235,10 +236,10 @@ export const paymentService = {
   },
 
   async getMySubscription(): Promise<{ tier: PlanTier; expiresAt: number | null; cancelledAt: number | null }> {
-    if (import.meta.env.DEV && (window as any).__e2e_subscription) {
+    if ((window as any).__e2e_subscription) {
       return { cancelledAt: null, ...(window as any).__e2e_subscription };
     }
-    if (import.meta.env.DEV && !PAYMENT_CANISTER_ID) return { tier: "Free", expiresAt: null, cancelledAt: null };
+    if (!PAYMENT_CANISTER_ID) return { tier: "Free", expiresAt: null, cancelledAt: null };
     const a = await getActor();
     const result = await a.getMySubscription();
     if ("err" in result) return { tier: "Free", expiresAt: null, cancelledAt: null };
@@ -267,12 +268,12 @@ export const paymentService = {
     tier: "Pro" | "Premium",
     onStep?: (step: "quoting" | "approving" | "confirming") => void,
   ): Promise<void> {
-    if (import.meta.env.DEV && !PAYMENT_CANISTER_ID) return;
+    if (!PAYMENT_CANISTER_ID) return;
     return this.subscribe(tier, onStep);
   },
 
   async cancel(): Promise<{ expiresAt: number | null }> {
-    if (import.meta.env.DEV && !PAYMENT_CANISTER_ID) return { expiresAt: null };
+    if (!PAYMENT_CANISTER_ID) return { expiresAt: null };
     const a = await getActor();
     const result = await a.cancelSubscription();
     if ("err" in result) {
@@ -327,7 +328,7 @@ export const paymentService = {
   },
 
   async getPricing(tier: PlanTier): Promise<{ priceUSD: number; periodDays: number; propertyLimit: number; photosPerJob: number; quoteRequestsPerMonth: number } | null> {
-    if (import.meta.env.DEV && !PAYMENT_CANISTER_ID) return null;
+    if (!PAYMENT_CANISTER_ID) return null;
     const a = await getActor();
     const result = await a.getPricing({ [tier]: null });
     return {
@@ -340,7 +341,7 @@ export const paymentService = {
   },
 
   async getAllPricing(): Promise<Array<{ tier: PlanTier; priceUSD: number; periodDays: number; propertyLimit: number; photosPerJob: number; quoteRequestsPerMonth: number }>> {
-    if (import.meta.env.DEV && !PAYMENT_CANISTER_ID) return [];
+    if (!PAYMENT_CANISTER_ID) return [];
     const a = await getActor();
     const results = await a.getAllPricing();
     return (results as any[]).map((r) => ({
@@ -387,7 +388,7 @@ export const paymentService = {
     }
 
     // Prod: canister makes the Stripe HTTP outcall directly.
-    if (import.meta.env.DEV && !PAYMENT_CANISTER_ID) throw new Error("Payment canister not deployed");
+    if (!PAYMENT_CANISTER_ID) throw new Error("Payment canister not deployed");
     const a = await getActor();
     const giftArg = gift
       ? [{ recipientEmail: gift.recipientEmail, recipientName: gift.recipientName,
@@ -423,7 +424,7 @@ export const paymentService = {
       return data as { type: "subscription"; tier?: string; billing?: string } | { type: "gift"; giftToken: string };
     }
 
-    if (import.meta.env.DEV && !PAYMENT_CANISTER_ID) throw new Error("Payment canister not deployed");
+    if (!PAYMENT_CANISTER_ID) throw new Error("Payment canister not deployed");
     const a = await getActor();
     const result = await a.verifyStripeSession(sessionId);
 
@@ -438,7 +439,7 @@ export const paymentService = {
 
   /** Redeem a pending gift using the token emailed to the recipient. */
   async redeemGift(giftToken: string): Promise<void> {
-    if (import.meta.env.DEV && !PAYMENT_CANISTER_ID) throw new Error("Payment canister not deployed");
+    if (!PAYMENT_CANISTER_ID) throw new Error("Payment canister not deployed");
     const a = await getActor();
     const result = await a.redeemGift(giftToken);
     if ("err" in result) {

--- a/frontend/src/services/photo.ts
+++ b/frontend/src/services/photo.ts
@@ -208,7 +208,7 @@ function createPhotoService() {
     const bytes      = new Uint8Array(buffer);
     const hash       = await computeHash(buffer);
 
-    if (import.meta.env.DEV && !PHOTO_CANISTER_ID) {
+    if (!PHOTO_CANISTER_ID) {
       const photo: Photo = {
         id:          String(Date.now()),
         jobId,
@@ -242,19 +242,19 @@ function createPhotoService() {
   },
 
   async getByJob(jobId: string): Promise<Photo[]> {
-    if (import.meta.env.DEV && !PHOTO_CANISTER_ID) return store.filter((p) => p.jobId === jobId);
+    if (!PHOTO_CANISTER_ID) return store.filter((p) => p.jobId === jobId);
     const a = await getActor();
     return (await a.getPhotosByJob(jobId) as any[]).map(fromPhoto);
   },
 
   async getByProperty(propertyId: string): Promise<Photo[]> {
-    if (import.meta.env.DEV && !PHOTO_CANISTER_ID) return store.filter((p) => p.propertyId === propertyId);
+    if (!PHOTO_CANISTER_ID) return store.filter((p) => p.propertyId === propertyId);
     const a = await getActor();
     return (await a.getPhotosByProperty(propertyId) as any[]).map(fromPhoto);
   },
 
   async getByRoom(roomId: string): Promise<Photo[]> {
-    if (import.meta.env.DEV && !PHOTO_CANISTER_ID) return store.filter((p) => p.jobId === `ROOM_${roomId}`);
+    if (!PHOTO_CANISTER_ID) return store.filter((p) => p.jobId === `ROOM_${roomId}`);
     const a = await getActor();
     return (await a.getPhotosByRoom(roomId) as any[]).map(fromPhoto);
   },
@@ -271,7 +271,7 @@ function createPhotoService() {
   },
 
   async deletePhoto(photoId: string): Promise<void> {
-    if (import.meta.env.DEV && !PHOTO_CANISTER_ID) return;
+    if (!PHOTO_CANISTER_ID) return;
     const a = await getActor();
     const result = await a.deletePhoto(photoId);
     if ("err" in result) {

--- a/frontend/src/services/property.ts
+++ b/frontend/src/services/property.ts
@@ -328,7 +328,7 @@ function unwrap(result: any): Property {
 
 export const propertyService = {
   async registerProperty(args: RegisterPropertyArgs): Promise<Property> {
-    if (import.meta.env.DEV && !PROPERTY_CANISTER_ID && !process.env.VITEST) {
+    if (!PROPERTY_CANISTER_ID && !process.env.VITEST) {
       const mock: Property = {
         id:                _mockNextId(),
         owner:             "local-dev",
@@ -366,7 +366,7 @@ export const propertyService = {
     if (typeof window !== "undefined" && (window as any).__e2e_properties) {
       return (window as any).__e2e_properties as Property[];
     }
-    if (import.meta.env.DEV && !PROPERTY_CANISTER_ID && !process.env.VITEST) return _mockProperties.map((p) => ({ ...p }));
+    if (!PROPERTY_CANISTER_ID && !process.env.VITEST) return _mockProperties.map((p) => ({ ...p }));
     const a = await getActor();
     const props = await a.getMyProperties();
     return (props as any[]).map(fromProperty);
@@ -472,7 +472,7 @@ export const propertyService = {
   },
 
   async getOwnershipHistory(propertyId: bigint): Promise<TransferRecord[]> {
-    if (import.meta.env.DEV && !PROPERTY_CANISTER_ID) return [];
+    if (!PROPERTY_CANISTER_ID) return [];
     const a = await getActor();
     const records: any[] = await a.getOwnershipHistory(propertyId);
     return records.map((r) => ({
@@ -493,7 +493,7 @@ export const propertyService = {
    * Returns multiple results when the address is ambiguous (e.g. multiple units).
    */
   async searchByAddress(address: string): Promise<Array<{ id: string; owner: string; address: string }>> {
-    if (import.meta.env.DEV && !PROPERTY_CANISTER_ID) {
+    if (!PROPERTY_CANISTER_ID) {
       // In dev/test: fuzzy match against mock properties
       const term = address.toLowerCase();
       return _mockProperties
@@ -577,7 +577,7 @@ export const propertyService = {
 
   /** Returns all properties where the caller has a manager role. */
   async getMyManagedProperties(): Promise<ManagedProperty[]> {
-    if (import.meta.env.DEV && !PROPERTY_CANISTER_ID) return [];
+    if (!PROPERTY_CANISTER_ID) return [];
     const a = await getActor();
     const results: any[] = await a.getMyManagedProperties();
     return results.map((r) => ({
@@ -617,7 +617,7 @@ export const propertyService = {
 
   /** Owner fetches notifications about manager actions on their property. */
   async getOwnerNotifications(propertyId: bigint): Promise<OwnerNotification[]> {
-    if (import.meta.env.DEV && !PROPERTY_CANISTER_ID) return [];
+    if (!PROPERTY_CANISTER_ID) return [];
     const a = await getActor();
     const result = await a.getOwnerNotifications(propertyId);
     if ("ok" in result) return (result.ok as any[]).map(fromOwnerNotification);

--- a/frontend/src/services/quote.ts
+++ b/frontend/src/services/quote.ts
@@ -192,7 +192,7 @@ function createQuoteService() {
     req: Omit<QuoteRequest, "id" | "createdAt" | "status" | "homeowner">,
     tier?: string
   ): Promise<QuoteRequest> {
-    if (import.meta.env.DEV && !QUOTE_CANISTER_ID) {
+    if (!QUOTE_CANISTER_ID) {
       if (tier) {
         const quota = this.getQuotaForTier(tier);
         if (quota > 0) {
@@ -223,7 +223,7 @@ function createQuoteService() {
   },
 
   async getRequests(): Promise<QuoteRequest[]> {
-    if (import.meta.env.DEV && !QUOTE_CANISTER_ID) {
+    if (!QUOTE_CANISTER_ID) {
       // E2E: use Playwright-injected fixture requests when available
       const e2e = typeof window !== "undefined" && (window as any).__e2e_quote_requests;
       return e2e ? (e2e as QuoteRequest[]) : [...mockRequests];
@@ -233,7 +233,7 @@ function createQuoteService() {
   },
 
   async getOpenRequests(): Promise<QuoteRequest[]> {
-    if (import.meta.env.DEV && !QUOTE_CANISTER_ID) return [...mockOpenRequests];
+    if (!QUOTE_CANISTER_ID) return [...mockOpenRequests];
     const a = await getActor();
     return (await a.getOpenRequests() as any[]).map(fromRequest);
   },
@@ -244,7 +244,7 @@ function createQuoteService() {
     timelineDays: number,
     validUntilMs: number
   ): Promise<Quote> {
-    if (import.meta.env.DEV && !QUOTE_CANISTER_ID) {
+    if (!QUOTE_CANISTER_ID) {
       const q: Quote = {
         id: `QUOTE_${Date.now()}`, requestId,
         contractor: "local",
@@ -270,11 +270,11 @@ function createQuoteService() {
   },
 
   async getRequest(id: string): Promise<QuoteRequest | undefined> {
-    if (import.meta.env.DEV && !QUOTE_CANISTER_ID) {
+    if (!QUOTE_CANISTER_ID) {
       const fromSeed = mockRequests.find((r) => r.id === id);
       if (fromSeed) return fromSeed;
       // Playwright e2e injection
-      const e2eRequests = import.meta.env.DEV && typeof window !== "undefined" && (window as any).__e2e_quote_requests;
+      const e2eRequests = typeof window !== "undefined" && (window as any).__e2e_quote_requests;
       return e2eRequests ? (e2eRequests as QuoteRequest[]).find((r) => r.id === id) : undefined;
     }
     const a = await getActor();
@@ -284,7 +284,7 @@ function createQuoteService() {
   },
 
   async getBidCountMap(requestIds: string[]): Promise<Record<string, number>> {
-    if (import.meta.env.DEV && !QUOTE_CANISTER_ID) {
+    if (!QUOTE_CANISTER_ID) {
       const map: Record<string, number> = {};
       for (const id of requestIds) {
         const stored = mockQuotesByRequest.get(id);
@@ -308,16 +308,16 @@ function createQuoteService() {
   },
 
   async getMyBids(): Promise<Quote[]> {
-    if (import.meta.env.DEV && !QUOTE_CANISTER_ID) return [...mockMyBids];
+    if (!QUOTE_CANISTER_ID) return [...mockMyBids];
     // No dedicated canister endpoint yet — return empty; canister can add getMyQuotes later
     return [];
   },
 
   async getQuotesForRequest(requestId: string): Promise<Quote[]> {
-    if (import.meta.env.DEV && !QUOTE_CANISTER_ID) {
+    if (!QUOTE_CANISTER_ID) {
       const fromMap = mockQuotesByRequest.get(requestId) ?? [];
       // Playwright e2e injection
-      const e2eQuotes = import.meta.env.DEV && typeof window !== "undefined" && (window as any).__e2e_quotes;
+      const e2eQuotes = typeof window !== "undefined" && (window as any).__e2e_quotes;
       const fromWindow = e2eQuotes
         ? (e2eQuotes as Quote[]).filter((q) => q.requestId === requestId)
         : [];
@@ -330,7 +330,7 @@ function createQuoteService() {
   },
 
   async accept(quoteId: string): Promise<void> {
-    if (import.meta.env.DEV && !QUOTE_CANISTER_ID) return;
+    if (!QUOTE_CANISTER_ID) return;
     const a = await getActor();
     const result = await a.acceptQuote(quoteId);
     if ("err" in result) {
@@ -340,7 +340,7 @@ function createQuoteService() {
   },
 
   async close(requestId: string): Promise<void> {
-    if (import.meta.env.DEV && !QUOTE_CANISTER_ID) return;
+    if (!QUOTE_CANISTER_ID) return;
     const a = await getActor();
     const result = await a.closeQuoteRequest(requestId);
     if ("err" in result) {
@@ -350,7 +350,7 @@ function createQuoteService() {
   },
 
   async cancel(requestId: string): Promise<void> {
-    if (import.meta.env.DEV && !QUOTE_CANISTER_ID) {
+    if (!QUOTE_CANISTER_ID) {
       const req = mockRequests.find((r) => r.id === requestId);
       if (req) req.status = "cancelled";
       return;

--- a/frontend/src/services/recurringService.ts
+++ b/frontend/src/services/recurringService.ts
@@ -252,7 +252,7 @@ function createRecurringService() {
   let _actor: any = null;
   // Seed from Playwright test globals if present (window.__e2e_recurring set by addInitScript)
   const mockServices: RecurringService[] =
-    import.meta.env.DEV && typeof window !== "undefined" && (window as any).__e2e_recurring
+    typeof window !== "undefined" && (window as any).__e2e_recurring
       ? [...(window as any).__e2e_recurring]
       : [];
   const mockVisits: VisitLog[] = [];
@@ -267,7 +267,7 @@ function createRecurringService() {
 
   return {
   async getById(serviceId: string): Promise<RecurringService | null> {
-    if (import.meta.env.DEV && !RECURRING_CANISTER_ID) {
+    if (!RECURRING_CANISTER_ID) {
       return mockServices.find((s) => s.id === serviceId) ?? null;
     }
     const a = await getActor();
@@ -277,7 +277,7 @@ function createRecurringService() {
   },
 
   async getByProperty(propertyId: string): Promise<RecurringService[]> {
-    if (import.meta.env.DEV && !RECURRING_CANISTER_ID) {
+    if (!RECURRING_CANISTER_ID) {
       return mockServices.filter((s) => s.propertyId === propertyId);
     }
     const a = await getActor();
@@ -285,11 +285,11 @@ function createRecurringService() {
   },
 
   async create(input: CreateRecurringServiceInput): Promise<RecurringService> {
-    if (import.meta.env.DEV && !RECURRING_CANISTER_ID) {
+    if (!RECURRING_CANISTER_ID) {
       const svc: RecurringService = {
         ...input,
         id:        `REC_${Date.now()}`,
-        homeowner: (import.meta.env.DEV && typeof window !== "undefined" && (window as any).__e2e_principal) || "mock-principal",
+        homeowner: (typeof window !== "undefined" && (window as any).__e2e_principal) || "mock-principal",
         status:    "Active",
         createdAt: Date.now(),
       };
@@ -312,7 +312,7 @@ function createRecurringService() {
   },
 
   async updateStatus(serviceId: string, status: ServiceStatus): Promise<RecurringService> {
-    if (import.meta.env.DEV && !RECURRING_CANISTER_ID) {
+    if (!RECURRING_CANISTER_ID) {
       const idx = mockServices.findIndex((s) => s.id === serviceId);
       if (idx === -1) throw new Error("Service not found");
       mockServices[idx] = { ...mockServices[idx], status };
@@ -324,7 +324,7 @@ function createRecurringService() {
   },
 
   async attachContractDoc(serviceId: string, photoId: string): Promise<RecurringService> {
-    if (import.meta.env.DEV && !RECURRING_CANISTER_ID) {
+    if (!RECURRING_CANISTER_ID) {
       const idx = mockServices.findIndex((s) => s.id === serviceId);
       if (idx === -1) throw new Error("Service not found");
       mockServices[idx] = { ...mockServices[idx], contractDocPhotoId: photoId };
@@ -336,7 +336,7 @@ function createRecurringService() {
   },
 
   async addVisitLog(serviceId: string, visitDate: string, note?: string): Promise<VisitLog> {
-    if (import.meta.env.DEV && !RECURRING_CANISTER_ID) {
+    if (!RECURRING_CANISTER_ID) {
       const svc = mockServices.find((s) => s.id === serviceId);
       if (!svc) throw new Error("Service not found");
       const entry: VisitLog = {
@@ -356,7 +356,7 @@ function createRecurringService() {
   },
 
   async getVisitLogs(serviceId: string): Promise<VisitLog[]> {
-    if (import.meta.env.DEV && !RECURRING_CANISTER_ID) {
+    if (!RECURRING_CANISTER_ID) {
       return mockVisits
         .filter((v) => v.serviceId === serviceId)
         .sort((a, b) => b.visitDate.localeCompare(a.visitDate));

--- a/frontend/src/services/referralService.ts
+++ b/frontend/src/services/referralService.ts
@@ -28,7 +28,7 @@ export const referralService = {
 
   /** Fetch pending referral fees (admin). Returns empty array when canister absent. */
   async getPendingFees(): Promise<ReferralFeeRecord[]> {
-    if (import.meta.env.DEV && !JOB_CANISTER_ID) return [];
+    if (!JOB_CANISTER_ID) return [];
     // TODO(#82): call job canister getReferralFees() once implemented on-chain
     return [];
   },

--- a/frontend/src/services/report.ts
+++ b/frontend/src/services/report.ts
@@ -374,7 +374,7 @@ function createReportService() {
     expiryDays:        number | null,
     visibility:        VisibilityLevel
   ): Promise<ShareLink> {
-    if (import.meta.env.DEV && !REPORT_CANISTER_ID) {
+    if (!REPORT_CANISTER_ID) {
       mockCounter++;
       const now        = Date.now();
       const snapshotId = `SNAP_${mockCounter}_${now}`;
@@ -453,7 +453,7 @@ function createReportService() {
   },
 
   async getReport(token: string): Promise<{ link: ShareLink; snapshot: ReportSnapshot }> {
-    if (import.meta.env.DEV && !REPORT_CANISTER_ID) {
+    if (!REPORT_CANISTER_ID) {
       const link = mockLinks.get(token);
       if (!link)         throw new Error("Report not found");
       if (!link.isActive) throw new Error("This report link has been revoked");
@@ -480,7 +480,7 @@ function createReportService() {
   },
 
   async listShareLinks(propertyId: string): Promise<ShareLink[]> {
-    if (import.meta.env.DEV && !REPORT_CANISTER_ID) {
+    if (!REPORT_CANISTER_ID) {
       return Array.from(mockLinks.values()).filter((l) => l.propertyId === propertyId);
     }
     const a = await getActor();
@@ -488,7 +488,7 @@ function createReportService() {
   },
 
   async revokeShareLink(token: string): Promise<void> {
-    if (import.meta.env.DEV && !REPORT_CANISTER_ID) {
+    if (!REPORT_CANISTER_ID) {
       const link = mockLinks.get(token);
       if (!link) throw new Error("Link not found");
       mockLinks.set(token, { ...link, isActive: false });

--- a/frontend/src/services/room.ts
+++ b/frontend/src/services/room.ts
@@ -201,7 +201,7 @@ function createRoomService() {
 
   return {
   async getRoomsByProperty(propertyId: string): Promise<Room[]> {
-    if (import.meta.env.DEV && !ROOM_CANISTER_ID) {
+    if (!ROOM_CANISTER_ID) {
       return mockRooms.filter((r) => r.propertyId === propertyId);
     }
     const actor = await getActor();
@@ -210,7 +210,7 @@ function createRoomService() {
   },
 
   async createRoom(args: CreateRoomArgs): Promise<Room> {
-    if (import.meta.env.DEV && !ROOM_CANISTER_ID) {
+    if (!ROOM_CANISTER_ID) {
       const room: Room = {
         ...args,
         id:        `ROOM_${mockRooms.length + 1}`,
@@ -227,7 +227,7 @@ function createRoomService() {
   },
 
   async updateRoom(id: string, args: UpdateRoomArgs): Promise<Room> {
-    if (import.meta.env.DEV && !ROOM_CANISTER_ID) {
+    if (!ROOM_CANISTER_ID) {
       mockRooms = mockRooms.map((r) =>
         r.id !== id ? r : { ...r, ...args, updatedAt: BigInt(Date.now()) * BigInt(1_000_000) }
       );
@@ -238,7 +238,7 @@ function createRoomService() {
   },
 
   async deleteRoom(id: string): Promise<void> {
-    if (import.meta.env.DEV && !ROOM_CANISTER_ID) {
+    if (!ROOM_CANISTER_ID) {
       mockRooms = mockRooms.filter((r) => r.id !== id);
       return;
     }
@@ -247,7 +247,7 @@ function createRoomService() {
   },
 
   async addFixture(roomId: string, args: AddFixtureArgs): Promise<Room> {
-    if (import.meta.env.DEV && !ROOM_CANISTER_ID) {
+    if (!ROOM_CANISTER_ID) {
       const fixture: Fixture = {
         id: `FIX_${++mockFixtureCounter}`,
         ...args,
@@ -262,7 +262,7 @@ function createRoomService() {
   },
 
   async updateFixture(roomId: string, fixtureId: string, args: AddFixtureArgs): Promise<Room> {
-    if (import.meta.env.DEV && !ROOM_CANISTER_ID) {
+    if (!ROOM_CANISTER_ID) {
       mockRooms = mockRooms.map((r) =>
         r.id !== roomId ? r : {
           ...r,
@@ -282,7 +282,7 @@ function createRoomService() {
   },
 
   async removeFixture(roomId: string, fixtureId: string): Promise<Room> {
-    if (import.meta.env.DEV && !ROOM_CANISTER_ID) {
+    if (!ROOM_CANISTER_ID) {
       mockRooms = mockRooms.map((r) =>
         r.id !== roomId ? r : { ...r, fixtures: r.fixtures.filter((f) => f.id !== fixtureId) }
       );

--- a/frontend/src/services/sensor.ts
+++ b/frontend/src/services/sensor.ts
@@ -157,7 +157,7 @@ function createSensorService() {
     source:           DeviceSource,
     name:             string
   ): Promise<SensorDevice> {
-    if (import.meta.env.DEV && !SENSOR_CANISTER_ID) {
+    if (!SENSOR_CANISTER_ID) {
       deviceCounter += 1;
       const device: SensorDevice = {
         id:               `DEV_${deviceCounter}`,
@@ -181,7 +181,7 @@ function createSensorService() {
   },
 
   async deactivateDevice(deviceId: string): Promise<void> {
-    if (import.meta.env.DEV && !SENSOR_CANISTER_ID) {
+    if (!SENSOR_CANISTER_ID) {
       const idx = devices.findIndex((d) => d.id === deviceId);
       if (idx !== -1) devices[idx] = { ...devices[idx], isActive: false };
       return;
@@ -192,7 +192,7 @@ function createSensorService() {
   },
 
   async getDevicesForProperty(propertyId: string): Promise<SensorDevice[]> {
-    if (import.meta.env.DEV && !SENSOR_CANISTER_ID) {
+    if (!SENSOR_CANISTER_ID) {
       return devices.filter((d) => d.propertyId === propertyId && d.isActive);
     }
     const a = await getActor();
@@ -200,7 +200,7 @@ function createSensorService() {
   },
 
   async getEventsForProperty(propertyId: string, limit = 50): Promise<SensorEvent[]> {
-    if (import.meta.env.DEV && !SENSOR_CANISTER_ID) {
+    if (!SENSOR_CANISTER_ID) {
       return mockEvents.filter((e) => e.propertyId === propertyId).slice(0, limit);
     }
     const a = await getActor();
@@ -208,7 +208,7 @@ function createSensorService() {
   },
 
   async getPendingAlerts(propertyId: string): Promise<SensorEvent[]> {
-    if (import.meta.env.DEV && !SENSOR_CANISTER_ID) {
+    if (!SENSOR_CANISTER_ID) {
       return mockEvents.filter((e) => e.propertyId === propertyId && e.severity === "Critical");
     }
     const a = await getActor();
@@ -247,7 +247,7 @@ function createSensorService() {
     unit:       string,
     rawPayload = ""
   ): Promise<SensorEvent> {
-    if (import.meta.env.DEV && !SENSOR_CANISTER_ID) {
+    if (!SENSOR_CANISTER_ID) {
       const severity = this.classifySeverity(eventType, value);
       const event: SensorEvent = {
         id:         `EVT_${++eventCounter}`,


### PR DESCRIPTION
…yer (#126)

All `import.meta.env.DEV && !CANISTER_ID` conditions reduced to `!CANISTER_ID` so mock fallbacks are gated only on runtime canister availability, not build mode.  The two non-mock cases get proper replacements:

- actor.ts loginWithLocalIdentity: guarded by `!IS_LOCAL` (DFX_NETWORK-based) instead of `!import.meta.env.DEV`; same effective block on IC mainnet.
- payment.ts USE_EXPRESS_CHECKOUT: driven by `DFX_NETWORK !== "ic"` rather than DEV flag; the local replica can't forward custom HTTP headers for Stripe outcalls regardless of build mode.

Security test (14.4.5) updated to assert `!IS_LOCAL` guard pattern. All 2983 unit tests pass.

## Summary
<!-- What does this PR do? -->

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [ ] Backend tests pass (`make test`)
- [ ] Frontend builds (`cd frontend && npm run build`)
- [ ] Tested locally with dfx

## Checklist
- [ ] Code follows project conventions
- [ ] Self-review completed
- [ ] No sensitive data committed
