### PR TITLE
feat(listing): add FSBO listing photos with drag-to-reorder (#114)

### DIFF
--- a/backend/listing/main.mo
+++ b/backend/listing/main.mo
@@ -81,6 +81,12 @@ persistent actor Listing {
 
   private let requests  = Map.empty<Text, ListingBidRequest>();
   private let proposals = Map.empty<Text, ListingProposal>();
+  /// propertyId → ordered list of photo IDs (first = cover image)
+  private let listingPhotos      = Map.empty<Text, [Text]>();
+  /// propertyId → the principal who first added a photo (owner lock)
+  private let listingPhotoOwners = Map.empty<Text, Principal>();
+
+  private let MAX_LISTING_PHOTOS : Nat = 15;
 
   // ─── Private Helpers ─────────────────────────────────────────────────────────
 
@@ -365,6 +371,96 @@ persistent actor Listing {
         }
       };
     }
+  };
+
+  // ─── Listing Photos ──────────────────────────────────────────────────────────
+
+  /// Associate a photo (already uploaded to the photo canister) with this
+  /// FSBO listing. The first caller becomes the listing photo owner; all
+  /// subsequent calls must come from the same principal.
+  /// Enforces a cap of 15 photos per listing.
+  public shared(msg) func addListingPhoto(propertyId: Text, photoId: Text) : async Result.Result<(), Error> {
+    switch (requireActive(msg.caller)) { case (#err(e)) return #err(e); case _ {} };
+    if (Text.size(propertyId) == 0) return #err(#InvalidInput("propertyId cannot be empty"));
+    if (Text.size(photoId) == 0)    return #err(#InvalidInput("photoId cannot be empty"));
+
+    // First caller claims ownership; subsequent callers must match.
+    switch (Map.get(listingPhotoOwners, Text.compare, propertyId)) {
+      case null    { Map.add(listingPhotoOwners, Text.compare, propertyId, msg.caller) };
+      case (?owner) {
+        if (owner != msg.caller and not isAdmin(msg.caller))
+          return #err(#Unauthorized);
+      };
+    };
+
+    let existing : [Text] = switch (Map.get(listingPhotos, Text.compare, propertyId)) {
+      case null   { [] };
+      case (?ids) { ids };
+    };
+
+    if (existing.size() >= MAX_LISTING_PHOTOS)
+      return #err(#InvalidInput(
+        "Listing photo limit (" # Nat.toText(MAX_LISTING_PHOTOS) # ") reached"
+      ));
+
+    if (Option.isSome(Array.find<Text>(existing, func(id) { id == photoId })))
+      return #err(#InvalidInput("Photo already added to this listing"));
+
+    Map.add(listingPhotos, Text.compare, propertyId, Array.concat(existing, [photoId]));
+    #ok(())
+  };
+
+  /// Returns the ordered photo IDs for a listing (first = cover image).
+  /// Publicly readable — no authentication required.
+  public query func getListingPhotos(propertyId: Text) : async [Text] {
+    switch (Map.get(listingPhotos, Text.compare, propertyId)) {
+      case null   { [] };
+      case (?ids) { ids };
+    }
+  };
+
+  /// Remove a photo from this listing's ordered list. Owner or admin only.
+  public shared(msg) func removeListingPhoto(propertyId: Text, photoId: Text) : async Result.Result<(), Error> {
+    switch (requireActive(msg.caller)) { case (#err(e)) return #err(e); case _ {} };
+    switch (Map.get(listingPhotoOwners, Text.compare, propertyId)) {
+      case null     { return #err(#NotFound) };
+      case (?owner) {
+        if (owner != msg.caller and not isAdmin(msg.caller))
+          return #err(#Unauthorized);
+      };
+    };
+    let existing : [Text] = switch (Map.get(listingPhotos, Text.compare, propertyId)) {
+      case null   { return #err(#NotFound) };
+      case (?ids) { ids };
+    };
+    Map.add(listingPhotos, Text.compare, propertyId,
+      Array.filter<Text>(existing, func(id) { id != photoId }));
+    #ok(())
+  };
+
+  /// Replace the photo ordering for a listing. The supplied list must contain
+  /// exactly the same IDs that are already stored — only the order may change.
+  public shared(msg) func reorderListingPhotos(propertyId: Text, photoIds: [Text]) : async Result.Result<(), Error> {
+    switch (requireActive(msg.caller)) { case (#err(e)) return #err(e); case _ {} };
+    switch (Map.get(listingPhotoOwners, Text.compare, propertyId)) {
+      case null     { return #err(#NotFound) };
+      case (?owner) {
+        if (owner != msg.caller and not isAdmin(msg.caller))
+          return #err(#Unauthorized);
+      };
+    };
+    let existing : [Text] = switch (Map.get(listingPhotos, Text.compare, propertyId)) {
+      case null   { return #err(#NotFound) };
+      case (?ids) { ids };
+    };
+    if (photoIds.size() != existing.size())
+      return #err(#InvalidInput("Reorder list must contain the same number of photos"));
+    for (id in photoIds.vals()) {
+      if (not Option.isSome(Array.find<Text>(existing, func(e) { e == id })))
+        return #err(#InvalidInput("Unknown photo ID in reorder list: " # id));
+    };
+    Map.add(listingPhotos, Text.compare, propertyId, photoIds);
+    #ok(())
   };
 
   // ─── Admin Controls ───────────────────────────────────────────────────────────

--- a/backend/photo/main.mo
+++ b/backend/photo/main.mo
@@ -30,6 +30,7 @@ persistent actor Photo {
     #Finishing;
     #PostConstruction;
     #Warranty;
+    #Listing;  // FSBO listing photos — uploaded with synthetic jobId "LISTING_<propertyId>"
   };
 
   public type SubscriptionTier = {
@@ -366,6 +367,16 @@ persistent actor Photo {
         #ok(p.data)
       };
     }
+  };
+
+  /// All photos for a FSBO listing — publicly readable without authentication.
+  /// Photos are stored with synthetic jobId "LISTING_<propertyId>" and phase #Listing.
+  /// No ownership check so prospective buyers can view listing photos anonymously.
+  public query func getPublicListingPhotos(propertyId: Text) : async [Photo] {
+    let syntheticJobId = "LISTING_" # propertyId;
+    Iter.toArray(Iter.filter(Map.values(photos), func(p: Photo) : Bool {
+      p.jobId == syntheticJobId
+    }))
   };
 
   /// All photos linked to a room (stored with synthetic jobId "ROOM_<roomId>").

--- a/frontend/src/__tests__/components/FsboListing.test.tsx
+++ b/frontend/src/__tests__/components/FsboListing.test.tsx
@@ -95,9 +95,21 @@ vi.mock("@/services/job", () => ({
 
 vi.mock("@/services/photo", () => ({
   photoService: {
-    getByProperty: vi.fn().mockResolvedValue(mockPhotos),
+    getByProperty:     vi.fn().mockResolvedValue(mockPhotos),
+    getListingPhotos:  vi.fn().mockResolvedValue(mockPhotos),
   },
 }));
+
+vi.mock("@/services/listing", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/services/listing")>();
+  return {
+    ...actual,
+    listingService: {
+      ...actual.listingService,
+      getListingPhotos: vi.fn().mockResolvedValue(["ph1"]),
+    },
+  };
+});
 
 const mockActiveShareLink = {
   token:      "tok-abc123",
@@ -240,20 +252,23 @@ describe("FsboListingPage (10.3.1)", () => {
 
   // ── Photo gallery ───────────────────────────────────────────────────────────
 
-  it("renders a photo when photos are available", async () => {
+  it("renders a photo gallery when listing photos are available", async () => {
     renderPage();
     await waitFor(() => {
-      const img = screen.getByRole("img", { name: /property photo/i });
-      expect(img).toBeInTheDocument();
+      // ListingPhotoManager renders a grid when photos are present
+      expect(screen.getByTestId("listing-photo-grid")).toBeInTheDocument();
+      // The first photo's src matches the injected mock URL
+      const img = screen.getByRole("img", { name: /roof replacement/i });
       expect(img).toHaveAttribute("src", "https://example.com/photo1.jpg");
     });
   });
 
   it("shows a placeholder when no photos exist", async () => {
-    vi.mocked(photoService.getByProperty).mockResolvedValue([]);
+    vi.mocked(photoService.getListingPhotos).mockResolvedValue([]);
     renderPage();
     await waitFor(() => {
-      expect(screen.getByText(/no photos/i)).toBeInTheDocument();
+      expect(screen.getByTestId("listing-photo-empty")).toBeInTheDocument();
+      expect(screen.getByText(/no photos available/i)).toBeInTheDocument();
     });
   });
 

--- a/frontend/src/__tests__/contracts/__snapshots__/candid.contract.test.ts.snap
+++ b/frontend/src/__tests__/contracts/__snapshots__/candid.contract.test.ts.snap
@@ -524,6 +524,16 @@ exports[`listing IDL factory > full signature snapshot 1`] = `
       "variant {ok; err:variant {InvalidInput:text; DeadlinePassed; NotFound; AlreadyCancelled; Unauthorized}}",
     ],
   },
+  "addListingPhoto": {
+    "args": [
+      "text",
+      "text",
+    ],
+    "mode": [],
+    "rets": [
+      "variant {ok; err:variant {InvalidInput:text; DeadlinePassed; NotFound; AlreadyCancelled; Unauthorized}}",
+    ],
+  },
   "cancelBidRequest": {
     "args": [
       "text",
@@ -555,6 +565,17 @@ exports[`listing IDL factory > full signature snapshot 1`] = `
     ],
     "rets": [
       "variant {ok:record {id:text; status:variant {Open; Awarded; Cancelled}; targetListDate:int; desiredSalePrice:opt nat; createdAt:int; propertyId:text; notes:text; homeowner:principal; bidDeadline:int}; err:variant {InvalidInput:text; DeadlinePassed; NotFound; AlreadyCancelled; Unauthorized}}",
+    ],
+  },
+  "getListingPhotos": {
+    "args": [
+      "text",
+    ],
+    "mode": [
+      "query",
+    ],
+    "rets": [
+      "vec text",
     ],
   },
   "getMyBidRequests": {
@@ -593,6 +614,26 @@ exports[`listing IDL factory > full signature snapshot 1`] = `
     ],
     "rets": [
       "vec record {id:text; status:variant {Withdrawn; Rejected; Accepted; Pending}; marketingPlan:text; requestId:text; cmaSummary:text; createdAt:int; commissionBps:nat; agentName:text; coverLetter:text; agentId:principal; agentBrokerage:text; estimatedDaysOnMarket:nat; includedServices:vec text; estimatedSalePrice:nat; validUntil:int}",
+    ],
+  },
+  "removeListingPhoto": {
+    "args": [
+      "text",
+      "text",
+    ],
+    "mode": [],
+    "rets": [
+      "variant {ok; err:variant {InvalidInput:text; DeadlinePassed; NotFound; AlreadyCancelled; Unauthorized}}",
+    ],
+  },
+  "reorderListingPhotos": {
+    "args": [
+      "text",
+      "vec text",
+    ],
+    "mode": [],
+    "rets": [
+      "variant {ok; err:variant {InvalidInput:text; DeadlinePassed; NotFound; AlreadyCancelled; Unauthorized}}",
     ],
   },
   "submitProposal": {
@@ -816,7 +857,7 @@ exports[`photo IDL factory > full signature snapshot 1`] = `
     ],
     "mode": [],
     "rets": [
-      "vec record {id:text; verified:bool; owner:principal; data:vec nat8; hash:text; createdAt:int; size:nat; jobId:text; description:text; propertyId:text; phase:variant {Framing; HVAC; Foundation; Plumbing; Finishing; Insulation; Drywall; Warranty; PreConstruction; Electrical; PostConstruction}; approvals:vec principal}",
+      "vec record {id:text; verified:bool; owner:principal; data:vec nat8; hash:text; createdAt:int; size:nat; jobId:text; description:text; propertyId:text; phase:variant {Framing; HVAC; Foundation; Plumbing; Finishing; Insulation; Drywall; Warranty; PreConstruction; Electrical; Listing; PostConstruction}; approvals:vec principal}",
     ],
   },
   "getPhotosByProperty": {
@@ -825,7 +866,7 @@ exports[`photo IDL factory > full signature snapshot 1`] = `
     ],
     "mode": [],
     "rets": [
-      "vec record {id:text; verified:bool; owner:principal; data:vec nat8; hash:text; createdAt:int; size:nat; jobId:text; description:text; propertyId:text; phase:variant {Framing; HVAC; Foundation; Plumbing; Finishing; Insulation; Drywall; Warranty; PreConstruction; Electrical; PostConstruction}; approvals:vec principal}",
+      "vec record {id:text; verified:bool; owner:principal; data:vec nat8; hash:text; createdAt:int; size:nat; jobId:text; description:text; propertyId:text; phase:variant {Framing; HVAC; Foundation; Plumbing; Finishing; Insulation; Drywall; Warranty; PreConstruction; Electrical; Listing; PostConstruction}; approvals:vec principal}",
     ],
   },
   "getPhotosByRoom": {
@@ -834,7 +875,18 @@ exports[`photo IDL factory > full signature snapshot 1`] = `
     ],
     "mode": [],
     "rets": [
-      "vec record {id:text; verified:bool; owner:principal; data:vec nat8; hash:text; createdAt:int; size:nat; jobId:text; description:text; propertyId:text; phase:variant {Framing; HVAC; Foundation; Plumbing; Finishing; Insulation; Drywall; Warranty; PreConstruction; Electrical; PostConstruction}; approvals:vec principal}",
+      "vec record {id:text; verified:bool; owner:principal; data:vec nat8; hash:text; createdAt:int; size:nat; jobId:text; description:text; propertyId:text; phase:variant {Framing; HVAC; Foundation; Plumbing; Finishing; Insulation; Drywall; Warranty; PreConstruction; Electrical; Listing; PostConstruction}; approvals:vec principal}",
+    ],
+  },
+  "getPublicListingPhotos": {
+    "args": [
+      "text",
+    ],
+    "mode": [
+      "query",
+    ],
+    "rets": [
+      "vec record {id:text; verified:bool; owner:principal; data:vec nat8; hash:text; createdAt:int; size:nat; jobId:text; description:text; propertyId:text; phase:variant {Framing; HVAC; Foundation; Plumbing; Finishing; Insulation; Drywall; Warranty; PreConstruction; Electrical; Listing; PostConstruction}; approvals:vec principal}",
     ],
   },
   "setPropertyCanisterId": {
@@ -850,14 +902,14 @@ exports[`photo IDL factory > full signature snapshot 1`] = `
     "args": [
       "text",
       "text",
-      "variant {Framing; HVAC; Foundation; Plumbing; Finishing; Insulation; Drywall; Warranty; PreConstruction; Electrical; PostConstruction}",
+      "variant {Framing; HVAC; Foundation; Plumbing; Finishing; Insulation; Drywall; Warranty; PreConstruction; Electrical; Listing; PostConstruction}",
       "text",
       "text",
       "vec nat8",
     ],
     "mode": [],
     "rets": [
-      "variant {ok:record {id:text; verified:bool; owner:principal; data:vec nat8; hash:text; createdAt:int; size:nat; jobId:text; description:text; propertyId:text; phase:variant {Framing; HVAC; Foundation; Plumbing; Finishing; Insulation; Drywall; Warranty; PreConstruction; Electrical; PostConstruction}; approvals:vec principal}; err:variant {InvalidInput:text; Duplicate:text; NotFound; Unauthorized; QuotaExceeded:text}}",
+      "variant {ok:record {id:text; verified:bool; owner:principal; data:vec nat8; hash:text; createdAt:int; size:nat; jobId:text; description:text; propertyId:text; phase:variant {Framing; HVAC; Foundation; Plumbing; Finishing; Insulation; Drywall; Warranty; PreConstruction; Electrical; Listing; PostConstruction}; approvals:vec principal}; err:variant {InvalidInput:text; Duplicate:text; NotFound; Unauthorized; QuotaExceeded:text}}",
     ],
   },
 }

--- a/frontend/src/__tests__/contracts/candid.contract.test.ts
+++ b/frontend/src/__tests__/contracts/candid.contract.test.ts
@@ -287,13 +287,17 @@ describe("listing IDL factory", () => {
     const svc = extractService(listingIdlFactory);
     expect(Object.keys(svc).sort()).toEqual([
       "acceptProposal",
+      "addListingPhoto",
       "cancelBidRequest",
       "createBidRequest",
       "getBidRequest",
+      "getListingPhotos",
       "getMyBidRequests",
       "getMyProposals",
       "getOpenBidRequests",
       "getProposalsForRequest",
+      "removeListingPhoto",
+      "reorderListingPhotos",
       "submitProposal",
     ]);
   });
@@ -306,6 +310,7 @@ describe("listing IDL factory", () => {
       .sort();
     expect(queries).toEqual([
       "getBidRequest",
+      "getListingPhotos",
       "getMyBidRequests",
       "getMyProposals",
       "getOpenBidRequests",
@@ -453,6 +458,7 @@ describe("photo IDL factory", () => {
       "getPhotosByJob",
       "getPhotosByProperty",
       "getPhotosByRoom",
+      "getPublicListingPhotos",
       "setPropertyCanisterId",
       "uploadPhoto",
     ]);

--- a/frontend/src/__tests__/services/__snapshots__/candidContracts.test.ts.snap
+++ b/frontend/src/__tests__/services/__snapshots__/candidContracts.test.ts.snap
@@ -91,13 +91,17 @@ verifyJob(1) -> (1)"
 
 exports[`Candid contract snapshots — method arity > listing 1`] = `
 "acceptProposal(1) -> (1)
+addListingPhoto(2) -> (1)
 cancelBidRequest(1) -> (1)
 createBidRequest(5) -> (1)
 getBidRequest(1) -> (1) [query]
+getListingPhotos(1) -> (1) [query]
 getMyBidRequests(0) -> (1) [query]
 getMyProposals(0) -> (1) [query]
 getOpenBidRequests(0) -> (1) [query]
 getProposalsForRequest(1) -> (1) [query]
+removeListingPhoto(2) -> (1)
+reorderListingPhotos(2) -> (1)
 submitProposal(11) -> (1)"
 `;
 
@@ -140,6 +144,7 @@ exports[`Candid contract snapshots — method arity > photo 1`] = `
 getPhotosByJob(1) -> (1)
 getPhotosByProperty(1) -> (1)
 getPhotosByRoom(1) -> (1)
+getPublicListingPhotos(1) -> (1) [query]
 setPropertyCanisterId(1) -> (1)
 uploadPhoto(6) -> (1)"
 `;

--- a/frontend/src/__tests__/services/listing.test.ts
+++ b/frontend/src/__tests__/services/listing.test.ts
@@ -653,3 +653,71 @@ describe("listingService.acceptProposal", () => {
     expect(open.some(r => r.id === req.id)).toBe(false);
   });
 });
+
+// ─── Listing photos (issue #114) ──────────────────────────────────────────────
+
+describe("listing photo management", () => {
+  beforeEach(() => { listingService.reset(); });
+
+  it("addListingPhoto appends a photo ID to the listing", async () => {
+    await listingService.addListingPhoto("prop-1", "PHOTO_1");
+    const ids = await listingService.getListingPhotos("prop-1");
+    expect(ids).toContain("PHOTO_1");
+  });
+
+  it("addListingPhoto preserves insertion order", async () => {
+    await listingService.addListingPhoto("prop-ord", "A");
+    await listingService.addListingPhoto("prop-ord", "B");
+    await listingService.addListingPhoto("prop-ord", "C");
+    const ids = await listingService.getListingPhotos("prop-ord");
+    expect(ids).toEqual(["A", "B", "C"]);
+  });
+
+  it("getListingPhotos returns [] for an unknown property", async () => {
+    const ids = await listingService.getListingPhotos("nonexistent");
+    expect(ids).toEqual([]);
+  });
+
+  it("addListingPhoto enforces the 15-photo cap", async () => {
+    for (let i = 0; i < 15; i++) {
+      await listingService.addListingPhoto("prop-cap", `PHOTO_${i}`);
+    }
+    await expect(
+      listingService.addListingPhoto("prop-cap", "PHOTO_15")
+    ).rejects.toThrow("Listing photo limit (15) reached");
+  });
+
+  it("addListingPhoto rejects duplicate photo IDs", async () => {
+    await listingService.addListingPhoto("prop-dup", "PHOTO_1");
+    await expect(
+      listingService.addListingPhoto("prop-dup", "PHOTO_1")
+    ).rejects.toThrow("already added");
+  });
+
+  it("removeListingPhoto removes a photo ID leaving the rest intact", async () => {
+    await listingService.addListingPhoto("prop-rm", "A");
+    await listingService.addListingPhoto("prop-rm", "B");
+    await listingService.addListingPhoto("prop-rm", "C");
+    await listingService.removeListingPhoto("prop-rm", "B");
+    const ids = await listingService.getListingPhotos("prop-rm");
+    expect(ids).not.toContain("B");
+    expect(ids).toContain("A");
+    expect(ids).toContain("C");
+  });
+
+  it("reorderListingPhotos changes the sequence", async () => {
+    await listingService.addListingPhoto("prop-reorder", "A");
+    await listingService.addListingPhoto("prop-reorder", "B");
+    await listingService.addListingPhoto("prop-reorder", "C");
+    await listingService.reorderListingPhotos("prop-reorder", ["C", "A", "B"]);
+    const ids = await listingService.getListingPhotos("prop-reorder");
+    expect(ids).toEqual(["C", "A", "B"]);
+  });
+
+  it("reset() clears all photo associations", async () => {
+    await listingService.addListingPhoto("prop-rst", "X");
+    listingService.reset();
+    const ids = await listingService.getListingPhotos("prop-rst");
+    expect(ids).toEqual([]);
+  });
+});

--- a/frontend/src/__tests__/services/photo.test.ts
+++ b/frontend/src/__tests__/services/photo.test.ts
@@ -253,4 +253,59 @@ describe("photoService", () => {
       expect(quota.limit).toBeGreaterThan(0);
     });
   });
+
+  // ── uploadListingPhoto (issue #114) ──────────────────────────────────────────
+  describe("uploadListingPhoto", () => {
+    it("stores photo with synthetic LISTING_<propertyId> jobId", async () => {
+      const photo = await photoService.uploadListingPhoto(
+        makeFile("front image", "front.jpg"),
+        "prop-1",
+        "Front of house"
+      );
+      expect(photo.jobId).toBe("LISTING_prop-1");
+    });
+
+    it("preserves the supplied propertyId", async () => {
+      const photo = await photoService.uploadListingPhoto(makeFile(), "prop-99", "Back yard");
+      expect(photo.propertyId).toBe("prop-99");
+    });
+
+    it("sets phase to Listing", async () => {
+      const photo = await photoService.uploadListingPhoto(makeFile(), "prop-1", "Kitchen");
+      expect(photo.phase).toBe("Listing");
+    });
+
+    it("preserves the description", async () => {
+      const photo = await photoService.uploadListingPhoto(makeFile(), "prop-1", "Master bedroom");
+      expect(photo.description).toBe("Master bedroom");
+    });
+  });
+
+  // ── getListingPhotos (issue #114) ─────────────────────────────────────────────
+  describe("getListingPhotos", () => {
+    it("returns an empty array when no listing photos uploaded", async () => {
+      expect(await photoService.getListingPhotos("any-prop")).toEqual([]);
+    });
+
+    it("returns only photos with the LISTING_<propertyId> synthetic jobId", async () => {
+      await photoService.uploadListingPhoto(makeFile("a"), "prop-listing", "Photo 1");
+      await photoService.uploadListingPhoto(makeFile("b"), "prop-listing", "Photo 2");
+      // upload a non-listing photo for the same property — must not appear
+      await photoService.upload(makeFile("job img"), "JOB_1", "prop-listing", "Finishing", "Job photo");
+      const listingPhotos = await photoService.getListingPhotos("prop-listing");
+      expect(listingPhotos).toHaveLength(2);
+      expect(listingPhotos.every((p) => p.jobId === "LISTING_prop-listing")).toBe(true);
+    });
+
+    it("does not return listing photos for a different property", async () => {
+      await photoService.uploadListingPhoto(makeFile(), "prop-A", "Photo");
+      expect(await photoService.getListingPhotos("prop-B")).toHaveLength(0);
+    });
+
+    it("reset() clears listing photos from the store", async () => {
+      await photoService.uploadListingPhoto(makeFile(), "prop-rst", "Photo");
+      photoService.reset();
+      expect(await photoService.getListingPhotos("prop-rst")).toHaveLength(0);
+    });
+  });
 });

--- a/frontend/src/components/ListingPhotoManager.tsx
+++ b/frontend/src/components/ListingPhotoManager.tsx
@@ -1,0 +1,354 @@
+/**
+ * ListingPhotoManager — Issue #114
+ *
+ * Owner view  : upload photos, drag-to-reorder, delete.  First photo becomes
+ *               the cover image shown in the public listing.
+ * Gallery view: read-only ordered gallery for prospective buyers.
+ *
+ * Props
+ *  propertyId  — the FSBO listing's property ID
+ *  isOwner     — when true the full management UI is shown
+ *  onPhotoCountChange — optional callback so the parent can reflect the count
+ */
+
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import { Camera, Trash2, GripVertical, AlertCircle, Upload } from "lucide-react";
+import { COLORS, FONTS, RADIUS } from "@/theme";
+import { photoService, type Photo } from "@/services/photo";
+import { listingService } from "@/services/listing";
+
+const MAX_PHOTOS = 15;
+
+const UI = {
+  ink:      COLORS.plum,
+  inkLight: COLORS.plumMid,
+  rule:     COLORS.rule,
+  sage:     COLORS.sage,
+  rust:     COLORS.rust,
+  paper:    COLORS.white,
+  sans:     FONTS.sans,
+  mono:     FONTS.sans,
+};
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function sortByOrder(photos: Photo[], order: string[]): Photo[] {
+  const byId = new Map(photos.map((p) => [p.id, p]));
+  // Photos present in order list first (preserves sequence), then any extras
+  const sorted = order.flatMap((id) => (byId.has(id) ? [byId.get(id)!] : []));
+  const inOrder = new Set(order);
+  photos.forEach((p) => { if (!inOrder.has(p.id)) sorted.push(p); });
+  return sorted;
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+interface ListingPhotoManagerProps {
+  propertyId:          string;
+  isOwner:             boolean;
+  onPhotoCountChange?: (count: number) => void;
+}
+
+export default function ListingPhotoManager({
+  propertyId,
+  isOwner,
+  onPhotoCountChange,
+}: ListingPhotoManagerProps) {
+  const [photos,     setPhotos]     = useState<Photo[]>([]);
+  const [order,      setOrder]      = useState<string[]>([]);
+  const [uploading,  setUploading]  = useState(false);
+  const [error,      setError]      = useState<string | null>(null);
+  const fileInputRef                = useRef<HTMLInputElement>(null);
+
+  // drag-to-reorder state
+  const dragIndexRef = useRef<number | null>(null);
+
+  const load = useCallback(async () => {
+    try {
+      const [rawPhotos, rawOrder] = await Promise.all([
+        photoService.getListingPhotos(propertyId),
+        listingService.getListingPhotos(propertyId),
+      ]);
+      setPhotos(rawPhotos);
+      setOrder(rawOrder);
+      onPhotoCountChange?.(rawPhotos.length);
+    } catch {
+      // non-fatal — show empty state
+    }
+  }, [propertyId, onPhotoCountChange]);
+
+  useEffect(() => { load(); }, [load]);
+
+  const sorted = sortByOrder(photos, order);
+
+  // ── Upload ────────────────────────────────────────────────────────────────
+
+  async function handleFiles(files: FileList | null) {
+    if (!files || files.length === 0) return;
+    if (photos.length >= MAX_PHOTOS) {
+      setError(`Maximum ${MAX_PHOTOS} photos per listing.`);
+      return;
+    }
+    setError(null);
+    setUploading(true);
+    try {
+      for (const file of Array.from(files)) {
+        if (photos.length >= MAX_PHOTOS) break;
+        if (!file.type.startsWith("image/")) continue;
+        const photo = await photoService.uploadListingPhoto(file, propertyId, file.name);
+        await listingService.addListingPhoto(propertyId, photo.id);
+      }
+      await load();
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : "Upload failed");
+    } finally {
+      setUploading(false);
+    }
+  }
+
+  // ── Delete ────────────────────────────────────────────────────────────────
+
+  async function handleDelete(photoId: string) {
+    try {
+      await photoService.deletePhoto(photoId);
+      await listingService.removeListingPhoto(propertyId, photoId);
+      await load();
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : "Delete failed");
+    }
+  }
+
+  // ── Drag-to-reorder ───────────────────────────────────────────────────────
+
+  function handleDragStart(index: number) {
+    dragIndexRef.current = index;
+  }
+
+  function handleDragOver(e: React.DragEvent, index: number) {
+    e.preventDefault();
+    const from = dragIndexRef.current;
+    if (from === null || from === index) return;
+    const next = [...sorted];
+    const [moved] = next.splice(from, 1);
+    next.splice(index, 0, moved);
+    dragIndexRef.current = index;
+    const newOrder = next.map((p) => p.id);
+    setOrder(newOrder);
+    setPhotos(next);
+  }
+
+  async function handleDrop() {
+    dragIndexRef.current = null;
+    const newOrder = sorted.map((p) => p.id);
+    try {
+      await listingService.reorderListingPhotos(propertyId, newOrder);
+    } catch {
+      // revert on failure
+      await load();
+    }
+  }
+
+  // ── Render ────────────────────────────────────────────────────────────────
+
+  const atCap = photos.length >= MAX_PHOTOS;
+
+  return (
+    <div data-testid="listing-photo-manager">
+
+      {/* ── Owner upload controls ────────────────────────────────────────── */}
+      {isOwner && (
+        <div style={{ marginBottom: "1rem" }}>
+          <div style={{ display: "flex", alignItems: "center", gap: "0.75rem", flexWrap: "wrap" }}>
+            <button
+              data-testid="upload-listing-photo-btn"
+              disabled={uploading || atCap}
+              onClick={() => fileInputRef.current?.click()}
+              style={{
+                display:      "inline-flex",
+                alignItems:   "center",
+                gap:          "0.4rem",
+                background:   atCap ? UI.rule : UI.sage,
+                color:        atCap ? UI.inkLight : "#fff",
+                border:       "none",
+                borderRadius: RADIUS.pill,
+                padding:      "0.5rem 1.1rem",
+                fontFamily:   UI.mono,
+                fontSize:     "0.75rem",
+                fontWeight:   700,
+                cursor:       atCap ? "not-allowed" : "pointer",
+                opacity:      uploading ? 0.6 : 1,
+              }}
+            >
+              <Upload size={13} />
+              {uploading ? "Uploading…" : "Add Photos"}
+            </button>
+            <span style={{ fontFamily: UI.mono, fontSize: "0.7rem", color: UI.inkLight }}>
+              {photos.length} / {MAX_PHOTOS} photos
+            </span>
+          </div>
+
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/*"
+            multiple
+            style={{ display: "none" }}
+            onChange={(e) => handleFiles(e.target.files)}
+          />
+
+          {isOwner && photos.length > 1 && (
+            <p style={{ fontFamily: UI.mono, fontSize: "0.65rem", color: UI.inkLight, marginTop: "0.5rem" }}>
+              Drag photos to reorder — first photo becomes the cover image.
+            </p>
+          )}
+        </div>
+      )}
+
+      {/* ── Error ───────────────────────────────────────────────────────── */}
+      {error && (
+        <div
+          style={{
+            display:      "flex",
+            alignItems:   "center",
+            gap:          "0.4rem",
+            background:   "#FFF5F5",
+            border:       `1px solid ${UI.rust}60`,
+            borderRadius: RADIUS.card,
+            padding:      "0.6rem 0.85rem",
+            marginBottom: "0.75rem",
+            fontFamily:   UI.sans,
+            fontSize:     "0.8rem",
+            color:        UI.rust,
+          }}
+        >
+          <AlertCircle size={14} />
+          {error}
+        </div>
+      )}
+
+      {/* ── Empty state ──────────────────────────────────────────────────── */}
+      {photos.length === 0 && (
+        <div
+          data-testid="listing-photo-empty"
+          style={{
+            background:   UI.rule + "50",
+            border:       `1px dashed ${UI.rule}`,
+            borderRadius: RADIUS.card,
+            padding:      "2rem",
+            textAlign:    "center",
+            color:        UI.inkLight,
+          }}
+        >
+          <Camera size={28} style={{ marginBottom: "0.5rem", opacity: 0.5 }} />
+          <p style={{ fontFamily: UI.mono, fontSize: "0.75rem", margin: 0 }}>
+            {isOwner ? "No photos yet — add some to attract buyers." : "No photos available."}
+          </p>
+        </div>
+      )}
+
+      {/* ── Photo grid ───────────────────────────────────────────────────── */}
+      {photos.length > 0 && (
+        <div
+          data-testid="listing-photo-grid"
+          style={{
+            display:             "grid",
+            gridTemplateColumns: "repeat(auto-fill, minmax(140px, 1fr))",
+            gap:                 "0.65rem",
+          }}
+        >
+          {sorted.map((photo, index) => (
+            <div
+              key={photo.id}
+              draggable={isOwner}
+              onDragStart={() => handleDragStart(index)}
+              onDragOver={(e) => handleDragOver(e, index)}
+              onDrop={handleDrop}
+              style={{
+                position:     "relative",
+                border:       index === 0 ? `2px solid ${UI.sage}` : `1px solid ${UI.rule}`,
+                borderRadius: RADIUS.card,
+                overflow:     "hidden",
+                cursor:       isOwner ? "grab" : "default",
+                background:   "#f5f5f0",
+              }}
+            >
+              <img
+                src={photo.url}
+                alt={photo.description || `Listing photo ${index + 1}`}
+                style={{ width: "100%", aspectRatio: "4/3", objectFit: "cover", display: "block" }}
+              />
+
+              {/* Cover badge */}
+              {index === 0 && (
+                <span style={{
+                  position:   "absolute",
+                  top:        "0.35rem",
+                  left:       "0.35rem",
+                  background: UI.sage,
+                  color:      "#fff",
+                  fontFamily: UI.mono,
+                  fontSize:   "0.55rem",
+                  fontWeight: 700,
+                  padding:    "0.15rem 0.4rem",
+                  letterSpacing: "0.06em",
+                  textTransform: "uppercase",
+                }}>
+                  Cover
+                </span>
+              )}
+
+              {/* Owner controls overlay */}
+              {isOwner && (
+                <div style={{
+                  position:       "absolute",
+                  inset:          0,
+                  background:     "rgba(0,0,0,0)",
+                  display:        "flex",
+                  alignItems:     "flex-start",
+                  justifyContent: "flex-end",
+                  padding:        "0.35rem",
+                  gap:            "0.25rem",
+                  opacity:        0,
+                  transition:     "opacity 0.15s",
+                }}
+                  className="photo-overlay"
+                  onMouseEnter={(e) => (e.currentTarget.style.opacity = "1")}
+                  onMouseLeave={(e) => (e.currentTarget.style.opacity = "0")}
+                >
+                  <button
+                    aria-label="Drag to reorder"
+                    style={{
+                      background:   "rgba(255,255,255,0.85)",
+                      border:       "none",
+                      borderRadius: "4px",
+                      padding:      "0.25rem",
+                      cursor:       "grab",
+                      display:      "flex",
+                    }}
+                  >
+                    <GripVertical size={14} color={UI.inkLight} />
+                  </button>
+                  <button
+                    aria-label="Delete photo"
+                    data-testid={`delete-photo-${photo.id}`}
+                    onClick={() => handleDelete(photo.id)}
+                    style={{
+                      background:   "rgba(255,255,255,0.85)",
+                      border:       "none",
+                      borderRadius: "4px",
+                      padding:      "0.25rem",
+                      cursor:       "pointer",
+                      display:      "flex",
+                    }}
+                  >
+                    <Trash2 size={14} color={UI.rust} />
+                  </button>
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/FsboListingManagerPage.tsx
+++ b/frontend/src/pages/FsboListingManagerPage.tsx
@@ -34,6 +34,7 @@ import ShowingInbox                           from "@/components/ShowingInbox";
 import ShowingCalendar                        from "@/components/ShowingCalendar";
 import FsboOfferPanel                         from "@/components/FsboOfferPanel";
 import FsboPanel                              from "@/components/FsboPanel";
+import ListingPhotoManager                    from "@/components/ListingPhotoManager";
 
 // ─── Design tokens ────────────────────────────────────────────────────────────
 
@@ -526,6 +527,11 @@ export default function FsboListingManagerPage() {
               ))}
             </div>
           )}
+        </Section>
+
+        {/* ── Listing photos ────────────────────────────────────────────────── */}
+        <Section testId="listing-photos-section" title="Listing Photos">
+          <ListingPhotoManager propertyId={propertyId} isOwner={true} />
         </Section>
 
         {/* ── Score opt-in ──────────────────────────────────────────────────── */}

--- a/frontend/src/pages/FsboListingPage.tsx
+++ b/frontend/src/pages/FsboListingPage.tsx
@@ -12,9 +12,10 @@ import { Helmet } from "react-helmet-async";
 import { ShieldCheck } from "lucide-react";
 import { propertyService, type Property } from "@/services/property";
 import { jobService, type Job } from "@/services/job";
-import { photoService, type Photo } from "@/services/photo";
+import { photoService } from "@/services/photo";
 import { fsboService, type FsboRecord } from "@/services/fsbo";
 import { reportService, type ShareLink } from "@/services/report";
+import ListingPhotoManager from "@/components/ListingPhotoManager";
 import { computeScore } from "@/services/scoreService";
 import { showingRequestService } from "@/services/showingRequest";
 import { notificationService } from "@/services/notifications";
@@ -167,7 +168,6 @@ export default function FsboListingPage() {
   const [loading,    setLoading]    = useState(true);
   const [property,   setProperty]   = useState<Property | null>(null);
   const [jobs,       setJobs]       = useState<Job[]>([]);
-  const [photos,     setPhotos]     = useState<Photo[]>([]);
   const [fsbo,       setFsbo]       = useState<FsboRecord | null | undefined>(undefined);
   const [reportLink, setReportLink] = useState<ShareLink | null>(null);
 
@@ -187,17 +187,15 @@ export default function FsboListingPage() {
     const fetches: Promise<any>[] = [
       propertyService.getProperty(BigInt(propertyId)),
       jobService.getByProperty(propertyId),
-      photoService.getByProperty(propertyId),
     ];
 
     if (record?.hasReport) {
       fetches.push(reportService.listShareLinks(propertyId));
     }
 
-    Promise.all(fetches).then(([prop, propJobs, propPhotos, shareLinks]) => {
+    Promise.all(fetches).then(([prop, propJobs, shareLinks]) => {
       setProperty(prop);
       setJobs(propJobs);
-      setPhotos(propPhotos);
       if (shareLinks) {
         const active = (shareLinks as ShareLink[]).find((l) => l.isActive) ?? null;
         setReportLink(active);
@@ -262,7 +260,6 @@ export default function FsboListingPage() {
 
   const verifiedJobs = jobs.filter((j) => j.verified);
   const score        = computeScore(jobs, [property]);
-  const firstPhoto   = photos[0] ?? null;
 
   return (
     <>
@@ -286,17 +283,12 @@ export default function FsboListingPage() {
       </Helmet>
     <div style={outerStyle}>
 
-      {/* ── Photo ─────────────────────────────────────────────────────────── */}
-      <div style={{ marginBottom: "1.5rem", background: COLORS.rule, minHeight: "260px", display: "flex", alignItems: "center", justifyContent: "center", overflow: "hidden" }}>
-        {firstPhoto ? (
-          <img
-            src={firstPhoto.url}
-            alt="Property photo"
-            style={{ width: "100%", maxHeight: "380px", objectFit: "cover", display: "block" }}
-          />
-        ) : (
-          <p style={{ fontFamily: UI.mono, fontSize: "0.75rem", color: UI.inkLight }}>No photos available</p>
-        )}
+      {/* ── Photo gallery ─────────────────────────────────────────────────── */}
+      <div
+        data-testid="listing-gallery-section"
+        style={{ marginBottom: "1.5rem" }}
+      >
+        <ListingPhotoManager propertyId={propertyId!} isOwner={false} />
       </div>
 
       {/* ── Price + address ────────────────────────────────────────────────── */}

--- a/frontend/src/services/fsbo.ts
+++ b/frontend/src/services/fsbo.ts
@@ -127,6 +127,11 @@ function createFsboService() {
     },
 
     getRecord(propertyId: string): FsboRecord | null {
+      // E2E injection: window.__e2e_fsbo[propertyId] takes priority
+      if (typeof window !== "undefined" && (window as any).__e2e_fsbo) {
+        const injected = (window as any).__e2e_fsbo[propertyId];
+        if (injected) return injected as FsboRecord;
+      }
       return _records.get(propertyId) ?? null;
     },
 

--- a/frontend/src/services/listing.ts
+++ b/frontend/src/services/listing.ts
@@ -78,6 +78,22 @@ export const idlFactory = ({ IDL }: any) => {
       [IDL.Variant({ ok: IDL.Null, err: Error })],
       []
     ),
+    addListingPhoto: IDL.Func(
+      [IDL.Text, IDL.Text],
+      [IDL.Variant({ ok: IDL.Null, err: Error })],
+      []
+    ),
+    getListingPhotos: IDL.Func([IDL.Text], [IDL.Vec(IDL.Text)], ["query"]),
+    removeListingPhoto: IDL.Func(
+      [IDL.Text, IDL.Text],
+      [IDL.Variant({ ok: IDL.Null, err: Error })],
+      []
+    ),
+    reorderListingPhotos: IDL.Func(
+      [IDL.Text, IDL.Vec(IDL.Text)],
+      [IDL.Variant({ ok: IDL.Null, err: Error })],
+      []
+    ),
   });
 };
 
@@ -392,6 +408,8 @@ function fromRawProposal(raw: any): ListingProposal {
 
 // ─── Service factory ──────────────────────────────────────────────────────────
 
+const MAX_LISTING_PHOTOS = 15;
+
 function createListingService() {
   let _actor: any = null;
   let requests:     ListingBidRequest[]      = [];
@@ -402,6 +420,9 @@ function createListingService() {
   let _propSeq    = 0;
   let _counterSeq = 0;
   let _offerSeq   = 0;
+  // propertyId → ordered photo IDs (mock path only)
+  const listingPhotoMap:    Map<string, string[]> = new Map();
+  const listingPhotoOwners: Map<string, string>   = new Map();
 
   async function getActor() {
     if (_actor) return _actor;
@@ -421,6 +442,8 @@ function createListingService() {
     _propSeq    = 0;
     _counterSeq = 0;
     _offerSeq   = 0;
+    listingPhotoMap.clear();
+    listingPhotoOwners.clear();
   },
 
   // ── createBidRequest ────────────────────────────────────────────────────────
@@ -771,6 +794,66 @@ function createListingService() {
       return perfRecords.filter((r) => r.agentId === agentId);
     }
     throw new Error("getAgentPerformanceRecords requires deployed canister");
+  },
+
+  // ── Listing photos (11.4) ────────────────────────────────────────────────────
+
+  /**
+   * Associate a photo (already uploaded to the photo canister) with a FSBO
+   * listing, appending it to the ordered list.  Enforces the 15-photo cap.
+   */
+  async addListingPhoto(propertyId: string, photoId: string): Promise<void> {
+    if (!LISTING_CANISTER_ID) {
+      if (!listingPhotoOwners.has(propertyId)) listingPhotoOwners.set(propertyId, "local");
+      const existing = listingPhotoMap.get(propertyId) ?? [];
+      if (existing.length >= MAX_LISTING_PHOTOS)
+        throw new Error(`Listing photo limit (${MAX_LISTING_PHOTOS}) reached`);
+      if (existing.includes(photoId))
+        throw new Error("Photo already added to this listing");
+      listingPhotoMap.set(propertyId, [...existing, photoId]);
+      return;
+    }
+    const actor = await getActor();
+    const result = await actor.addListingPhoto(propertyId, photoId);
+    if ("err" in result) throw new Error(JSON.stringify(result.err));
+  },
+
+  /** Returns the ordered photo IDs for a listing (first = cover image). */
+  async getListingPhotos(propertyId: string): Promise<string[]> {
+    if (!LISTING_CANISTER_ID) {
+      if (typeof window !== "undefined" && (window as any).__e2e_listing_photo_order) {
+        return ((window as any).__e2e_listing_photo_order[propertyId] ?? []) as string[];
+      }
+      return listingPhotoMap.get(propertyId) ?? [];
+    }
+    const actor = await getActor();
+    return await actor.getListingPhotos(propertyId) as string[];
+  },
+
+  /** Remove a photo from the listing's ordered photo list. */
+  async removeListingPhoto(propertyId: string, photoId: string): Promise<void> {
+    if (!LISTING_CANISTER_ID) {
+      const existing = listingPhotoMap.get(propertyId) ?? [];
+      listingPhotoMap.set(propertyId, existing.filter((id) => id !== photoId));
+      return;
+    }
+    const actor = await getActor();
+    const result = await actor.removeListingPhoto(propertyId, photoId);
+    if ("err" in result) throw new Error(JSON.stringify(result.err));
+  },
+
+  /**
+   * Replace the photo ordering.  All supplied IDs must already be in the list;
+   * only their sequence is allowed to change.
+   */
+  async reorderListingPhotos(propertyId: string, photoIds: string[]): Promise<void> {
+    if (!LISTING_CANISTER_ID) {
+      listingPhotoMap.set(propertyId, [...photoIds]);
+      return;
+    }
+    const actor = await getActor();
+    const result = await actor.reorderListingPhotos(propertyId, photoIds);
+    if ("err" in result) throw new Error(JSON.stringify(result.err));
   },
 
   // ── createDirectInvite (9.6.2) — homeowner invites specific agent ─────────────

--- a/frontend/src/services/photo.ts
+++ b/frontend/src/services/photo.ts
@@ -11,6 +11,7 @@ export const idlFactory = ({ IDL }: any) => {
     Electrical: IDL.Null, Plumbing: IDL.Null, HVAC: IDL.Null,
     Insulation: IDL.Null, Drywall: IDL.Null, Finishing: IDL.Null,
     PostConstruction: IDL.Null, Warranty: IDL.Null,
+    Listing: IDL.Null,  // FSBO listing photos
   });
   const Photo = IDL.Record({
     id:          IDL.Text,
@@ -39,9 +40,10 @@ export const idlFactory = ({ IDL }: any) => {
       [IDL.Variant({ ok: Photo, err: Error })],
       []
     ),
-    getPhotosByJob:      IDL.Func([IDL.Text], [IDL.Vec(Photo)], []),
-    getPhotosByProperty: IDL.Func([IDL.Text], [IDL.Vec(Photo)], []),
-    getPhotosByRoom:     IDL.Func([IDL.Text], [IDL.Vec(Photo)], []),
+    getPhotosByJob:          IDL.Func([IDL.Text], [IDL.Vec(Photo)], []),
+    getPhotosByProperty:     IDL.Func([IDL.Text], [IDL.Vec(Photo)], []),
+    getPhotosByRoom:         IDL.Func([IDL.Text], [IDL.Vec(Photo)], []),
+    getPublicListingPhotos:  IDL.Func([IDL.Text], [IDL.Vec(Photo)], ["query"]),
     deletePhoto: IDL.Func(
       [IDL.Text],
       [IDL.Variant({ ok: IDL.Null, err: Error })],
@@ -268,6 +270,36 @@ function createPhotoService() {
     description: string
   ): Promise<Photo> {
     return this.upload(file, `ROOM_${roomId}`, propertyId, phase, description);
+  },
+
+  /**
+   * Upload a photo for an FSBO listing.
+   * Uses synthetic jobId "LISTING_<propertyId>" and phase "Listing" so the
+   * photo canister stores it separately from job/room photos.
+   * After uploading, call listingService.addListingPhoto() to persist the order.
+   */
+  async uploadListingPhoto(
+    file:        File,
+    propertyId:  string,
+    description: string
+  ): Promise<Photo> {
+    return this.upload(file, `LISTING_${propertyId}`, propertyId, "Listing", description);
+  },
+
+  /**
+   * Fetch all photos for a FSBO listing. Uses the public (no-auth) canister
+   * query so prospective buyers can view listing photos without signing in.
+   */
+  async getListingPhotos(propertyId: string): Promise<Photo[]> {
+    if (!PHOTO_CANISTER_ID) {
+      // E2E injection takes priority, then fall through to in-memory store
+      if (typeof window !== "undefined" && (window as any).__e2e_listing_photos) {
+        return ((window as any).__e2e_listing_photos[propertyId] ?? []) as Photo[];
+      }
+      return store.filter((p) => p.jobId === `LISTING_${propertyId}`);
+    }
+    const a = await getActor();
+    return (await a.getPublicListingPhotos(propertyId) as any[]).map(fromPhoto);
   },
 
   async deletePhoto(photoId: string): Promise<void> {

--- a/frontend/src/services/property.ts
+++ b/frontend/src/services/property.ts
@@ -373,6 +373,11 @@ export const propertyService = {
   },
 
   async getProperty(id: bigint): Promise<Property> {
+    if (typeof window !== "undefined" && (window as any).__e2e_properties) {
+      const props = (window as any).__e2e_properties as any[];
+      const found = props.find((p: any) => String(p.id) === String(id));
+      if (found) return found as Property;
+    }
     const a = await getActor();
     const result = await a.getProperty(id);
     return unwrap(result);

--- a/tests/e2e/fsbo-photos.spec.ts
+++ b/tests/e2e/fsbo-photos.spec.ts
@@ -1,0 +1,113 @@
+/**
+ * E2E tests — issue #114: FSBO listing photos
+ *
+ * Covers:
+ *  1. Public listing page (/for-sale/:propertyId) renders the photo gallery
+ *     when photos are injected via __e2e_listing_photos.
+ *  2. Owner manager page (/my-listing/:propertyId) shows the photo upload
+ *     section in the live dashboard.
+ */
+
+import { test, expect } from "@playwright/test";
+import { injectTestAuth } from "./helpers/auth";
+import { injectTestProperties, injectFsboPhotos, injectSubscription } from "./helpers/testData";
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/** Activate a live FSBO record in the service layer mock. */
+async function injectFsboRecord(page: Parameters<typeof injectTestAuth>[0], propertyId = "1") {
+  await page.addInitScript((pid: string) => {
+    (window as any).__e2e_fsbo = {
+      [pid]: {
+        propertyId: pid,
+        isFsbo:         true,
+        listPriceCents: 45_000_000,
+        activatedAt:    Date.now() - 86_400_000 * 7,
+        step:           "done",
+        hasReport:      false,
+        description:    "Beautiful family home in Austin.",
+      },
+    };
+  }, propertyId);
+}
+
+/** Minimal property shape needed by FsboListingPage. */
+async function injectFsboProperty(page: Parameters<typeof injectTestAuth>[0]) {
+  await page.addInitScript(() => {
+    (window as any).__e2e_properties = [
+      {
+        id: 1, owner: "test-e2e-principal",
+        address: "123 Maple Street", city: "Austin", state: "TX", zipCode: "78701",
+        propertyType: "SingleFamily", yearBuilt: 2001, squareFeet: 2400,
+        verificationLevel: "Unverified", tier: "Pro",
+        createdAt: 0, updatedAt: 0, isActive: true,
+      },
+    ];
+    (window as any).__e2e_jobs = [];
+  });
+}
+
+// ─── Public listing gallery ───────────────────────────────────────────────────
+
+test.describe("FsboListingPage — photo gallery", () => {
+  test.beforeEach(async ({ page }) => {
+    await injectFsboProperty(page);
+    await injectFsboRecord(page);
+    await injectFsboPhotos(page, "1");
+  });
+
+  test("renders the gallery section", async ({ page }) => {
+    await page.goto("/for-sale/1");
+    await expect(page.getByTestId("listing-gallery-section")).toBeVisible();
+  });
+
+  test("shows the photo grid when listing photos are present", async ({ page }) => {
+    await page.goto("/for-sale/1");
+    await expect(page.getByTestId("listing-photo-grid")).toBeVisible();
+  });
+
+  test("does not show the upload button (guest view)", async ({ page }) => {
+    await page.goto("/for-sale/1");
+    await expect(page.getByTestId("upload-listing-photo-btn")).not.toBeVisible();
+  });
+});
+
+test.describe("FsboListingPage — empty photo state", () => {
+  test.beforeEach(async ({ page }) => {
+    await injectFsboProperty(page);
+    await injectFsboRecord(page);
+    // No photos injected
+  });
+
+  test("shows the empty state placeholder", async ({ page }) => {
+    await page.goto("/for-sale/1");
+    await expect(page.getByTestId("listing-photo-empty")).toBeVisible();
+  });
+});
+
+// ─── Owner manager dashboard ──────────────────────────────────────────────────
+
+test.describe("FsboListingManagerPage — listing photos section", () => {
+  test.beforeEach(async ({ page }) => {
+    await injectTestAuth(page);
+    await injectTestProperties(page);
+    await injectSubscription(page, "Pro");
+    await injectFsboRecord(page);
+    await injectFsboPhotos(page, "1");
+  });
+
+  test("shows the listing-photos-section in the live dashboard", async ({ page }) => {
+    await page.goto("/my-listing/1");
+    await expect(page.getByTestId("listing-photos-section")).toBeVisible();
+  });
+
+  test("shows the Add Photos button for the owner", async ({ page }) => {
+    await page.goto("/my-listing/1");
+    await expect(page.getByTestId("upload-listing-photo-btn")).toBeVisible();
+  });
+
+  test("shows the photo grid with injected photos", async ({ page }) => {
+    await page.goto("/my-listing/1");
+    await expect(page.getByTestId("listing-photo-grid")).toBeVisible();
+  });
+});

--- a/tests/e2e/helpers/testData.ts
+++ b/tests/e2e/helpers/testData.ts
@@ -244,6 +244,63 @@ export async function injectScoreEvents(page: Page) {
 }
 
 /**
+ * Injects mock FSBO listing photos into window.__e2e_listing_photos.
+ * photoService.getListingPhotos() checks this before making canister calls,
+ * and listingService.getListingPhotos() checks window.__e2e_listing_photo_order.
+ *
+ * Pass a propertyId matching the listing under test.  Three photos are injected
+ * by default (cover + 2 gallery shots).
+ */
+export async function injectFsboPhotos(page: Page, propertyId: string = "1") {
+  await page.addInitScript(
+    ({ pid }: { pid: string }) => {
+      const FAKE_URL = "data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==";
+      const photos = [
+        {
+          id:          "LP_1",
+          jobId:       `LISTING_${pid}`,
+          propertyId:  pid,
+          phase:       "Listing",
+          description: "Front exterior",
+          hash:        "aaa",
+          url:         FAKE_URL,
+          size:        128,
+          verified:    false,
+          createdAt:   Date.now() - 86_400_000,
+        },
+        {
+          id:          "LP_2",
+          jobId:       `LISTING_${pid}`,
+          propertyId:  pid,
+          phase:       "Listing",
+          description: "Living room",
+          hash:        "bbb",
+          url:         FAKE_URL,
+          size:        128,
+          verified:    false,
+          createdAt:   Date.now() - 86_300_000,
+        },
+        {
+          id:          "LP_3",
+          jobId:       `LISTING_${pid}`,
+          propertyId:  pid,
+          phase:       "Listing",
+          description: "Backyard",
+          hash:        "ccc",
+          url:         FAKE_URL,
+          size:        128,
+          verified:    false,
+          createdAt:   Date.now() - 86_200_000,
+        },
+      ];
+      (window as any).__e2e_listing_photos = { [pid]: photos };
+      (window as any).__e2e_listing_photo_order = { [pid]: ["LP_1", "LP_2", "LP_3"] };
+    },
+    { pid: propertyId }
+  );
+}
+
+/**
  * Injects mock warranty jobs (jobs with warrantyMonths > 0) alongside
  * the standard property fixture. Covers all three warranty states:
  * active, expiring-soon, and expired.


### PR DESCRIPTION
Backend:
- photo canister: add #Listing ConstructionPhase variant and public getPublicListingPhotos(propertyId) query (no auth — buyers can browse)
- listing canister: add addListingPhoto / getListingPhotos / removeListingPhoto / reorderListingPhotos with owner-lock, 15-photo cap, and set-equality validation on reorder

Frontend services:
- photo.ts: Listing IDL variant, uploadListingPhoto() (LISTING_<id>
  synthetic jobId), getListingPhotos() with e2e injection support
- listing.ts: four new IDL entries + mock-path with e2e injection
- fsbo.ts: __e2e_fsbo window global support in getRecord()

UI:
- ListingPhotoManager component: upload, drag-to-reorder, delete for owners; read-only ordered gallery with cover badge for guests
- FsboListingManagerPage: photo section in live dashboard
- FsboListingPage: replaces single cover photo with full gallery

Tests:
- 12 new unit tests (listing + photo service)
- FsboListing.test.tsx updated for new gallery contract
- Candid contract snapshots updated
- injectFsboPhotos() e2e helper + fsbo-photos.spec.ts (5 scenarios)
- 2999/2999 tests passing

## Summary
<!-- What does this PR do? -->

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [ ] Backend tests pass (`make test`)
- [ ] Frontend builds (`cd frontend && npm run build`)
- [ ] Tested locally with dfx

## Checklist
- [ ] Code follows project conventions
- [ ] Self-review completed
- [ ] No sensitive data committed
