### PR TITLE
fix(settings): prefetch subscription tier to eliminate spinner on sub…

### DIFF
--- a/frontend/src/__tests__/components/AgentPages.test.tsx
+++ b/frontend/src/__tests__/components/AgentPages.test.tsx
@@ -61,6 +61,9 @@ vi.mock("@/store/authStore", () => ({
     principal: "agent-principal-1",
     profile: { role: "Realtor", tier: "Pro" },
     isAuthenticated: true,
+    tier: null,
+    setTier: vi.fn(),
+    setProfile: vi.fn(),
   }),
 }));
 

--- a/frontend/src/__tests__/components/CancelledAccount835.test.tsx
+++ b/frontend/src/__tests__/components/CancelledAccount835.test.tsx
@@ -43,7 +43,7 @@ vi.mock("@/services/payment", async (importOriginal) => {
 });
 
 vi.mock("@/store/authStore", () => ({
-  useAuthStore: () => ({ principal: "test", profile: { role: "Homeowner" }, isAuthenticated: true }),
+  useAuthStore: () => ({ principal: "test", profile: { role: "Homeowner" }, isAuthenticated: true, tier: null, setTier: vi.fn(), setProfile: vi.fn() }),
 }));
 
 vi.mock("@/store/propertyStore", () => ({

--- a/frontend/src/__tests__/components/CheckoutPage.test.tsx
+++ b/frontend/src/__tests__/components/CheckoutPage.test.tsx
@@ -80,6 +80,9 @@ function renderCheckout(
       isAuthenticated: authenticated,
       principal: authenticated ? "test-principal" : null,
       profile: authenticated ? { email: "test@example.com" } : null,
+      tier: null,
+      setTier: vi.fn(),
+      setProfile: vi.fn(),
     };
     return sel ? sel(state) : state;
   });

--- a/frontend/src/__tests__/components/FsboOffer105.test.tsx
+++ b/frontend/src/__tests__/components/FsboOffer105.test.tsx
@@ -88,6 +88,7 @@ vi.mock("@/services/fsbo", async (importOriginal) => {
 vi.mock("@/store/authStore", () => ({
   useAuthStore: () => ({
     principal: "local", profile: { role: "Homeowner", tier: "Pro" }, isAuthenticated: true,
+    tier: null, setTier: vi.fn(), setProfile: vi.fn(),
   }),
 }));
 

--- a/frontend/src/__tests__/components/Gate1564.test.tsx
+++ b/frontend/src/__tests__/components/Gate1564.test.tsx
@@ -34,6 +34,9 @@ vi.mock("@/store/authStore", () => ({
     principal: "test-principal",
     profile: { role: "Homeowner" },
     isAuthenticated: true,
+    tier: null,
+    setTier: vi.fn(),
+    setProfile: vi.fn(),
   }),
 }));
 

--- a/frontend/src/__tests__/components/Layout.test.tsx
+++ b/frontend/src/__tests__/components/Layout.test.tsx
@@ -42,7 +42,7 @@ let mockProperties: { id: string; address: string }[] = [];
 let mockProfile: { role: string; email?: string } = { role: "Homeowner", email: "test@example.com" };
 
 vi.mock("@/store/authStore", () => ({
-  useAuthStore: () => ({ principal: "test-principal", profile: mockProfile }),
+  useAuthStore: () => ({ principal: "test-principal", profile: mockProfile, tier: null, setTier: vi.fn(), setProfile: vi.fn() }),
 }));
 
 vi.mock("@/store/propertyStore", () => ({

--- a/frontend/src/__tests__/components/Listing94.test.tsx
+++ b/frontend/src/__tests__/components/Listing94.test.tsx
@@ -105,6 +105,7 @@ vi.mock("@/store/authStore", () => ({
   useAuthStore: () => ({
     principal: "local", profile: { role: "Homeowner", tier: "Pro" },
     isAuthenticated: true,
+    tier: null, setTier: vi.fn(), setProfile: vi.fn(),
   }),
 }));
 

--- a/frontend/src/__tests__/components/Listing95.test.tsx
+++ b/frontend/src/__tests__/components/Listing95.test.tsx
@@ -163,6 +163,7 @@ vi.mock("@/store/authStore", () => ({
   useAuthStore: () => ({
     principal: "local", profile: { role: "Homeowner", tier: "Pro" },
     isAuthenticated: true,
+    tier: null, setTier: vi.fn(), setProfile: vi.fn(),
   }),
 }));
 

--- a/frontend/src/__tests__/components/Listing96.test.tsx
+++ b/frontend/src/__tests__/components/Listing96.test.tsx
@@ -76,6 +76,7 @@ vi.mock("@/store/authStore", () => ({
     principal: "local",
     profile: { role: "Homeowner", tier: "Pro" },
     isAuthenticated: true,
+    tier: null, setTier: vi.fn(), setProfile: vi.fn(),
   }),
 }));
 

--- a/frontend/src/__tests__/components/ListingPages.test.tsx
+++ b/frontend/src/__tests__/components/ListingPages.test.tsx
@@ -123,6 +123,7 @@ vi.mock("@/store/authStore", () => ({
     principal: "local",
     profile: { role: "Homeowner", tier: "Pro" },
     isAuthenticated: true,
+    tier: null, setTier: vi.fn(), setProfile: vi.fn(),
   }),
 }));
 

--- a/frontend/src/__tests__/components/PaymentPages.test.tsx
+++ b/frontend/src/__tests__/components/PaymentPages.test.tsx
@@ -23,7 +23,7 @@ vi.mock("@/services/payment", async (importOriginal) => {
 });
 
 vi.mock("@/store/authStore", () => ({
-  useAuthStore: () => ({ isAuthenticated: true }),
+  useAuthStore: () => ({ isAuthenticated: true, tier: null, setTier: vi.fn(), setProfile: vi.fn() }),
 }));
 
 vi.mock("@/contexts/AuthContext", () => ({

--- a/frontend/src/__tests__/components/PricingPage.test.tsx
+++ b/frontend/src/__tests__/components/PricingPage.test.tsx
@@ -63,6 +63,9 @@ function renderPricing(authenticated = false, search = "") {
       isAuthenticated: authenticated,
       principal: authenticated ? "test-principal" : null,
       profile: null,
+      tier: null,
+      setTier: vi.fn(),
+      setProfile: vi.fn(),
     };
     return sel ? sel(state) : state;
   });

--- a/frontend/src/__tests__/components/RegisterPage.test.tsx
+++ b/frontend/src/__tests__/components/RegisterPage.test.tsx
@@ -38,7 +38,7 @@ vi.mock("@/services/auth", () => ({
 }));
 
 vi.mock("@/store/authStore", () => ({
-  useAuthStore: () => ({ setProfile: vi.fn() }),
+  useAuthStore: () => ({ setProfile: vi.fn(), tier: null, setTier: vi.fn() }),
 }));
 
 vi.mock("react-hot-toast", () => ({

--- a/frontend/src/__tests__/components/Showing104.test.tsx
+++ b/frontend/src/__tests__/components/Showing104.test.tsx
@@ -113,6 +113,7 @@ vi.mock("@/store/authStore", () => ({
     principal:       "local",
     profile:         { role: "Homeowner", tier: "Pro" },
     isAuthenticated: true,
+    tier: null, setTier: vi.fn(), setProfile: vi.fn(),
   }),
 }));
 

--- a/frontend/src/__tests__/components/UpgradeModal.test.tsx
+++ b/frontend/src/__tests__/components/UpgradeModal.test.tsx
@@ -75,6 +75,9 @@ vi.mock("@/store/authStore", () => ({
     principal: "test-principal",
     profile: { name: "Test User", role: "Homeowner" },
     isLoading: false,
+    tier: null,
+    setTier: vi.fn(),
+    setProfile: vi.fn(),
   })),
 }));
 

--- a/frontend/src/__tests__/pages/SettingsPage.test.tsx
+++ b/frontend/src/__tests__/pages/SettingsPage.test.tsx
@@ -50,6 +50,9 @@ vi.mock("@/store/authStore", () => ({
     principal:       "test-principal",
     profile:         { name: "Test User", role: "Homeowner", email: "test@example.com" },
     isLoading:       false,
+    tier:            null,
+    setTier:         vi.fn(),
+    setProfile:      vi.fn(),
   })),
 }));
 

--- a/frontend/src/__tests__/perf/renderPerf1341_1342.test.tsx
+++ b/frontend/src/__tests__/perf/renderPerf1341_1342.test.tsx
@@ -165,6 +165,9 @@ vi.mock("@/store/authStore", () => ({
     principal:   "test-principal",
     profile:     null,
     lastLoginAt: 0,
+    tier:        null,
+    setTier:     vi.fn(),
+    setProfile:  vi.fn(),
   })),
 }));
 

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -9,6 +9,7 @@ import {
   loginWithLocalIdentity,
 } from "@/services/actor";
 import { authService } from "@/services/auth";
+import { paymentService } from "@/services/payment";
 import { propertyService } from "@/services/property";
 
 interface AuthContextValue {
@@ -33,7 +34,7 @@ async function homeownerDestination(): Promise<string> {
 
 export function AuthProvider({ children }: { children: ReactNode }) {
   const navigate = useNavigate();
-  const { setAuthenticated, setProfile, setLastLoginAt, clearAuth, setLoading } = useAuthStore();
+  const { setAuthenticated, setProfile, setLastLoginAt, setTier, clearAuth, setLoading } = useAuthStore();
 
   useEffect(() => {
     // E2E test bypass: Playwright sets window.__e2e_principal before React boots.
@@ -65,6 +66,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           setLastLoginAt(profile.lastLoggedIn);   // capture previous session timestamp
           setProfile(profile);
           authService.recordLogin().catch((err) => console.error("[AuthContext] recordLogin failed:", err)); // fire-and-forget
+          paymentService.getMySubscription().then((sub) => setTier(sub.tier)).catch(() => {}); // fire-and-forget
         } catch {
           // Not registered yet
         }
@@ -82,6 +84,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       setLastLoginAt(profile.lastLoggedIn);
       setProfile(profile);
       authService.recordLogin().catch((err) => console.error("[AuthContext] recordLogin failed:", err));
+      paymentService.getMySubscription().then((sub) => setTier(sub.tier)).catch(() => {}); // fire-and-forget
       if (profile.role === "Contractor") {
         navigate("/contractor-dashboard");
       } else {
@@ -115,6 +118,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       setLastLoginAt(profile.lastLoggedIn);
       setProfile(profile);
       authService.recordLogin().catch((err) => console.error("[AuthContext] recordLogin failed:", err));
+      paymentService.getMySubscription().then((sub) => setTier(sub.tier)).catch(() => {}); // fire-and-forget
       if (profile.role === "Contractor") {
         navigate("/contractor-dashboard");
       } else {
@@ -141,9 +145,16 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   };
 
   const logout = async () => {
-    await iiLogout();
-    navigate("/");   // navigate before clearing so ProtectedRoute doesn't race-redirect to /login
-    clearAuth();
+    try {
+      await iiLogout();
+    } catch {
+      // II logout may fail when the user authenticated via devLogin (bypasses
+      // AuthClient) or when the identity provider is unreachable. Clear local
+      // state regardless so the button always works.
+    } finally {
+      navigate("/");   // navigate before clearing so ProtectedRoute doesn't race-redirect to /login
+      clearAuth();
+    }
   };
 
   return (

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -277,10 +277,11 @@ function AgentDashboardLink() {
 
 function SubscriptionTab({ profile }: { profile: any }) {
   const navigate = useNavigate();
-  const [tier,             setTier]             = useState<PlanTier>(profile?.role === "Contractor" ? "ContractorPro" : "Free");
+  const { tier: cachedTier, setTier: setStoreTier } = useAuthStore();
+  const [tier,             setTier]             = useState<PlanTier>(cachedTier ?? (profile?.role === "Contractor" ? "ContractorPro" : "Free"));
   const [expiresAt,        setExpiresAt]        = useState<number | null>(null);
   const [cancelledAt,      setCancelledAt]      = useState<number | null>(null);
-  const [subLoaded,        setSubLoaded]        = useState(false);
+  const [subLoaded,        setSubLoaded]        = useState(cachedTier !== null);
   const [showUpgradeModal, setShowUpgradeModal] = useState(false);
   const [cancelStep,       setCancelStep]       = useState<"idle" | "confirm" | "loading" | "done">("idle");
   const [pauseState,       setPauseState]       = useState(paymentService.getPauseState());
@@ -288,6 +289,7 @@ function SubscriptionTab({ profile }: { profile: any }) {
   useEffect(() => {
     paymentService.getMySubscription().then((sub) => {
       setTier(sub.tier);
+      setStoreTier(sub.tier);
       setExpiresAt(sub.expiresAt);
       if (sub.cancelledAt) {
         setCancelledAt(sub.cancelledAt);

--- a/frontend/src/store/authStore.ts
+++ b/frontend/src/store/authStore.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import { UserProfile } from "@/services/auth";
+import type { PlanTier } from "@/services/planConstants";
 
 interface AuthState {
   isAuthenticated: boolean;
@@ -7,9 +8,11 @@ interface AuthState {
   profile: UserProfile | null;
   isLoading: boolean;
   lastLoginAt: number | null;   // ms timestamp of the *previous* session
+  tier: PlanTier | null;        // null = not yet fetched
   setAuthenticated: (principal: string) => void;
   setProfile: (profile: UserProfile) => void;
   setLastLoginAt: (v: number | null) => void;
+  setTier: (tier: PlanTier) => void;
   clearAuth: () => void;
   setLoading: (v: boolean) => void;
 }
@@ -20,12 +23,14 @@ export const useAuthStore = create<AuthState>((set) => ({
   profile: null,
   isLoading: true,
   lastLoginAt: null,
+  tier: null,
   setAuthenticated: (principal) => {
     if (!principal) throw new Error("setAuthenticated: principal must be a non-empty string");
     set({ isAuthenticated: true, principal });
   },
   setProfile: (profile) => set({ profile }),
   setLastLoginAt: (lastLoginAt) => set({ lastLoginAt }),
-  clearAuth: () => set({ isAuthenticated: false, principal: null, profile: null, lastLoginAt: null }),
+  setTier: (tier) => set({ tier }),
+  clearAuth: () => set({ isAuthenticated: false, principal: null, profile: null, lastLoginAt: null, tier: null }),
   setLoading: (isLoading) => set({ isLoading }),
 }));

--- a/scripts/init-test-data.sh
+++ b/scripts/init-test-data.sh
@@ -2,6 +2,9 @@
 set -euo pipefail
 echo "▶ Initializing test data..."
 
+# Dev identity principal (fixed-seed Ed25519, seed[0]=42 — see frontend/src/services/actor.ts)
+DEV_PRINCIPAL="qxmov-duod5-ahrw6-wydp4-lppe4-ljtvj-7zvu3-qke5i-umwsv-vcb7g-mqe"
+
 dfx canister call auth register '(record { role = variant { Homeowner }; email = "homeowner@test.com"; phone = "555-0001" })'
 dfx canister call property registerProperty '(record {
   address = "123 Main Street";
@@ -13,5 +16,9 @@ dfx canister call property registerProperty '(record {
   squareFeet = 2000;
   tier = variant { Pro };
 })'
+
+echo "  Granting Basic subscription to dev identity ($DEV_PRINCIPAL)..."
+dfx canister call payment grantSubscription "(principal \"$DEV_PRINCIPAL\", variant { Basic })" \
+  2>/dev/null || echo "  ⚠️  grantSubscription failed (payment canister may not be initialized)"
 
 echo "✅ Test data initialized!"


### PR DESCRIPTION
…scription tab

Cache the tier in authStore during login so SubscriptionTab renders instantly on subsequent visits. Also seeds the dev identity (Basic tier) in init-test-data.sh so local dev starts with the correct subscription.

## Summary
<!-- What does this PR do? -->

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [ ] Backend tests pass (`make test`)
- [ ] Frontend builds (`cd frontend && npm run build`)
- [ ] Tested locally with dfx

## Checklist
- [ ] Code follows project conventions
- [ ] Self-review completed
- [ ] No sensitive data committed
