### PR TITLE
security(auth): close addAdmin bootstrap race and harden deploy.sh

### DIFF
--- a/backend/auth/main.mo
+++ b/backend/auth/main.mo
@@ -12,7 +12,7 @@ import Text "mo:core/Text";
 import Time "mo:core/Time";
 import Array "mo:core/Array";
 
-persistent actor Auth {
+persistent actor class Auth(initDeployer : Principal) {
 
   // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -80,8 +80,9 @@ persistent actor Auth {
 
   private var isPaused: Bool = false;
   private var pauseExpiryNs: ?Int = null;
-  private var admins: [Principal] = [];
-  private var adminInitialized: Bool = false;
+  // initDeployer is set atomically at install time — no open window for a
+  // first-caller race. On upgrade, stable storage restores the existing value.
+  private var admins: [Principal] = [initDeployer];
 
   /// Per-principal update-call rate limiting (cycle-drain protection).
   private transient let updateCallLimits : Map.Map<Text, (Nat, Int)> = Map.empty();
@@ -166,11 +167,12 @@ persistent actor Auth {
     #ok(())
   };
 
-  /// Add a new admin principal
+  /// Add a new admin principal (existing admin only — bootstrap is closed at install time)
   public shared(msg) func addAdmin(newAdmin: Principal) : async Result.Result<(), Error> {
-    if (adminInitialized and not isAdmin(msg.caller)) return #err(#NotAuthorized);
-    admins := Array.concat(admins, [newAdmin]);
-    adminInitialized := true;
+    if (not isAdmin(msg.caller)) return #err(#NotAuthorized);
+    if (not isAdmin(newAdmin)) {
+      admins := Array.concat(admins, [newAdmin]);
+    };
     #ok(())
   };
 

--- a/frontend/src/__tests__/security/icpProd567.test.ts
+++ b/frontend/src/__tests__/security/icpProd567.test.ts
@@ -4,6 +4,7 @@
  * PROD.5  deploy.sh builds frontend and deploys the frontend canister
  * PROD.6  all backend canisters use `persistent actor` + mo:core/Map (no preupgrade needed)
  * PROD.7  deploy.sh wires addAdmin for every canister that has the method
+ *         (auth is excluded — its deployer is set atomically via --argument at install time)
  */
 
 import { describe, it, expect } from "vitest";
@@ -102,8 +103,11 @@ describe("PROD.7 — deploy.sh calls addAdmin for each non-payment canister", ()
   // ai_proxy is already wired in the existing AI Proxy section.
   // All others must have addAdmin called so the deployer owns them from the first block.
 
+  // auth is intentionally excluded: its deployer principal is set atomically via
+  // `dfx canister install auth --argument "(principal \"...\")"`  at install time,
+  // so no post-deploy addAdmin call is needed or safe (#144).
   const CANISTERS_WITH_ADMIN = [
-    "auth", "property", "job", "contractor", "quote",
+    "property", "job", "contractor", "quote",
     "photo", "report", "maintenance", "market", "sensor",
     "listing", "agent", "recurring", "monitoring",
   ];
@@ -126,6 +130,21 @@ describe("PROD.7 — deploy.sh calls addAdmin for each non-payment canister", ()
       ).toBe(true);
     });
   }
+
+  it("deploy.sh does NOT call addAdmin for auth (auth uses --argument constructor bootstrap instead)", () => {
+    // auth gets its deployer via `dfx canister install auth --argument "(principal \"...\")"`.
+    // Calling addAdmin after the fact would re-open the bootstrap race we closed in #144.
+    expect(deploy()).not.toMatch(/canister call auth addAdmin/);
+  });
+
+  it("deploy.sh installs auth with --argument passing the deployer principal", () => {
+    const src = deploy();
+    // Must pass the deployer principal as a Candid argument so the actor class
+    // constructor receives it atomically — closing the bootstrap race (#144).
+    // The two strings may be on separate lines, so check both independently.
+    expect(src).toContain("canister install auth");
+    expect(src).toMatch(/--argument.*principal/);
+  });
 
   it("deploy.sh does NOT call addAdmin for payment (payment uses initAdmins instead)", () => {
     // payment uses a one-time initAdmins bootstrap, not the addAdmin pattern

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -82,12 +82,67 @@ if [ "$NETWORK" != "local" ]; then
     echo "  ✓ VITE_VOICE_AGENT_API_KEY is set"
   fi
 
+  # PROD.4 — STRIPE_SECRET_KEY must be set; without it payment processing fails
+  # silently and subscriptions cannot be created.
+  if [ -z "${STRIPE_SECRET_KEY:-}" ]; then
+    echo "  ✗ STRIPE_SECRET_KEY is not set — payment processing will fail"
+    PREFLIGHT_FAILED=1
+  else
+    echo "  ✓ STRIPE_SECRET_KEY is set"
+  fi
+
+  # PROD.5 — VITE_STRIPE_PUBLISHABLE_KEY must be set; Stripe.js cannot initialize
+  # without it and the frontend payment flow breaks entirely.
+  if [ -z "${VITE_STRIPE_PUBLISHABLE_KEY:-}" ]; then
+    echo "  ✗ VITE_STRIPE_PUBLISHABLE_KEY is not set — Stripe.js will fail to initialize"
+    PREFLIGHT_FAILED=1
+  else
+    echo "  ✓ VITE_STRIPE_PUBLISHABLE_KEY is set"
+  fi
+
+  # PROD.6 — Reject test Stripe key on mainnet. A sk_test_* key on the ic network
+  # means real-money subscriptions are silently processed against Stripe's test mode.
+  if [ "$NETWORK" = "ic" ] && [[ "${STRIPE_SECRET_KEY:-}" == sk_test_* ]]; then
+    echo "  ✗ Test Stripe key (sk_test_*) used on mainnet — use a live key for ic deploys"
+    PREFLIGHT_FAILED=1
+  fi
+
+  # PROD.7 — DFX identity must not be anonymous; an anonymous deploy means no one
+  # owns the canisters and they cannot be upgraded or managed after deployment.
+  CURRENT_IDENTITY=$(dfx identity whoami 2>/dev/null || echo "anonymous")
+  if [ "$CURRENT_IDENTITY" = "anonymous" ]; then
+    echo "  ✗ DFX identity is 'anonymous' — switch with: dfx identity use <name>"
+    PREFLIGHT_FAILED=1
+  else
+    echo "  ✓ DFX identity: $CURRENT_IDENTITY"
+  fi
+
+  # PROD.8 — ICP network must be reachable before we spend time building canisters.
+  echo -n "  Checking network reachability ($NETWORK)... "
+  if dfx ping --network "$NETWORK" >/dev/null 2>&1; then
+    echo "✓"
+  else
+    echo "✗"
+    echo "  ✗ ICP network '$NETWORK' is not reachable — check your connection or dfx config"
+    PREFLIGHT_FAILED=1
+  fi
+
   if [ "$PREFLIGHT_FAILED" -ne 0 ]; then
     echo ""
     echo "❌ Pre-flight failed. Set the missing secrets and retry."
     exit 1
   fi
   echo ""
+fi
+
+# ── DRY_RUN short-circuit ────────────────────────────────────────────────────
+# DRY_RUN=1 bash scripts/deploy.sh <network>
+# Runs all preflight checks above and exits without deploying anything.
+# Useful in CI to validate secrets are wired up correctly before a real deploy.
+if [ "${DRY_RUN:-0}" = "1" ]; then
+  echo ""
+  echo "✅ DRY_RUN=1 — env and network validation passed. Exiting without deploying."
+  exit 0
 fi
 
 # ── Bootstrap management canister IDL ───────────────────────────────────────────
@@ -141,13 +196,25 @@ echo "▶ Creating canister IDs (phase 1/2)..."
 dfx canister create --all --network "$NETWORK" 2>/dev/null || true
 
 # Phase 2: build + install every canister in parallel
+# auth canister takes an init arg (deployer principal) so it is bootstrapped
+# atomically — no window exists for a first-caller race after deploy.
 echo "▶ Building and installing ${#CANISTERS[@]} canisters in parallel (phase 2/2)..."
+DEPLOY_PRINCIPAL=$(dfx identity get-principal)
 PIDS=()
 for canister in "${CANISTERS[@]}"; do
-  (
-    dfx build "$canister" --network "$NETWORK" 2>&1 && \
-    dfx canister install "$canister" --mode install --network "$NETWORK" 2>&1
-  ) >"$LOG_DIR/$canister.log" 2>&1 &
+  if [ "$canister" = "auth" ]; then
+    (
+      dfx build auth --network "$NETWORK" 2>&1 && \
+      dfx canister install auth --mode install \
+        --argument "(principal \"$DEPLOY_PRINCIPAL\")" \
+        --network "$NETWORK" 2>&1
+    ) >"$LOG_DIR/auth.log" 2>&1 &
+  else
+    (
+      dfx build "$canister" --network "$NETWORK" 2>&1 && \
+      dfx canister install "$canister" --mode install --network "$NETWORK" 2>&1
+    ) >"$LOG_DIR/$canister.log" 2>&1 &
+  fi
   PIDS+=($!)
 done
 
@@ -185,6 +252,42 @@ for canister in "${CANISTERS[@]}"; do
   ID=$(dfx canister id "$canister" --network "$NETWORK" 2>/dev/null || echo "not deployed")
   echo "  $canister: $ID"
 done
+
+echo ""
+echo "============================================"
+echo "  Validating Canister IDs"
+echo "============================================"
+# PROD.9 — Every canister must have a non-empty ID after the deploy step.
+# An empty ID means the canister failed to create or install silently, which
+# can cause the frontend to fall back to mock data (see #138).
+CANISTER_ID_FAILED=0
+for canister in "${CANISTERS[@]}"; do
+  ID=$(dfx canister id "$canister" --network "$NETWORK" 2>/dev/null || echo "")
+  if [ -z "$ID" ]; then
+    echo "  ✗ $canister: no canister ID — deploy may be incomplete"
+    CANISTER_ID_FAILED=1
+  else
+    echo "  ✓ $canister: $ID"
+  fi
+done
+
+if [ "$CANISTER_ID_FAILED" -ne 0 ]; then
+  echo ""
+  echo "❌ One or more canister IDs are missing. Re-run deploy or check logs above."
+  exit 1
+fi
+
+# PROD.10 — canister_ids.json must exist on non-local deploys.
+# This file is the source of truth for CI and upgrade scripts; a missing file
+# means the deploy wrote IDs only to ephemeral dfx state.
+if [ "$NETWORK" != "local" ]; then
+  REPO_ROOT_CID="$(cd "$(dirname "$0")/.." && pwd)/canister_ids.json"
+  if [ -f "$REPO_ROOT_CID" ]; then
+    echo "  ✓ canister_ids.json present"
+  else
+    echo "  ⚠️  canister_ids.json not found at $REPO_ROOT_CID — IDs may not persist across dfx restarts"
+  fi
+fi
 
 echo ""
 echo "============================================"
@@ -251,8 +354,9 @@ echo "============================================"
 DEPLOYER=$(dfx identity get-principal)
 echo "  Deployer principal: $DEPLOYER"
 
-# All canisters that expose addAdmin, excluding ai_proxy (handled separately).
-ADMIN_CANISTERS=(auth property job contractor quote photo report maintenance market sensor listing agent recurring bills monitoring)
+# All canisters that expose addAdmin, excluding auth (bootstrapped via init arg)
+# and ai_proxy (handled separately below).
+ADMIN_CANISTERS=(property job contractor quote photo report maintenance market sensor listing agent recurring bills monitoring)
 
 # Fire all addAdmin calls in parallel — each targets a different canister so
 # there is no shared state and no ordering requirement between them.


### PR DESCRIPTION
## Summary

- **#144** — Converted `Auth` from `persistent actor` to `persistent actor class Auth(initDeployer : Principal)` so the deployer principal is written into stable storage atomically at install time. Removed the `adminInitialized` flag (now dead code) and the open bootstrap window in `addAdmin`.
- **#146** — Added preflight checks to `deploy.sh`: Stripe key presence and test/live key guard, identity check, network reachability ping, post-deploy canister ID validation, and `canister_ids.json` presence warning. Added `DRY_RUN=1` mode to validate env/network without deploying.

## Test plan

- [ ] Build `backend/auth` locally — confirm `persistent actor class` compiles without error
- [ ] `dfx canister install auth --argument "(principal \"$(dfx identity get-principal)\")"` — confirm deployer is admin immediately after install, no `addAdmin` call needed
- [ ] Call `addAdmin` as deployer — confirm a second principal can be added
- [ ] Call `addAdmin` as non-admin — confirm `#err(#NotAuthorized)` is returned
- [ ] `DRY_RUN=1 DFX_NETWORK=ic bash scripts/deploy.sh` — confirm it exits 0 after passing all preflight checks without deploying
- [ ] Run with a `sk_test_*` `STRIPE_SECRET_KEY` against `DFX_NETWORK=ic` — confirm it exits 1 with the key-mismatch error

Closes #144, closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)