### PR TITLE
security: add secrets scanning CI job, pre-commit hook installer, and…

### DIFF
--- a/.github/workflows/secrets-scan.yml
+++ b/.github/workflows/secrets-scan.yml
@@ -1,0 +1,26 @@
+name: Secrets Scan
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  gitleaks:
+    name: Detect secrets (gitleaks)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Full history needed so gitleaks can diff the entire push, not just
+          # the tip commit.
+          fetch-depth: 0
+
+      - name: Run gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -109,3 +109,77 @@ See [DEPLOYMENT.md](DEPLOYMENT.md) for controller rotation procedures.
 - Rotate identity PEMs on a regular schedule for mainnet deployments
 - `fetchRootKey` is only called when `IS_LOCAL = true` — never in production
   builds (enforced by the canister-security test suite)
+
+## Secret Management
+
+### Preventing secret commits
+
+Two layers of defense are in place:
+
+1. **Pre-commit hook** — `scripts/check-secrets.sh` scans staged files for
+   common secret patterns (Anthropic keys, AWS access keys, private key
+   blocks, generic password assignments) and blocks the commit if any match.
+   Install it once after cloning:
+   ```bash
+   bash scripts/install-hooks.sh
+   ```
+
+2. **CI secrets scan** — `.github/workflows/secrets-scan.yml` runs
+   [gitleaks](https://github.com/gitleaks/gitleaks) on every push and PR
+   against `main`. Any commit containing a secret pattern fails the check
+   before the branch can be merged.
+
+### Confirming `.env` is not in history
+
+Run these two commands against a local clone to verify the working tree
+has never contained secrets:
+
+```bash
+# Check if .env itself was ever tracked
+git log --all --full-history -- .env
+
+# Scan all commits for actual key values
+git grep -I "sk-ant-api" $(git rev-list --all)
+git grep -I "sk_live_[A-Za-z0-9]" $(git rev-list --all)
+```
+
+Both commands should produce no output. If either does, follow the key
+rotation procedure below immediately.
+
+### Key rotation procedure
+
+Follow these steps any time a key is suspected to be compromised or is
+confirmed in git history:
+
+#### Anthropic API key (`ANTHROPIC_API_KEY`)
+
+1. Log in to [console.anthropic.com](https://console.anthropic.com) →
+   **API Keys** → revoke the exposed key.
+2. Generate a new key and copy it immediately.
+3. Update the GitHub Secret: **Settings → Secrets and variables → Actions**
+   → update `ANTHROPIC_API_KEY`.
+4. Update your local `.env` with the new value.
+5. Restart the voice agent (`agents/voice`).
+
+#### Stripe secret key (`STRIPE_SECRET_KEY`)
+
+1. Log in to the [Stripe Dashboard](https://dashboard.stripe.com) →
+   **Developers → API keys** → roll the secret key.
+2. Copy the new `sk_live_...` value before closing the dialog (it is shown
+   only once).
+3. Update the GitHub Secret: update `STRIPE_SECRET_KEY` in **Settings →
+   Secrets and variables → Actions**.
+4. Update your local `.env` with the new value.
+5. Redeploy the voice agent or restart the process that reads the key.
+
+#### If a key was committed to git history
+
+Rotating the key is necessary but not sufficient — the old key may have
+been cloned or cached. Additional steps:
+
+1. Rotate the key immediately (see above).
+2. Force-push a rewritten history using `git filter-repo` to remove the
+   commit containing the key. Coordinate with all contributors to re-clone.
+3. Contact GitHub Support to purge cached views of the exposed commit.
+4. Review access logs in the Anthropic / Stripe dashboards for unexpected
+   usage between the exposure date and the rotation date.

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# install-hooks.sh — install local Git hooks for this repository.
+#
+# Run once after cloning:
+#   bash scripts/install-hooks.sh
+#
+# The pre-commit hook calls scripts/check-secrets.sh to block commits that
+# contain secrets (API keys, private key blocks, generic password assignments).
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+HOOKS_DIR="$REPO_ROOT/.git/hooks"
+HOOK_FILE="$HOOKS_DIR/pre-commit"
+
+cat > "$HOOK_FILE" <<'EOF'
+#!/usr/bin/env bash
+# Pre-commit: block commits that contain common secret patterns.
+set -euo pipefail
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+exec bash "$REPO_ROOT/scripts/check-secrets.sh"
+EOF
+
+chmod +x "$HOOK_FILE"
+echo "Pre-commit hook installed at $HOOK_FILE"


### PR DESCRIPTION
… key rotation docs (#136)

- Add .github/workflows/secrets-scan.yml: gitleaks-action runs on every push/PR to main, full history fetch so diffs spanning multiple commits are covered
- Add scripts/install-hooks.sh: wires scripts/check-secrets.sh (already present) as a local pre-commit hook; run once after cloning
- Extend docs/SECURITY.md: new "Secret Management" section documents the two-layer defence, how to confirm .env is clean in history, and step-by-step key rotation procedures for ANTHROPIC_API_KEY and STRIPE_SECRET_KEY including the git-history-rewrite path

Audit results: git log confirms .env was never committed; no actual sk-ant-api or sk_live_ values found anywhere in full history.

## Summary
<!-- What does this PR do? -->

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [ ] Backend tests pass (`make test`)
- [ ] Frontend builds (`cd frontend && npm run build`)
- [ ] Tested locally with dfx

## Checklist
- [ ] Code follows project conventions
- [ ] Self-review completed
- [ ] No sensitive data committed
