### PR TITLE
feat(credits): agent credit top-ups for power users (#89)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,3 +40,9 @@ VITE_RENTCAST_API_KEY=
 VITE_VOICE_AGENT_URL=http://localhost:3001
 # Must match VOICE_AGENT_API_KEY above so the frontend can authenticate
 VITE_VOICE_AGENT_API_KEY=
+
+# Agent credit top-up pack price IDs (one-time Stripe prices, mode=payment)
+# 25 credits — $5
+STRIPE_PRICE_CREDITS_25=
+# 100 credits — $15
+STRIPE_PRICE_CREDITS_100=

--- a/agents/voice/__tests__/creditTopUp.test.ts
+++ b/agents/voice/__tests__/creditTopUp.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Agent Credit Top-Up — source analysis + behaviour tests  (#89)
+ *
+ * CREDIT.1  CREDIT_PACKS constant is exported and contains entries for 25 and 100
+ * CREDIT.2  consumeAgentCredit helper exists in server source
+ * CREDIT.3  grantAgentCredits helper exists in server source
+ * CREDIT.4  /api/agent fallback: credit draw attempted before returning 429
+ * CREDIT.5  POST /api/stripe/create-credit-checkout route is registered
+ * CREDIT.6  POST /api/stripe/verify-credit-purchase route is registered
+ * CREDIT.7  Both new routes read STRIPE_SECRET_KEY from env (never hardcoded)
+ * CREDIT.8  create-credit-checkout reads pack price IDs from env vars
+ * CREDIT.9  CREDIT_PACKS.25 → STRIPE_PRICE_CREDITS_25 env var
+ * CREDIT.10 CREDIT_PACKS.100 → STRIPE_PRICE_CREDITS_100 env var
+ * CREDIT.11 /api/agent 429 body includes creditsAvailable: false
+ * CREDIT.12 consumeAgentCredit validates principal format before shell call
+ * CREDIT.13 grantAgentCredits validates principal format before shell call
+ * CREDIT.14 verify-credit-purchase rejects sessions where type !== "agent_credits"
+ */
+
+import { describe, it, expect } from "@jest/globals";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+import { CREDIT_PACKS } from "../server";
+
+const SERVER_PATH = resolve(__dirname, "../server.ts");
+const src = readFileSync(SERVER_PATH, "utf8");
+
+// ── CREDIT.1 — CREDIT_PACKS exported with 25 and 100 entries ─────────────────
+
+describe("CREDIT.1 — CREDIT_PACKS constant", () => {
+  it("exports CREDIT_PACKS", () => {
+    expect(CREDIT_PACKS).toBeDefined();
+  });
+
+  it("has an entry for pack size 25", () => {
+    expect(CREDIT_PACKS[25]).toBeDefined();
+    expect(typeof CREDIT_PACKS[25].envVar).toBe("string");
+    expect(typeof CREDIT_PACKS[25].label).toBe("string");
+  });
+
+  it("has an entry for pack size 100", () => {
+    expect(CREDIT_PACKS[100]).toBeDefined();
+    expect(typeof CREDIT_PACKS[100].envVar).toBe("string");
+    expect(typeof CREDIT_PACKS[100].label).toBe("string");
+  });
+
+  it("has no entry for an invalid pack size", () => {
+    expect(CREDIT_PACKS[50]).toBeUndefined();
+  });
+});
+
+// ── CREDIT.2 / CREDIT.3 — helpers defined in server source ───────────────────
+
+describe("CREDIT.2 — consumeAgentCredit helper", () => {
+  it("is defined as an async function in server.ts", () => {
+    expect(src).toMatch(/async function consumeAgentCredit/);
+  });
+
+  it("calls the payment canister consumeAgentCredit method via dfx", () => {
+    expect(src).toMatch(/dfx canister call payment consumeAgentCredit/);
+  });
+});
+
+describe("CREDIT.3 — grantAgentCredits helper", () => {
+  it("is defined as an async function in server.ts", () => {
+    expect(src).toMatch(/async function grantAgentCredits/);
+  });
+
+  it("calls the payment canister adminGrantAgentCredits method", () => {
+    expect(src).toMatch(/adminGrantAgentCredits/);
+  });
+});
+
+// ── CREDIT.4 — /api/agent credit fallback before 429 ─────────────────────────
+
+describe("CREDIT.4 — /api/agent credit fallback", () => {
+  it("attempts consumeAgentCredit when tier quota is exhausted", () => {
+    expect(src).toMatch(/consumeAgentCredit\(principal\)/);
+  });
+
+  it("logs a structured event when a credit is consumed", () => {
+    expect(src).toMatch(/agent_credit_used/);
+  });
+
+  it("only falls back when principal is not 'anon'", () => {
+    // The guard `principal !== "anon"` must appear before the consumeAgentCredit call
+    const agentRoute = src.slice(src.indexOf('app.post("/api/agent"'));
+    expect(agentRoute).toMatch(/principal.*!==.*["']anon["']/);
+  });
+});
+
+// ── CREDIT.5 / CREDIT.6 — route registration ─────────────────────────────────
+
+describe("CREDIT.5 — create-credit-checkout route", () => {
+  it("registers POST /api/stripe/create-credit-checkout", () => {
+    expect(src).toMatch(/app\.post\(\s*["'`]\/api\/stripe\/create-credit-checkout["'`]/);
+  });
+});
+
+describe("CREDIT.6 — verify-credit-purchase route", () => {
+  it("registers POST /api/stripe/verify-credit-purchase", () => {
+    expect(src).toMatch(/app\.post\(\s*["'`]\/api\/stripe\/verify-credit-purchase["'`]/);
+  });
+});
+
+// ── CREDIT.7 — secret key from env ───────────────────────────────────────────
+
+describe("CREDIT.7 — secret key sourced from env in credit routes", () => {
+  it("does not hardcode sk_live_ or sk_test_ keys", () => {
+    expect(src).not.toMatch(/["'`]sk_(?:live|test)_[A-Za-z0-9]+["'`]/);
+  });
+
+  it("reads STRIPE_SECRET_KEY from process.env in create-credit-checkout", () => {
+    const routeBlock = src.slice(src.indexOf("/api/stripe/create-credit-checkout"));
+    expect(routeBlock.slice(0, routeBlock.indexOf("});") + 3)).toMatch(/STRIPE_SECRET_KEY/);
+  });
+});
+
+// ── CREDIT.8 / CREDIT.9 / CREDIT.10 — env-var price IDs ─────────────────────
+
+describe("CREDIT.8 — pack price IDs from env vars", () => {
+  it("reads STRIPE_PRICE_CREDITS_25 from process.env", () => {
+    expect(src).toMatch(/STRIPE_PRICE_CREDITS_25/);
+  });
+
+  it("reads STRIPE_PRICE_CREDITS_100 from process.env", () => {
+    expect(src).toMatch(/STRIPE_PRICE_CREDITS_100/);
+  });
+});
+
+describe("CREDIT.9 — CREDIT_PACKS[25] uses STRIPE_PRICE_CREDITS_25", () => {
+  it("envVar field matches the expected env var name", () => {
+    expect(CREDIT_PACKS[25].envVar).toBe("STRIPE_PRICE_CREDITS_25");
+  });
+});
+
+describe("CREDIT.10 — CREDIT_PACKS[100] uses STRIPE_PRICE_CREDITS_100", () => {
+  it("envVar field matches the expected env var name", () => {
+    expect(CREDIT_PACKS[100].envVar).toBe("STRIPE_PRICE_CREDITS_100");
+  });
+});
+
+// ── CREDIT.11 — 429 body shape ────────────────────────────────────────────────
+
+describe("CREDIT.11 — 429 response includes creditsAvailable: false", () => {
+  it("emits creditsAvailable: false when both tier and credits are exhausted", () => {
+    expect(src).toMatch(/creditsAvailable:\s*false/);
+  });
+});
+
+// ── CREDIT.12 / CREDIT.13 — principal validation ─────────────────────────────
+
+describe("CREDIT.12 — consumeAgentCredit validates principal", () => {
+  it("rejects an invalid principal format before calling dfx", () => {
+    // The principal regex check must appear inside consumeAgentCredit
+    const helperBlock = src.slice(
+      src.indexOf("async function consumeAgentCredit"),
+      src.indexOf("async function grantAgentCredits"),
+    );
+    expect(helperBlock).toMatch(/Invalid principal/);
+  });
+});
+
+describe("CREDIT.13 — grantAgentCredits validates principal", () => {
+  it("rejects an invalid principal format before calling dfx", () => {
+    const helperBlock = src.slice(
+      src.indexOf("async function grantAgentCredits"),
+      src.indexOf("// ── Credit top-up helpers") + 5000,
+    );
+    expect(helperBlock).toMatch(/Invalid principal/);
+  });
+});
+
+// ── CREDIT.14 — verify-credit-purchase type guard ────────────────────────────
+
+describe("CREDIT.14 — verify-credit-purchase rejects non-credit sessions", () => {
+  it('checks that session metadata type === "agent_credits"', () => {
+    const start = src.indexOf('"/api/stripe/verify-credit-purchase"');
+    const routeBlock = src.slice(start, start + 2000);
+    expect(routeBlock).toMatch(/agent_credits/);
+  });
+});

--- a/agents/voice/server.ts
+++ b/agents/voice/server.ts
@@ -189,8 +189,23 @@ app.post("/api/agent", async (req: Request, res: Response): Promise<void> => {
   const { allowed, count, limit, resetsAt } = checkAndRecord(principal, tier);
 
   if (!allowed) {
-    res.status(429).json({ error: "daily_agent_limit_reached", limit, count, resetsAt });
-    return;
+    // Tier quota exhausted — try to draw from one-time credit balance (#89).
+    let creditFallback = false;
+    if (principal !== "anon") {
+      try {
+        await consumeAgentCredit(principal);
+        creditFallback = true;
+        process.stdout.write(JSON.stringify({
+          ts: new Date().toISOString(), event: "agent_credit_used", principal, tier,
+        }) + "\n");
+      } catch {
+        // No credits, expired, or canister unreachable — fall through to 429.
+      }
+    }
+    if (!creditFallback) {
+      res.status(429).json({ error: "daily_agent_limit_reached", limit, count, resetsAt, creditsAvailable: false });
+      return;
+    }
   }
 
   // ── respond with remaining quota header so the UI can update the counter ──
@@ -1060,6 +1075,48 @@ async function activateInCanister(principal: string, tier: string, months: numbe
   }
 }
 
+// ── Credit top-up helpers (#89) ───────────────────────────────────────────────
+
+/** Valid top-up pack sizes and their Stripe price-ID env vars. */
+export const CREDIT_PACKS: Record<number, { envVar: string; label: string }> = {
+  25:  { envVar: "STRIPE_PRICE_CREDITS_25",  label: "25 credits" },
+  100: { envVar: "STRIPE_PRICE_CREDITS_100", label: "100 credits" },
+};
+
+/**
+ * Atomically decrement 1 agent credit for `principal` in the payment canister.
+ * Throws if the canister returns an error (no credits, expired, or unavailable).
+ */
+async function consumeAgentCredit(principal: string): Promise<void> {
+  if (!/^[a-z0-9]([a-z0-9-]{0,60}[a-z0-9])?$/.test(principal)) {
+    throw new Error("Invalid principal format");
+  }
+  const { exec }      = await import("child_process");
+  const { promisify } = await import("util");
+  const execAsync = promisify(exec);
+  const cmd = `dfx canister call payment consumeAgentCredit '(principal "${principal}")'`;
+  const { stdout, stderr } = await execAsync(cmd);
+  if (stderr && /error/i.test(stderr)) throw new Error(`Credit consume failed: ${stderr.trim()}`);
+  if (/\berr\b/i.test(stdout))         throw new Error("No agent credits available");
+}
+
+/**
+ * Grant agent credits to `principal` in the payment canister.
+ * Called by the voice server after Stripe confirms a one-time credit pack purchase.
+ */
+async function grantAgentCredits(principal: string, amount: number): Promise<void> {
+  if (!/^[a-z0-9]([a-z0-9-]{0,60}[a-z0-9])?$/.test(principal)) {
+    throw new Error("Invalid principal format");
+  }
+  if (!Number.isInteger(amount) || amount <= 0) throw new Error("Invalid credit amount");
+  const { exec }      = await import("child_process");
+  const { promisify } = await import("util");
+  const execAsync = promisify(exec);
+  const cmd = `dfx canister call payment adminGrantAgentCredits '(principal "${principal}", ${amount} : nat)'`;
+  const { stderr } = await execAsync(cmd);
+  if (stderr && /error/i.test(stderr)) throw new Error(`Credit grant failed: ${stderr.trim()}`);
+}
+
 app.post("/api/stripe/verify-session", async (req: Request, res: Response) => {
   const stripeSecretKey = process.env.STRIPE_SECRET_KEY;
   if (!stripeSecretKey) { res.status(500).json({ error: "STRIPE_SECRET_KEY not configured" }); return; }
@@ -1166,6 +1223,92 @@ app.post("/api/stripe/verify-subscription", async (req: Request, res: Response) 
     }
 
     res.json({ type: "subscription", tier, billing });
+  } catch (err) {
+    res.status(500).json({ error: err instanceof Error ? err.message : "Stripe error" });
+  }
+});
+
+// ── POST /api/stripe/create-credit-checkout ──────────────────────────────────
+// Creates a Stripe Checkout Session in one-time payment mode for an agent credit
+// pack (25 or 100 credits).  On success the browser is redirected to Stripe;
+// the verify-credit-purchase route tops up the balance after payment.
+app.post("/api/stripe/create-credit-checkout", async (req: Request, res: Response) => {
+  const stripeSecretKey = process.env.STRIPE_SECRET_KEY;
+  if (!stripeSecretKey) { res.status(500).json({ error: "STRIPE_SECRET_KEY not configured" }); return; }
+
+  const { packSize, principal, successUrl, cancelUrl } = req.body as {
+    packSize: number; principal: string; successUrl: string; cancelUrl: string;
+  };
+
+  const pack = CREDIT_PACKS[packSize];
+  if (!pack) {
+    res.status(400).json({ error: `Unknown pack size: ${packSize}. Valid sizes: ${Object.keys(CREDIT_PACKS).join(", ")}` });
+    return;
+  }
+
+  const priceId = process.env[pack.envVar]?.trim();
+  if (!priceId) {
+    res.status(500).json({ error: `${pack.envVar} is not configured` });
+    return;
+  }
+
+  if (!/^[a-z0-9]([a-z0-9-]{0,60}[a-z0-9])?$/.test(principal ?? "")) {
+    res.status(400).json({ error: "Invalid principal" }); return;
+  }
+
+  try {
+    const Stripe = (await import("stripe")).default;
+    const stripe = new Stripe(stripeSecretKey);
+    const session = await stripe.checkout.sessions.create({
+      mode: "payment",
+      line_items: [{ price: priceId, quantity: 1 }],
+      success_url: successUrl,
+      cancel_url:  cancelUrl,
+      metadata: { principal, pack_size: String(packSize), type: "agent_credits" },
+    });
+    res.json({ url: session.url });
+  } catch (err) {
+    res.status(500).json({ error: err instanceof Error ? err.message : "Stripe error" });
+  }
+});
+
+// ── POST /api/stripe/verify-credit-purchase ───────────────────────────────────
+// Called from the payment success page after a credit pack checkout completes.
+// Verifies the Stripe session, then calls adminGrantAgentCredits on the canister.
+app.post("/api/stripe/verify-credit-purchase", async (req: Request, res: Response) => {
+  const stripeSecretKey = process.env.STRIPE_SECRET_KEY;
+  if (!stripeSecretKey) { res.status(500).json({ error: "STRIPE_SECRET_KEY not configured" }); return; }
+
+  const { sessionId } = req.body as { sessionId: string };
+  if (!sessionId) { res.status(400).json({ error: "sessionId required" }); return; }
+
+  try {
+    const Stripe = (await import("stripe")).default;
+    const stripe  = new Stripe(stripeSecretKey);
+    const session = await stripe.checkout.sessions.retrieve(sessionId);
+
+    if (session.payment_status !== "paid") {
+      res.status(400).json({ error: `Payment not confirmed — status: ${session.payment_status}` }); return;
+    }
+    if (session.metadata?.type !== "agent_credits") {
+      res.status(400).json({ error: "Session is not a credit pack purchase" }); return;
+    }
+
+    const principal = session.metadata?.principal ?? "";
+    const packSize  = Number(session.metadata?.pack_size ?? 0);
+
+    if (!principal || !CREDIT_PACKS[packSize]) {
+      res.status(400).json({ error: "Missing or invalid metadata in session" }); return;
+    }
+
+    try {
+      await grantAgentCredits(principal, packSize);
+      console.log(`[stripe] granted ${packSize} agent credits to ${principal}`);
+    } catch (e) {
+      console.warn(`[stripe] credit grant skipped: ${(e as Error).message}`);
+    }
+
+    res.json({ type: "agent_credits", packSize, principal });
   } catch (err) {
     res.status(500).json({ error: err instanceof Error ? err.message : "Stripe error" });
   }

--- a/backend/payment/main.mo
+++ b/backend/payment/main.mo
@@ -68,6 +68,11 @@ persistent actor Payment {
     redeemedBy     : ?Principal;
   };
 
+  public type AgentCreditBalance = {
+    balance:   Nat;
+    expiresAt: Int;  // nanoseconds; 0 = never expires
+  };
+
   public type SubscriptionStats = {
     total: Nat;
     free: Nat;
@@ -206,7 +211,8 @@ persistent actor Payment {
 
   // ─── State ───────────────────────────────────────────────────────────────────
 
-  private let subscriptions = Map.empty<Principal, Subscription>();
+  private let subscriptions        = Map.empty<Principal, Subscription>();
+  private let agentCreditBalances  = Map.empty<Principal, AgentCreditBalance>();
 
   // Admin
   private var adminEntries     : [Principal] = [];
@@ -932,6 +938,67 @@ persistent actor Payment {
       case (?s)  {
         if (s.expiresAt > 0 and s.expiresAt <= Time.now()) { #Free }
         else { s.tier }
+      };
+    }
+  };
+
+  // ─── Agent Credit Top-Ups (#89) ──────────────────────────────────────────────
+
+  /// Returns the caller's remaining agent credit balance.
+  /// Returns 0 if no credits exist or all credits have expired.
+  public query(msg) func getMyAgentCredits() : async Nat {
+    let now = Time.now();
+    switch (Map.get(agentCreditBalances, Principal.compare, msg.caller)) {
+      case null  { 0 };
+      case (?b)  {
+        if (b.expiresAt > 0 and b.expiresAt <= now) { 0 }
+        else { b.balance }
+      };
+    }
+  };
+
+  /// Admin: grant agent credits to a principal after a verified Stripe payment.
+  /// If the principal already has an active balance the new amount is added;
+  /// expiry is extended to 12 months from now if that is later than the current expiry.
+  public shared(msg) func adminGrantAgentCredits(
+    user   : Principal,
+    amount : Nat,
+  ) : async Result.Result<Nat, Error> {
+    if (not isAdmin(msg.caller)) return #err(#NotAuthorized);
+    if (amount == 0)             return #err(#InvalidInput("amount must be > 0"));
+    let now          = Time.now();
+    let twelveMonths : Int = 365 * 24 * 60 * 60 * 1_000_000_000;
+    let newExpiry    = now + twelveMonths;
+    let existing     = switch (Map.get(agentCreditBalances, Principal.compare, user)) {
+      case null  { { balance = 0; expiresAt = 0 } };
+      case (?b)  {
+        if (b.expiresAt > 0 and b.expiresAt <= now) { { balance = 0; expiresAt = 0 } }
+        else { b }
+      };
+    };
+    let updated : AgentCreditBalance = {
+      balance   = existing.balance + amount;
+      expiresAt = if (existing.expiresAt > newExpiry) existing.expiresAt else newExpiry;
+    };
+    Map.add(agentCreditBalances, Principal.compare, user, updated);
+    #ok(updated.balance)
+  };
+
+  /// Admin: atomically decrement 1 agent credit for a user.
+  /// Called by the voice server when the tier quota is exhausted but the user has
+  /// purchased top-up credits.  Returns the remaining balance after decrement.
+  /// Returns #err(#NotFound) when the user has no credits or all credits have expired.
+  public shared(msg) func consumeAgentCredit(user: Principal) : async Result.Result<Nat, Error> {
+    if (not isAdmin(msg.caller)) return #err(#NotAuthorized);
+    let now = Time.now();
+    switch (Map.get(agentCreditBalances, Principal.compare, user)) {
+      case null  { #err(#NotFound) };
+      case (?b)  {
+        if (b.expiresAt > 0 and b.expiresAt <= now) return #err(#NotFound);
+        if (b.balance == 0)                          return #err(#NotFound);
+        let updated : AgentCreditBalance = { balance = b.balance - 1; expiresAt = b.expiresAt };
+        Map.add(agentCreditBalances, Principal.compare, user, updated);
+        #ok(updated.balance)
       };
     }
   };

--- a/frontend/src/__tests__/components/AgentPages.test.tsx
+++ b/frontend/src/__tests__/components/AgentPages.test.tsx
@@ -53,6 +53,7 @@ vi.mock("@icp-sdk/core/agent", () => ({
 
 vi.mock("@/services/payment", () => ({
   paymentService: {
+    getMyAgentCredits: vi.fn(() => Promise.resolve(0)),
     getMySubscription: vi.fn().mockResolvedValue({ tier: "Pro" }),
   },
 }));

--- a/frontend/src/__tests__/components/CancelledAccount835.test.tsx
+++ b/frontend/src/__tests__/components/CancelledAccount835.test.tsx
@@ -28,6 +28,7 @@ vi.mock("@/services/payment", async (importOriginal) => {
     ...actual,
     paymentService: {
       ...actual.paymentService,
+      getMyAgentCredits: vi.fn(() => Promise.resolve(0)),
       getMySubscription: vi.fn().mockImplementation(() =>
         Promise.resolve({ tier: mockTier, expiresAt: null })
       ),

--- a/frontend/src/__tests__/components/CheckoutPage.test.tsx
+++ b/frontend/src/__tests__/components/CheckoutPage.test.tsx
@@ -43,6 +43,7 @@ vi.mock("@/services/payment", async (importOriginal) => {
       ...actual.paymentService,
       subscribe:        vi.fn().mockResolvedValue(undefined),
       subscribeAnnual:  vi.fn().mockResolvedValue(undefined),
+      getMyAgentCredits: vi.fn(() => Promise.resolve(0)),
       getMySubscription: vi.fn().mockResolvedValue({ tier: "Free", expiresAt: null }),
     },
   };

--- a/frontend/src/__tests__/components/Fsbo101.test.tsx
+++ b/frontend/src/__tests__/components/Fsbo101.test.tsx
@@ -15,6 +15,7 @@ import { MemoryRouter } from "react-router-dom";
 
 vi.mock("@/services/payment", () => ({
   paymentService: {
+    getMyAgentCredits: vi.fn(() => Promise.resolve(0)),
     getMySubscription: vi.fn().mockResolvedValue({ tier: "Pro" }),
   },
 }));

--- a/frontend/src/__tests__/components/FsboHandoff107.test.tsx
+++ b/frontend/src/__tests__/components/FsboHandoff107.test.tsx
@@ -93,6 +93,7 @@ vi.mock("@/services/mlsService", () => ({
 
 vi.mock("@/services/payment", () => ({
   paymentService: {
+    getMyAgentCredits: vi.fn(() => Promise.resolve(0)),
     getMySubscription: vi.fn().mockResolvedValue({ tier: "Pro" }),
   },
 }));

--- a/frontend/src/__tests__/components/FsboPanel.test.tsx
+++ b/frontend/src/__tests__/components/FsboPanel.test.tsx
@@ -45,6 +45,7 @@ const { mockRecord, mockProperty } = vi.hoisted(() => ({
 
 vi.mock("@/services/payment", () => ({
   paymentService: {
+    getMyAgentCredits: vi.fn(() => Promise.resolve(0)),
     getMySubscription: vi.fn().mockResolvedValue({ tier: "Pro" }),
   },
 }));

--- a/frontend/src/__tests__/components/Gate1564.test.tsx
+++ b/frontend/src/__tests__/components/Gate1564.test.tsx
@@ -21,6 +21,7 @@ let mockTier: "Free" | "Pro" | "Premium" | "ContractorPro" = "Pro";
 
 vi.mock("@/services/payment", () => ({
   paymentService: {
+    getMyAgentCredits: vi.fn(() => Promise.resolve(0)),
     getMySubscription: vi.fn().mockImplementation(() =>
       Promise.resolve({ tier: mockTier, expiresAt: null, cancelledAt: null })
     ),

--- a/frontend/src/__tests__/components/GenerateReportModal.test.tsx
+++ b/frontend/src/__tests__/components/GenerateReportModal.test.tsx
@@ -79,6 +79,7 @@ vi.mock("react-hot-toast", () => ({
 let mockTier: "Free" | "Pro" | "Premium" | "ContractorPro" = "Free";
 vi.mock("@/services/payment", () => ({
   paymentService: {
+    getMyAgentCredits: vi.fn(() => Promise.resolve(0)),
     getMySubscription: vi.fn().mockImplementation(() =>
       Promise.resolve({ tier: mockTier, expiresAt: null, cancelledAt: null })
     ),

--- a/frontend/src/__tests__/components/Listing96.test.tsx
+++ b/frontend/src/__tests__/components/Listing96.test.tsx
@@ -67,6 +67,7 @@ vi.mock("@/services/listing", () => ({
 
 vi.mock("@/services/payment", () => ({
   paymentService: {
+    getMyAgentCredits: vi.fn(() => Promise.resolve(0)),
     getMySubscription: vi.fn().mockResolvedValue({ tier: "Pro" }),
   },
 }));

--- a/frontend/src/__tests__/components/ListingPages.test.tsx
+++ b/frontend/src/__tests__/components/ListingPages.test.tsx
@@ -106,6 +106,7 @@ const mockOpenRequest = {
 
 vi.mock("@/services/payment", () => ({
   paymentService: {
+    getMyAgentCredits: vi.fn(() => Promise.resolve(0)),
     getMySubscription: vi.fn().mockResolvedValue({ tier: "Pro" }),
   },
 }));

--- a/frontend/src/__tests__/components/PricingPage.test.tsx
+++ b/frontend/src/__tests__/components/PricingPage.test.tsx
@@ -41,6 +41,7 @@ vi.mock("@/services/payment", async (importOriginal) => {
     ...actual,
     paymentService: {
       ...actual.paymentService,
+      getMyAgentCredits: vi.fn(() => Promise.resolve(0)),
       getMySubscription: vi.fn().mockResolvedValue({ tier: "Free", expiresAt: null }),
     },
   };

--- a/frontend/src/__tests__/components/Report152.test.tsx
+++ b/frontend/src/__tests__/components/Report152.test.tsx
@@ -138,6 +138,7 @@ vi.mock("@/services/notifications", () => ({
 let mockTier: "Free" | "Pro" | "Premium" | "ContractorPro" = "Free";
 vi.mock("@/services/payment", () => ({
   paymentService: {
+    getMyAgentCredits: vi.fn(() => Promise.resolve(0)),
     getMySubscription: vi.fn().mockImplementation(() =>
       Promise.resolve({ tier: mockTier, expiresAt: null, cancelledAt: null })
     ),

--- a/frontend/src/__tests__/components/UpgradeModal.test.tsx
+++ b/frontend/src/__tests__/components/UpgradeModal.test.tsx
@@ -22,6 +22,7 @@ vi.mock("@/services/payment", async (importOriginal) => {
     paymentService: {
       subscribe:              vi.fn().mockResolvedValue(undefined),
       startStripeCheckout:    vi.fn().mockResolvedValue(undefined),
+      getMyAgentCredits: vi.fn(() => Promise.resolve(0)),
       getMySubscription:      vi.fn().mockResolvedValue({ tier: "Free", expiresAt: null }),
       initiate:               vi.fn().mockResolvedValue({ url: "/" }),
     },

--- a/frontend/src/__tests__/contracts/__snapshots__/candid.contract.test.ts.snap
+++ b/frontend/src/__tests__/contracts/__snapshots__/candid.contract.test.ts.snap
@@ -704,6 +704,16 @@ exports[`maintenance IDL factory > full signature snapshot 1`] = `
 
 exports[`payment IDL factory > full signature snapshot 1`] = `
 {
+  "adminGrantAgentCredits": {
+    "args": [
+      "principal",
+      "nat",
+    ],
+    "mode": [],
+    "rets": [
+      "variant {ok:nat; err:variant {InvalidInput:text; PaymentFailed:text; NotFound; NotAuthorized; RateLimited}}",
+    ],
+  },
   "cancelSubscription": {
     "args": [],
     "mode": [],
@@ -738,6 +748,15 @@ exports[`payment IDL factory > full signature snapshot 1`] = `
     ],
     "rets": [
       "vec record {periodDays:nat; tier:variant {Pro; Premium; Free; Basic; ContractorPro; ContractorFree}; quoteRequestsPerMonth:nat; propertyLimit:nat; priceUSD:nat; photosPerJob:nat}",
+    ],
+  },
+  "getMyAgentCredits": {
+    "args": [],
+    "mode": [
+      "query",
+    ],
+    "rets": [
+      "nat",
     ],
   },
   "getMySubscription": {

--- a/frontend/src/__tests__/contracts/candid.contract.test.ts
+++ b/frontend/src/__tests__/contracts/candid.contract.test.ts
@@ -123,10 +123,12 @@ describe("payment IDL factory", () => {
   it("exposes the expected methods", () => {
     const svc = extractService(paymentIdlFactory);
     expect(Object.keys(svc).sort()).toEqual([
+      "adminGrantAgentCredits",
       "cancelSubscription",
       "configureStripe",
       "createStripeCheckoutSession",
       "getAllPricing",
+      "getMyAgentCredits",
       "getMySubscription",
       "getPriceQuote",
       "getPricing",
@@ -148,7 +150,7 @@ describe("payment IDL factory", () => {
       .filter(([, sig]) => sig.mode.includes("query"))
       .map(([name]) => name)
       .sort();
-    expect(queries).toEqual(["getAllPricing", "getMySubscription", "getPricing", "getSubscriptionStats", "isStripeConfigured", "listPendingGifts"]);
+    expect(queries).toEqual(["getAllPricing", "getMyAgentCredits", "getMySubscription", "getPricing", "getSubscriptionStats", "isStripeConfigured", "listPendingGifts"]);
   });
 
   it("getSubscriptionStats returns all tier breakdown fields", () => {

--- a/frontend/src/__tests__/pages/SettingsPage.test.tsx
+++ b/frontend/src/__tests__/pages/SettingsPage.test.tsx
@@ -20,6 +20,7 @@ vi.mock("@/services/payment", async (importOriginal) => {
   return {
     ...actual,
     paymentService: {
+      getMyAgentCredits: vi.fn(() => Promise.resolve(0)),
       getMySubscription: vi.fn(),
       initiate:          vi.fn().mockResolvedValue({ url: "/dashboard" }),
       cancel:            vi.fn().mockResolvedValue({ expiresAt: null }),

--- a/frontend/src/__tests__/pages/WarrantyOcr.test.tsx
+++ b/frontend/src/__tests__/pages/WarrantyOcr.test.tsx
@@ -35,6 +35,7 @@ vi.mock("@/services/property", () => ({
 
 vi.mock("@/services/payment", () => ({
   paymentService: {
+    getMyAgentCredits: vi.fn(() => Promise.resolve(0)),
     getMySubscription: vi.fn().mockResolvedValue({ tier: "Pro" }),
   },
   PLANS: [],

--- a/frontend/src/__tests__/perf/renderPerf1341_1342.test.tsx
+++ b/frontend/src/__tests__/perf/renderPerf1341_1342.test.tsx
@@ -93,7 +93,8 @@ vi.mock("@/services/recurringService", () => ({
 
 vi.mock("@/services/payment", () => ({
   paymentService: {
-    getMySubscription: vi.fn(() => Promise.resolve({ tier: "Pro", expiresAt: null, cancelledAt: null })),
+    getMySubscription:   vi.fn(() => Promise.resolve({ tier: "Pro", expiresAt: null, cancelledAt: null })),
+    getMyAgentCredits:   vi.fn(() => Promise.resolve(0)),
   },
 }));
 

--- a/frontend/src/__tests__/services/__snapshots__/candidContracts.test.ts.snap
+++ b/frontend/src/__tests__/services/__snapshots__/candidContracts.test.ts.snap
@@ -123,10 +123,12 @@ unregisterCanister(1) -> (1)"
 `;
 
 exports[`Candid contract snapshots — method arity > payment 1`] = `
-"cancelSubscription(0) -> (1)
+"adminGrantAgentCredits(2) -> (1)
+cancelSubscription(0) -> (1)
 configureStripe(1) -> (1)
 createStripeCheckoutSession(3) -> (1)
 getAllPricing(0) -> (1) [query]
+getMyAgentCredits(0) -> (1) [query]
 getMySubscription(0) -> (1) [query]
 getPriceQuote(1) -> (1)
 getPricing(1) -> (1) [query]

--- a/frontend/src/hooks/useVoiceAgent.ts
+++ b/frontend/src/hooks/useVoiceAgent.ts
@@ -65,6 +65,7 @@ export interface UseVoiceAgentReturn {
   history:            AgentAction[];
   pendingImage:       { base64: string; mimeType: string } | null;
   pendingProposal:    PendingProposal | null;
+  creditBalance:      number | null;
   clearHistory:       () => void;
   startListening:     () => void;
   stopListening:      () => void;
@@ -74,6 +75,7 @@ export interface UseVoiceAgentReturn {
   sendImageToAgent:   (userText: string) => void;
   confirmProposal:    () => Promise<void>;
   dismissProposal:    () => void;
+  buyCredits:         (packSize: 25 | 100) => Promise<void>;
 }
 
 // ── Config ─────────────────────────────────────────────────────────────────────
@@ -104,6 +106,13 @@ export function useVoiceAgent(): UseVoiceAgentReturn {
   const [alerts,          setAlerts]         = useState<ProactiveAlert[]>([]);
   const [pendingImage,    setPendingImage]   = useState<{ base64: string; mimeType: string } | null>(null);
   const [pendingProposal, setPendingProposal] = useState<PendingProposal | null>(null);
+  const [creditBalance,   setCreditBalance]  = useState<number | null>(null);
+
+  useEffect(() => {
+    paymentService.getMyAgentCredits()
+      .then(setCreditBalance)
+      .catch(() => setCreditBalance(0));
+  }, []);
 
   const recognitionRef     = useRef<any>(null);
   const finalTranscriptRef = useRef("");
@@ -395,8 +404,11 @@ export function useVoiceAgent(): UseVoiceAgentReturn {
           const resetTime = resetsAt
             ? new Date(resetsAt).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })
             : "midnight UTC";
+          // Refresh credit balance after a quota-exhausted response.
+          paymentService.getMyAgentCredits().then(setCreditBalance).catch(() => {});
           throw new Error(
-            `You've used your ${body.limit ?? ""} AI assistant calls for today. Resets at ${resetTime} — or upgrade for more.`
+            `You've used your ${body.limit ?? ""} AI assistant calls for today. Resets at ${resetTime}.` +
+            ` Buy a credit pack for instant top-up, or upgrade your plan for a higher daily limit.`
           );
         }
 
@@ -594,12 +606,16 @@ export function useVoiceAgent(): UseVoiceAgentReturn {
     setResponse("No problem — proposal discarded.");
   }, []);
 
+  const buyCredits = useCallback(async (packSize: 25 | 100) => {
+    await paymentService.startCreditPackCheckout(packSize);
+  }, []);
+
   return {
     state, transcript, response, error, isSupported,
     alerts, history, clearHistory, pendingImage,
-    pendingProposal,
+    pendingProposal, creditBalance,
     startListening, stopListening, reset,
     attachImage, clearImage, sendImageToAgent,
-    confirmProposal, dismissProposal,
+    confirmProposal, dismissProposal, buyCredits,
   };
 }

--- a/frontend/src/services/payment.ts
+++ b/frontend/src/services/payment.ts
@@ -166,6 +166,17 @@ export const idlFactory = ({ IDL }: any) => {
       [IDL.Variant({ ok: IDL.Null, err: Error })],
       []
     ),
+    // ── Agent credit top-ups (#89) ──
+    getMyAgentCredits: IDL.Func(
+      [],
+      [IDL.Nat],
+      ["query"]
+    ),
+    adminGrantAgentCredits: IDL.Func(
+      [IDL.Principal, IDL.Nat],
+      [IDL.Variant({ ok: IDL.Nat, err: Error })],
+      []
+    ),
   });
 };
 
@@ -443,5 +454,36 @@ export const paymentService = {
       const detail = (result.err as any)[key];
       throw new Error(typeof detail === "string" ? detail : key);
     }
+  },
+
+  // ── Agent credit top-ups (#89) ────────────────────────────────────────────────
+
+  /** Returns the caller's remaining agent credit balance (0 if none or expired). */
+  async getMyAgentCredits(): Promise<number> {
+    if ((window as any).__e2e_agent_credits != null) {
+      return Number((window as any).__e2e_agent_credits);
+    }
+    const a = await getActor();
+    const result = await a.getMyAgentCredits();
+    return Number(result);
+  },
+
+  /**
+   * Start a Stripe Checkout session to purchase an agent credit pack.
+   * Redirects the browser to the Stripe-hosted payment page on success.
+   * `packSize` must be 25 or 100.
+   */
+  async startCreditPackCheckout(packSize: 25 | 100): Promise<void> {
+    const principal  = await getPrincipal().catch(() => "");
+    const successUrl = `${window.location.origin}/payment-success?credit_session_id={CHECKOUT_SESSION_ID}`;
+    const cancelUrl  = `${window.location.origin}/payment-failure`;
+    const resp = await fetch(`${VOICE_AGENT_URL}/api/stripe/create-credit-checkout`, {
+      method:  "POST",
+      headers: { "Content-Type": "application/json" },
+      body:    JSON.stringify({ packSize, principal, successUrl, cancelUrl }),
+    });
+    const data = await resp.json();
+    if (!resp.ok) throw new Error(data.error ?? "Checkout failed");
+    window.location.href = data.url;
   },
 };


### PR DESCRIPTION
Payment canister: add AgentCreditBalance type, agentCreditBalances map, and three methods — getMyAgentCredits (query), consumeAgentCredit (admin, atomic decrement), adminGrantAgentCredits (admin, adds credits with 12-month expiry).

Voice server: add consumeAgentCredit/grantAgentCredits dfx-CLI helpers; update /api/agent to fall back to one-time credit balance before returning 429 (emits agent_credit_used log event); add POST /api/stripe/create-credit-checkout (one-time Stripe payment session for 25 or 100 credit packs) and POST /api/stripe/verify-credit-purchase (verifies payment, calls adminGrantAgentCredits); export CREDIT_PACKS constant.

Frontend: add getMyAgentCredits + startCreditPackCheckout to paymentService IDL and service; add creditBalance state (fetched on mount), buyCredits callback, and updated 429 message to useVoiceAgent hook.

Tests: 23-case creditTopUp.test.ts covers CREDIT.1–14 (constant shape, helper presence, route registration, env-var sourcing, 429 body, principal validation, type guard).

## Summary
<!-- What does this PR do? -->

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [ ] Backend tests pass (`make test`)
- [ ] Frontend builds (`cd frontend && npm run build`)
- [ ] Tested locally with dfx

## Checklist
- [ ] Code follows project conventions
- [ ] Self-review completed
- [ ] No sensitive data committed
