### PR TITLE
feat(payments): add Stripe webhook endpoint with subscription lifecyc…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,3 +46,7 @@ VITE_VOICE_AGENT_API_KEY=
 STRIPE_PRICE_CREDITS_25=
 # 100 credits — $15
 STRIPE_PRICE_CREDITS_100=
+
+# Stripe webhook endpoint secret — from the Stripe Dashboard → Webhooks → your endpoint
+# Required in production; if unset the /api/stripe/webhook route returns 500 (fail-closed).
+STRIPE_WEBHOOK_SECRET=

--- a/agents/voice/__tests__/stripe.subscription.integration.test.ts
+++ b/agents/voice/__tests__/stripe.subscription.integration.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Stripe Subscription Lifecycle Integration Tests (#143)
+ *
+ * Tests the full subscription lifecycle via the /api/stripe/webhook endpoint
+ * using real Stripe test-mode signatures (STRIPE_WEBHOOK_SECRET required).
+ *
+ * Scenarios covered:
+ *   - checkout session creation with correct metadata
+ *   - customer.subscription.deleted  → 200 { received: true }
+ *   - customer.subscription.updated (cancel_at_period_end) → 200
+ *   - invoice.payment_failed → 200
+ *   - invoice.payment_succeeded → 200
+ *   - spoofed webhook (wrong signature) → 400
+ *   - downgrade: subscription updated status=canceled → 200
+ *
+ * Requires STRIPE_SECRET_KEY (sk_test_...) and STRIPE_WEBHOOK_SECRET in .env.
+ * Skipped automatically when unconfigured so CI stays green without secrets.
+ *
+ * Run manually:
+ *   cd agents/voice && npm test -- stripe.subscription
+ */
+
+import "dotenv/config";
+
+// jest.mock is hoisted above all imports.
+jest.mock("../anthropicProvider", () => ({
+  createAnthropicProvider: jest.fn().mockReturnValue({
+    stream: jest.fn(),
+    complete: jest.fn(),
+    completeWithTools: jest.fn(),
+  }),
+}));
+jest.mock("../prompts", () => ({
+  buildSystemPrompt: jest.fn().mockReturnValue("test"),
+}));
+jest.mock("../../maintenance/prompts", () => ({
+  buildMaintenanceSystemPrompt: jest.fn().mockReturnValue("test"),
+}));
+// Prevent dfx CLI calls during tests — canister activation is best-effort anyway.
+jest.mock("child_process", () => ({
+  exec: jest.fn((_cmd: string, cb: (err: null, result: { stdout: string; stderr: string }) => void) => {
+    cb(null, { stdout: "(ok)", stderr: "" });
+  }),
+}));
+
+import Stripe from "stripe";
+import supertest from "supertest";
+import { app } from "../server";
+
+const SECRET_KEY       = process.env.STRIPE_SECRET_KEY ?? "";
+const WEBHOOK_SECRET   = process.env.STRIPE_WEBHOOK_SECRET ?? "";
+const PRICE_PRO_MONTHLY = process.env.STRIPE_PRICE_PRO_MONTHLY ?? "";
+
+const describeIfConfigured =
+  SECRET_KEY.startsWith("sk_test_") && WEBHOOK_SECRET.length > 0
+    ? describe
+    : describe.skip;
+
+describeIfConfigured("Stripe subscription lifecycle integration", () => {
+  let stripe: Stripe;
+
+  beforeAll(() => {
+    stripe = new Stripe(SECRET_KEY);
+  });
+
+  /**
+   * Send an event object to the webhook endpoint signed with STRIPE_WEBHOOK_SECRET.
+   * The event is serialised to JSON, signed, then sent as a raw Buffer so the
+   * express.raw() middleware on /api/stripe/webhook receives the unmodified body.
+   */
+  async function sendWebhookEvent(event: object) {
+    const payload = JSON.stringify(event);
+    const header  = stripe.webhooks.generateTestHeaderString({ payload, secret: WEBHOOK_SECRET });
+    return supertest(app)
+      .post("/api/stripe/webhook")
+      .set("Content-Type", "application/json")
+      .set("stripe-signature", header)
+      .send(payload);
+  }
+
+  /** Build a minimal Stripe event envelope. */
+  function makeEvent(type: string, data: object) {
+    return {
+      id:          `evt_inttest_${type.replace(/\./g, "_")}_${Date.now()}`,
+      object:      "event",
+      type,
+      data:        { object: data },
+      created:     Math.floor(Date.now() / 1000),
+      livemode:    false,
+      api_version: "2024-04-10",
+    };
+  }
+
+  // ── checkout session ─────────────────────────────────────────────────────────
+
+  it("creates a Pro Monthly checkout session with icp_principal metadata", async () => {
+    if (!PRICE_PRO_MONTHLY) {
+      console.warn("[stripe.subscription.integration] STRIPE_PRICE_PRO_MONTHLY not set — skipping");
+      return;
+    }
+    const session = await stripe.checkout.sessions.create({
+      mode: "subscription",
+      line_items: [{ price: PRICE_PRO_MONTHLY, quantity: 1 }],
+      success_url: "http://localhost:5173/payment-success",
+      cancel_url:  "http://localhost:5173/payment-failure",
+      metadata: {
+        icp_principal: "lifecycle-integration-test",
+        tier:          "Pro",
+        billing:       "Monthly",
+        is_gift:       "false",
+      },
+    });
+    expect(session.id).toMatch(/^cs_test_/);
+    expect(session.metadata?.tier).toBe("Pro");
+    expect(session.metadata?.icp_principal).toBe("lifecycle-integration-test");
+  }, 15_000);
+
+  // ── customer.subscription.deleted ────────────────────────────────────────────
+
+  it("customer.subscription.deleted → 200 { received: true }", async () => {
+    const event = makeEvent("customer.subscription.deleted", {
+      id:       "sub_inttest_deleted",
+      object:   "subscription",
+      status:   "canceled",
+      metadata: { icp_principal: "lifecycle-test-delete", tier: "Pro", billing: "Monthly" },
+    });
+    const res = await sendWebhookEvent(event);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ received: true });
+  }, 15_000);
+
+  // ── customer.subscription.updated — cancel_at_period_end ─────────────────────
+
+  it("customer.subscription.updated (cancel_at_period_end=true) → 200", async () => {
+    const event = makeEvent("customer.subscription.updated", {
+      id:                  "sub_inttest_updated",
+      object:              "subscription",
+      status:              "active",
+      cancel_at_period_end: true,
+      metadata:            { icp_principal: "lifecycle-test-downgrade", tier: "Pro" },
+    });
+    const res = await sendWebhookEvent(event);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ received: true });
+  }, 15_000);
+
+  // ── customer.subscription.updated — status=canceled ──────────────────────────
+
+  it("customer.subscription.updated (status=canceled) → 200", async () => {
+    const event = makeEvent("customer.subscription.updated", {
+      id:                  "sub_inttest_canceled",
+      object:              "subscription",
+      status:              "canceled",
+      cancel_at_period_end: false,
+      metadata:            { icp_principal: "lifecycle-test-cancel", tier: "Premium" },
+    });
+    const res = await sendWebhookEvent(event);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ received: true });
+  }, 15_000);
+
+  // ── invoice.payment_failed ────────────────────────────────────────────────────
+
+  it("invoice.payment_failed → 200, reverts tier to Free", async () => {
+    const event = makeEvent("invoice.payment_failed", {
+      id:       "in_inttest_fail",
+      object:   "invoice",
+      status:   "open",
+      metadata: { icp_principal: "lifecycle-test-fail" },
+    });
+    const res = await sendWebhookEvent(event);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ received: true });
+  }, 15_000);
+
+  // ── invoice.payment_succeeded ─────────────────────────────────────────────────
+
+  it("invoice.payment_succeeded → 200, activates Pro tier", async () => {
+    const event = makeEvent("invoice.payment_succeeded", {
+      id:       "in_inttest_ok",
+      object:   "invoice",
+      status:   "paid",
+      metadata: { icp_principal: "lifecycle-test-ok", tier: "Pro", billing: "Monthly" },
+    });
+    const res = await sendWebhookEvent(event);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ received: true });
+  }, 15_000);
+
+  // ── spoofed webhook ───────────────────────────────────────────────────────────
+
+  it("rejects a webhook signed with the wrong secret → 400", async () => {
+    const payload     = JSON.stringify(makeEvent("customer.subscription.deleted", {}));
+    const wrongHeader = stripe.webhooks.generateTestHeaderString({
+      payload,
+      secret: "whsec_spoofed_wrong_secret_00000000000",
+    });
+    const res = await supertest(app)
+      .post("/api/stripe/webhook")
+      .set("Content-Type", "application/json")
+      .set("stripe-signature", wrongHeader)
+      .send(payload);
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/signature/i);
+  }, 15_000);
+
+  // ── no stripe-signature header ────────────────────────────────────────────────
+
+  it("rejects a request with no stripe-signature header → 400", async () => {
+    const payload = JSON.stringify(makeEvent("ping", {}));
+    const res = await supertest(app)
+      .post("/api/stripe/webhook")
+      .set("Content-Type", "application/json")
+      .send(payload);
+    expect(res.status).toBe(400);
+  }, 15_000);
+});

--- a/agents/voice/__tests__/stripe.webhook.test.ts
+++ b/agents/voice/__tests__/stripe.webhook.test.ts
@@ -1,0 +1,353 @@
+/**
+ * Stripe Webhook endpoint tests (#143)
+ *
+ * WEBHOOK.1  POST /api/stripe/webhook — route is registered in server.ts (source)
+ * WEBHOOK.2  POST /api/stripe/webhook — uses express.raw body parser (source)
+ * WEBHOOK.3  POST /api/stripe/webhook — STRIPE_WEBHOOK_SECRET not configured → 500
+ * WEBHOOK.4  POST /api/stripe/webhook — missing stripe-signature header → 400
+ * WEBHOOK.5  POST /api/stripe/webhook — invalid stripe-signature (wrong secret) → 400
+ * WEBHOOK.6  POST /api/stripe/webhook — valid signature, unhandled event type → 200 { received: true }
+ * WEBHOOK.7  POST /api/stripe/webhook — customer.subscription.deleted → 200, reverts to Free
+ * WEBHOOK.8  POST /api/stripe/webhook — subscription.deleted with no principal → 200, no dfx call
+ * WEBHOOK.9  POST /api/stripe/webhook — invoice.payment_failed → 200, reverts to Free
+ * WEBHOOK.10 POST /api/stripe/webhook — invoice.payment_succeeded → 200, activates tier
+ * WEBHOOK.11 POST /api/stripe/webhook — replayed timestamp (> 300 s old) → 400
+ * WEBHOOK.12 webhook route bypasses VOICE_AGENT_API_KEY auth (source)
+ *
+ * No real Stripe API calls — uses stripe.webhooks.generateTestHeaderString with a
+ * fixed test secret. child_process is mocked so no dfx binary is needed.
+ */
+
+// jest.mock calls are hoisted above all imports by babel-jest.
+jest.mock("../anthropicProvider", () => ({
+  createAnthropicProvider: jest.fn().mockReturnValue({
+    stream: jest.fn(),
+    complete: jest.fn(),
+    completeWithTools: jest.fn(),
+  }),
+}));
+jest.mock("../prompts", () => ({
+  buildSystemPrompt: jest.fn().mockReturnValue("test"),
+}));
+jest.mock("../../maintenance/prompts", () => ({
+  buildMaintenanceSystemPrompt: jest.fn().mockReturnValue("test"),
+}));
+
+// Mock exec so dfx CLI calls inside activateInCanister / revertPrincipalToFree succeed.
+// util.promisify wraps the callback-style exec, so the mock must accept (cmd, callback).
+jest.mock("child_process", () => ({
+  exec: jest.fn((_cmd: string, cb: (err: null, result: { stdout: string; stderr: string }) => void) => {
+    cb(null, { stdout: "(ok)", stderr: "" });
+  }),
+}));
+
+import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
+import supertest from "supertest";
+import Stripe from "stripe";
+import { exec } from "child_process";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+import { app } from "../server";
+
+const mockExec = exec as jest.Mock;
+
+const SERVER_PATH = resolve(__dirname, "../server.ts");
+const src = readFileSync(SERVER_PATH, "utf8");
+
+// Fixed test secret — never used for real Stripe calls.
+const WEBHOOK_SECRET = "whsec_test_01234567890abcdef01234567890abcdef";
+// Stripe instance used only for generateTestHeaderString (no API calls made).
+const stripeHelper = new Stripe("sk_test_placeholder_for_test_header_generation_only");
+
+/** Sign a JSON payload string with the given webhook secret. */
+function sign(payload: string, secret = WEBHOOK_SECRET): string {
+  return stripeHelper.webhooks.generateTestHeaderString({ payload, secret });
+}
+
+/** Build a minimal Stripe event envelope. */
+function makeEvent(type: string, data: object): string {
+  return JSON.stringify({
+    id:          `evt_test_${type.replace(/\./g, "_")}`,
+    object:      "event",
+    type,
+    data:        { object: data },
+    created:     Math.floor(Date.now() / 1000),
+    livemode:    false,
+    api_version: "2024-04-10",
+  });
+}
+
+// ── WEBHOOK.1 — route registration (source) ───────────────────────────────────
+
+describe("WEBHOOK.1 — route registration", () => {
+  it("registers POST /api/stripe/webhook in server.ts", () => {
+    expect(src).toMatch(/app\.post\(\s*["'`]\/api\/stripe\/webhook["'`]/);
+  });
+});
+
+// ── WEBHOOK.2 — raw body parser (source) ──────────────────────────────────────
+
+describe("WEBHOOK.2 — raw body parser", () => {
+  it("calls express.raw() for the webhook path", () => {
+    expect(src).toMatch(/express\.raw\s*\(/);
+  });
+
+  it("guards the raw parser behind a stripe/webhook path check", () => {
+    // The raw parser must be conditional on the webhook path
+    const bodyParserBlock = src.slice(
+      src.indexOf("app.use((req, res, next) => {"),
+      src.indexOf("app.use(\"/api/\", apiLimiter)"),
+    );
+    expect(bodyParserBlock).toMatch(/stripe\/webhook/);
+    expect(bodyParserBlock).toMatch(/express\.raw/);
+  });
+});
+
+// ── WEBHOOK.12 — webhook bypasses API key auth (source) ───────────────────────
+
+describe("WEBHOOK.12 — webhook bypasses VOICE_AGENT_API_KEY auth", () => {
+  it("skips API key check for stripe/webhook path", () => {
+    // The API key middleware must have an early-return for the webhook path
+    const authMiddlewareBlock = src.slice(
+      src.indexOf("§49 — API key auth middleware"),
+      src.indexOf("// ── Structured request logging"),
+    );
+    expect(authMiddlewareBlock).toMatch(/stripe\/webhook/);
+  });
+});
+
+// ── WEBHOOK.3 — fail-closed when secret is not configured ────────────────────
+
+describe("WEBHOOK.3 — STRIPE_WEBHOOK_SECRET guard", () => {
+  let saved: string | undefined;
+  beforeEach(() => { saved = process.env.STRIPE_WEBHOOK_SECRET; delete process.env.STRIPE_WEBHOOK_SECRET; });
+  afterEach(() => { saved !== undefined ? (process.env.STRIPE_WEBHOOK_SECRET = saved) : delete process.env.STRIPE_WEBHOOK_SECRET; });
+
+  it("returns 500 when STRIPE_WEBHOOK_SECRET is not set", async () => {
+    const payload = makeEvent("ping", {});
+    const res = await supertest(app)
+      .post("/api/stripe/webhook")
+      .set("Content-Type", "application/json")
+      .send(payload);
+    expect(res.status).toBe(500);
+    expect(res.body.error).toMatch(/STRIPE_WEBHOOK_SECRET/);
+  });
+});
+
+// ── WEBHOOK.4 — missing stripe-signature ──────────────────────────────────────
+
+describe("WEBHOOK.4 — missing stripe-signature header", () => {
+  beforeEach(() => { process.env.STRIPE_WEBHOOK_SECRET = WEBHOOK_SECRET; });
+  afterEach(() => { delete process.env.STRIPE_WEBHOOK_SECRET; });
+
+  it("returns 400 when stripe-signature header is absent", async () => {
+    const payload = makeEvent("ping", {});
+    const res = await supertest(app)
+      .post("/api/stripe/webhook")
+      .set("Content-Type", "application/json")
+      .send(payload);
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/stripe-signature/i);
+  });
+});
+
+// ── WEBHOOK.5 — invalid stripe-signature ──────────────────────────────────────
+
+describe("WEBHOOK.5 — invalid stripe-signature", () => {
+  beforeEach(() => { process.env.STRIPE_WEBHOOK_SECRET = WEBHOOK_SECRET; });
+  afterEach(() => { delete process.env.STRIPE_WEBHOOK_SECRET; });
+
+  it("returns 400 when signature is signed with the wrong secret", async () => {
+    const payload     = makeEvent("ping", {});
+    const wrongHeader = sign(payload, "whsec_totally_wrong_secret_xxxxxxxxxxx");
+    const res = await supertest(app)
+      .post("/api/stripe/webhook")
+      .set("Content-Type", "application/json")
+      .set("stripe-signature", wrongHeader)
+      .send(payload);
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/signature/i);
+  });
+});
+
+// ── WEBHOOK.6 — unhandled event type ─────────────────────────────────────────
+
+describe("WEBHOOK.6 — valid signature, unhandled event type", () => {
+  beforeEach(() => { process.env.STRIPE_WEBHOOK_SECRET = WEBHOOK_SECRET; });
+  afterEach(() => { delete process.env.STRIPE_WEBHOOK_SECRET; });
+
+  it("returns 200 { received: true } for event types we do not act on", async () => {
+    const payload = makeEvent("product.created", { id: "prod_test" });
+    const header  = sign(payload);
+    const res = await supertest(app)
+      .post("/api/stripe/webhook")
+      .set("Content-Type", "application/json")
+      .set("stripe-signature", header)
+      .send(payload);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ received: true });
+  });
+});
+
+// ── WEBHOOK.7 — customer.subscription.deleted (with principal) ────────────────
+
+describe("WEBHOOK.7 — customer.subscription.deleted", () => {
+  beforeEach(() => {
+    process.env.STRIPE_WEBHOOK_SECRET = WEBHOOK_SECRET;
+    mockExec.mockClear();
+  });
+  afterEach(() => { delete process.env.STRIPE_WEBHOOK_SECRET; });
+
+  it("returns 200 and calls dfx to revert principal to Free", async () => {
+    const sub = {
+      id: "sub_test123", object: "subscription", status: "canceled",
+      metadata: { icp_principal: "test-user-001" },
+    };
+    const payload = makeEvent("customer.subscription.deleted", sub);
+    const header  = sign(payload);
+
+    const res = await supertest(app)
+      .post("/api/stripe/webhook")
+      .set("Content-Type", "application/json")
+      .set("stripe-signature", header)
+      .send(payload);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ received: true });
+    expect(mockExec).toHaveBeenCalled();
+    const cmd = mockExec.mock.calls[0][0] as string;
+    expect(cmd).toContain("adminActivateStripeSubscription");
+    expect(cmd).toContain("Free");
+    expect(cmd).toContain("test-user-001");
+  });
+});
+
+// ── WEBHOOK.8 — customer.subscription.deleted (no principal) ─────────────────
+
+describe("WEBHOOK.8 — subscription.deleted with no principal", () => {
+  beforeEach(() => {
+    process.env.STRIPE_WEBHOOK_SECRET = WEBHOOK_SECRET;
+    mockExec.mockClear();
+  });
+  afterEach(() => { delete process.env.STRIPE_WEBHOOK_SECRET; });
+
+  it("returns 200 and makes no dfx call when principal is absent", async () => {
+    const sub = { id: "sub_noprincipal", object: "subscription", status: "canceled", metadata: {} };
+    const payload = makeEvent("customer.subscription.deleted", sub);
+    const header  = sign(payload);
+
+    const res = await supertest(app)
+      .post("/api/stripe/webhook")
+      .set("Content-Type", "application/json")
+      .set("stripe-signature", header)
+      .send(payload);
+
+    expect(res.status).toBe(200);
+    expect(mockExec).not.toHaveBeenCalled();
+  });
+});
+
+// ── WEBHOOK.9 — invoice.payment_failed ───────────────────────────────────────
+
+describe("WEBHOOK.9 — invoice.payment_failed", () => {
+  beforeEach(() => {
+    process.env.STRIPE_WEBHOOK_SECRET = WEBHOOK_SECRET;
+    mockExec.mockClear();
+  });
+  afterEach(() => { delete process.env.STRIPE_WEBHOOK_SECRET; });
+
+  it("returns 200 and reverts to Free on payment failure", async () => {
+    const invoice = {
+      id: "in_test_fail", object: "invoice", status: "open",
+      metadata: { icp_principal: "test-user-002" },
+    };
+    const payload = makeEvent("invoice.payment_failed", invoice);
+    const header  = sign(payload);
+
+    const res = await supertest(app)
+      .post("/api/stripe/webhook")
+      .set("Content-Type", "application/json")
+      .set("stripe-signature", header)
+      .send(payload);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ received: true });
+    expect(mockExec).toHaveBeenCalled();
+    const cmd = mockExec.mock.calls[0][0] as string;
+    expect(cmd).toContain("Free");
+    expect(cmd).toContain("test-user-002");
+  });
+});
+
+// ── WEBHOOK.10 — invoice.payment_succeeded ───────────────────────────────────
+
+describe("WEBHOOK.10 — invoice.payment_succeeded", () => {
+  beforeEach(() => {
+    process.env.STRIPE_WEBHOOK_SECRET = WEBHOOK_SECRET;
+    mockExec.mockClear();
+  });
+  afterEach(() => { delete process.env.STRIPE_WEBHOOK_SECRET; });
+
+  it("returns 200 and activates the Pro tier on payment success", async () => {
+    const invoice = {
+      id: "in_test_ok", object: "invoice", status: "paid",
+      metadata: { icp_principal: "test-user-003", tier: "Pro", billing: "Monthly" },
+    };
+    const payload = makeEvent("invoice.payment_succeeded", invoice);
+    const header  = sign(payload);
+
+    const res = await supertest(app)
+      .post("/api/stripe/webhook")
+      .set("Content-Type", "application/json")
+      .set("stripe-signature", header)
+      .send(payload);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ received: true });
+    expect(mockExec).toHaveBeenCalled();
+    const cmd = mockExec.mock.calls[0][0] as string;
+    expect(cmd).toContain("adminActivateStripeSubscription");
+    expect(cmd).toContain("Pro");
+    expect(cmd).toContain("test-user-003");
+  });
+
+  it("uses 12 months for Yearly billing", async () => {
+    const invoice = {
+      id: "in_test_yearly", object: "invoice", status: "paid",
+      metadata: { icp_principal: "test-user-004", tier: "Premium", billing: "Yearly" },
+    };
+    const payload = makeEvent("invoice.payment_succeeded", invoice);
+    const header  = sign(payload);
+    mockExec.mockClear();
+
+    await supertest(app)
+      .post("/api/stripe/webhook")
+      .set("Content-Type", "application/json")
+      .set("stripe-signature", header)
+      .send(payload);
+
+    const cmd = mockExec.mock.calls[0][0] as string;
+    expect(cmd).toContain("12");  // 12 months for Yearly
+  });
+});
+
+// ── WEBHOOK.11 — replayed / old timestamp ─────────────────────────────────────
+
+describe("WEBHOOK.11 — replayed signature (timestamp outside tolerance)", () => {
+  beforeEach(() => { process.env.STRIPE_WEBHOOK_SECRET = WEBHOOK_SECRET; });
+  afterEach(() => { delete process.env.STRIPE_WEBHOOK_SECRET; });
+
+  it("returns 400 when the Stripe timestamp is more than 5 minutes old", async () => {
+    const payload  = makeEvent("ping", {});
+    const oldTs    = Math.floor(Date.now() / 1000) - 400; // 400 s ago — outside 300 s tolerance
+    const oldHeader = stripeHelper.webhooks.generateTestHeaderString({
+      payload, secret: WEBHOOK_SECRET, timestamp: oldTs,
+    });
+    const res = await supertest(app)
+      .post("/api/stripe/webhook")
+      .set("Content-Type", "application/json")
+      .set("stripe-signature", oldHeader)
+      .send(payload);
+    expect(res.status).toBe(400);
+  });
+});

--- a/agents/voice/server.ts
+++ b/agents/voice/server.ts
@@ -64,7 +64,11 @@ app.use(cors({ origin }));
 // 50 kb default — sufficient for all text payloads; prevents DoS on every route.
 // /api/classify gets its own 5 mb parser (base64 image payloads) registered below.
 app.use((req, res, next) => {
-  if (req.path === "/api/classify") {
+  if (req.path === "/api/stripe/webhook") {
+    // Stripe signature verification requires the raw request body — do NOT parse as JSON.
+    // Use type:"*/*" so the raw parser captures any Content-Type (Stripe sends application/json).
+    express.raw({ type: "*/*" })(req, res, next);
+  } else if (req.path === "/api/classify") {
     express.json({ limit: "5mb" })(req, res, next);
   } else {
     express.json({ limit: "50kb" })(req, res, next);
@@ -88,6 +92,8 @@ app.use("/api/", apiLimiter);
 // Skipped in dev when VOICE_AGENT_API_KEY is not set.
 app.use("/api/", (req: Request, res: Response, next: express.NextFunction): void => {
   if (!VOICE_API_KEY) { next(); return; }
+  // Stripe webhooks are authenticated via HMAC signature, not the API key header.
+  if (req.originalUrl.startsWith("/api/stripe/webhook")) { next(); return; }
   const provided = req.headers["x-api-key"];
   if (provided !== VOICE_API_KEY) {
     res.status(401).json({ error: "Unauthorized" });
@@ -1075,6 +1081,14 @@ async function activateInCanister(principal: string, tier: string, months: numbe
   }
 }
 
+/**
+ * Revert a user's subscription tier to Free in the payment canister.
+ * Called by the webhook handler on subscription cancellation or payment failure.
+ */
+async function revertPrincipalToFree(principal: string): Promise<void> {
+  await activateInCanister(principal, "Free", 0);
+}
+
 // ── Credit top-up helpers (#89) ───────────────────────────────────────────────
 
 /** Valid top-up pack sizes and their Stripe price-ID env vars. */
@@ -1351,6 +1365,118 @@ app.post("/api/buyers-truth-kit", async (req: Request, res: Response): Promise<v
   } catch (err) {
     res.status(500).json({ error: err instanceof Error ? err.message : "Analysis failed" });
   }
+});
+
+// ── POST /api/stripe/webhook ──────────────────────────────────────────────────
+// Handles Stripe subscription lifecycle events (#143).
+// Raw body required for HMAC signature verification — see body-parser middleware above.
+// Signature verified via STRIPE_WEBHOOK_SECRET (fail-closed: returns 500 if not set).
+//
+// Handled events:
+//   customer.subscription.deleted  → revert principal to Free
+//   customer.subscription.updated  → revert if cancelled (cancel_at_period_end) or status=canceled
+//   invoice.payment_failed         → revert principal to Free
+//   invoice.payment_succeeded      → activate tier in canister
+app.post("/api/stripe/webhook", async (req: Request, res: Response) => {
+  const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET;
+  if (!webhookSecret) {
+    res.status(500).json({ error: "STRIPE_WEBHOOK_SECRET not configured" });
+    return;
+  }
+
+  const sig = req.headers["stripe-signature"];
+  if (!sig) {
+    res.status(400).json({ error: "Missing stripe-signature header" });
+    return;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let event: any;
+  try {
+    const Stripe = (await import("stripe")).default;
+    // constructEvent is synchronous and doesn't call the Stripe API —
+    // the secret key is only needed to instantiate the SDK.
+    const stripe = new Stripe(process.env.STRIPE_SECRET_KEY ?? "placeholder_webhook_key");
+    event = stripe.webhooks.constructEvent(req.body as Buffer, sig as string, webhookSecret);
+  } catch (err) {
+    res.status(400).json({ error: `Webhook signature verification failed: ${(err as Error).message}` });
+    return;
+  }
+
+  try {
+    switch (event.type) {
+      case "customer.subscription.deleted": {
+        const sub       = event.data.object;
+        const principal = (sub.metadata?.icp_principal ?? "") as string;
+        if (principal) {
+          try { await revertPrincipalToFree(principal); }
+          catch (e) { console.warn(`[stripe-webhook] revert failed: ${(e as Error).message}`); }
+        }
+        break;
+      }
+      case "customer.subscription.updated": {
+        const sub       = event.data.object;
+        const status    = (sub.status ?? "") as string;
+        const cancelled = status === "canceled" || sub.cancel_at_period_end === true;
+        if (cancelled) {
+          const principal = (sub.metadata?.icp_principal ?? "") as string;
+          if (principal) {
+            try { await revertPrincipalToFree(principal); }
+            catch (e) { console.warn(`[stripe-webhook] revert failed: ${(e as Error).message}`); }
+          }
+        }
+        break;
+      }
+      case "invoice.payment_failed": {
+        const invoice   = event.data.object;
+        // Try subscription_details.metadata (newer Stripe API) then invoice.metadata
+        const principal = (
+          invoice.subscription_details?.metadata?.icp_principal ??
+          invoice.metadata?.icp_principal ??
+          ""
+        ) as string;
+        if (principal) {
+          try { await revertPrincipalToFree(principal); }
+          catch (e) { console.warn(`[stripe-webhook] payment_failed revert: ${(e as Error).message}`); }
+        }
+        break;
+      }
+      case "invoice.payment_succeeded": {
+        const invoice   = event.data.object;
+        const principal = (
+          invoice.subscription_details?.metadata?.icp_principal ??
+          invoice.metadata?.icp_principal ??
+          ""
+        ) as string;
+        const tier    = (
+          invoice.subscription_details?.metadata?.tier ??
+          invoice.metadata?.tier ??
+          ""
+        ) as string;
+        const billing = (
+          invoice.subscription_details?.metadata?.billing ??
+          invoice.metadata?.billing ??
+          "Monthly"
+        ) as string;
+        const months  = billing === "Yearly" ? 12 : 1;
+        if (principal && tier) {
+          try { await activateInCanister(principal, tier, months); }
+          catch (e) { console.warn(`[stripe-webhook] activate failed: ${(e as Error).message}`); }
+        }
+        break;
+      }
+      default:
+        process.stdout.write(JSON.stringify({
+          ts: new Date().toISOString(), event: "stripe_webhook_unhandled", type: event.type,
+        }) + "\n");
+    }
+  } catch (err) {
+    console.error(`[stripe-webhook] handler error: ${(err as Error).message}`);
+    res.status(500).json({ error: "Internal webhook handler error" });
+    return;
+  }
+
+  res.json({ received: true });
 });
 
 // ── GET /health ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
…le tests (#143)

- POST /api/stripe/webhook: raw body parser (type:*/*) for HMAC signature verification via STRIPE_WEBHOOK_SECRET; bypasses VOICE_AGENT_API_KEY auth
- Handles customer.subscription.deleted/updated, invoice.payment_failed/succeeded: revert to Free tier or activate tier in payment canister via dfx CLI
- revertPrincipalToFree() helper delegates to activateInCanister with tier=Free
- stripe.webhook.test.ts: 14 unit tests (WEBHOOK.1–12) covering signature rejection, valid events, dfx call verification — no Stripe credentials needed
- stripe.subscription.integration.test.ts: full lifecycle tests (checkout, cancellation, failed payment, spoofed webhook) skipped when STRIPE keys absent
- .env.example: adds STRIPE_WEBHOOK_SECRET placeholder

## Summary
<!-- What does this PR do? -->

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [ ] Backend tests pass (`make test`)
- [ ] Frontend builds (`cd frontend && npm run build`)
- [ ] Tested locally with dfx

## Checklist
- [ ] Code follows project conventions
- [ ] Self-review completed
- [ ] No sensitive data committed
