### PR TITLE
feat(observability): add lightweight client-side error tracker

### DIFF
--- a/agents/voice/server.ts
+++ b/agents/voice/server.ts
@@ -788,23 +788,57 @@ Rules:
 });
 
 // ── POST /api/errors ─────────────────────────────────────────────────────────
-// Frontend ErrorBoundary reports caught render errors here (production only).
-// The structured logging middleware above records them as JSON lines — no extra
-// storage needed. Endpoint always returns 204 so the fire-and-forget client
-// doesn't need to parse a response body.
+// Receives structured error reports from the frontend errorTracker.
+// Enriched payload: level, errorType, stack, componentStack, breadcrumbs,
+// tier, release, userAgent, tags — all sanitised and length-bounded before logging.
+// Falls back gracefully to the legacy { message, componentStack, url, ts } shape
+// so old clients keep working. Always returns 204.
 app.post("/api/errors", (req: Request, res: Response): void => {
-  // Body is already captured by the logging middleware on "finish".
-  // Log it immediately at warn level so it stands out from regular request logs.
-  const { message, componentStack, url, ts } = req.body ?? {};
+  const b = req.body ?? {};
+
+  // Accept enriched payload (errorTracker) or legacy (old ErrorBoundary) shape.
+  const level         = typeof b.level === "string" ? b.level.slice(0, 20) : "error";
+  const message       = typeof b.message === "string" ? b.message.slice(0, 500) : "(no message)";
+  const errorType     = typeof b.errorType === "string" ? b.errorType.slice(0, 80) : undefined;
+  const stack         = typeof b.stack === "string" ? b.stack.slice(0, 3000) : undefined;
+  const componentStack = typeof b.componentStack === "string" ? b.componentStack.slice(0, 2000) : undefined;
+  const url           = typeof b.url === "string" ? b.url.slice(0, 500) : undefined;
+  const ts            = typeof b.ts === "string" ? b.ts : new Date().toISOString();
+  const tier          = typeof b.tier === "string" ? b.tier.slice(0, 40) : undefined;
+  const release       = typeof b.release === "string" ? b.release.slice(0, 50) : undefined;
+  const userAgent     = typeof b.userAgent === "string" ? b.userAgent.slice(0, 200) : undefined;
+  const tags          = b.tags && typeof b.tags === "object" && !Array.isArray(b.tags)
+    ? b.tags as Record<string, string>
+    : undefined;
+
+  // Sanitise breadcrumbs — cap count and individual field lengths.
+  type RawCrumb = { type?: unknown; message?: unknown; data?: unknown; ts?: unknown };
+  const breadcrumbs = Array.isArray(b.breadcrumbs)
+    ? (b.breadcrumbs as RawCrumb[]).slice(0, 25).map((c) => ({
+        type:    typeof c?.type    === "string" ? c.type.slice(0, 20) : "custom",
+        message: typeof c?.message === "string" ? c.message.slice(0, 200) : "",
+        data:    c?.data && typeof c.data === "object" && !Array.isArray(c.data) ? c.data : undefined,
+        ts:      typeof c?.ts === "number" ? c.ts : undefined,
+      }))
+    : undefined;
+
   process.stdout.write(JSON.stringify({
-    level:          "warn",
-    event:          "frontend_error",
-    message:        typeof message === "string"        ? message.slice(0, 500)  : "(no message)",
-    componentStack: typeof componentStack === "string" ? componentStack.slice(0, 2000) : null,
-    url:            typeof url === "string"            ? url.slice(0, 500)      : null,
-    ts:             typeof ts === "string"             ? ts                     : new Date().toISOString(),
-    principal:      (req.headers["x-icp-principal"] as string | undefined) ?? "anon",
+    event:      "frontend_error",
+    level,
+    message,
+    ...(errorType      && { errorType }),
+    ...(stack          && { stack }),
+    ...(componentStack && { componentStack }),
+    ...(url            && { url }),
+    ts,
+    principal:  (req.headers["x-icp-principal"] as string | undefined) ?? "anon",
+    ...(tier       && { tier }),
+    ...(release    && { release }),
+    ...(userAgent  && { userAgent }),
+    ...(breadcrumbs && { breadcrumbs }),
+    ...(tags       && { tags }),
   }) + "\n");
+
   res.sendStatus(204);
 });
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,9 +1,19 @@
-import React, { Suspense } from "react";
+import React, { Suspense, useEffect } from "react";
 import { Routes, Route, Navigate, useLocation } from "react-router-dom";
 import { Toaster } from "react-hot-toast";
 import { AuthProvider } from "@/contexts/AuthContext";
 import { useAuthStore } from "@/store/authStore";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
+import { errorTracker } from "@/services/errorTracker";
+
+/** Records route changes as navigation breadcrumbs in the error tracker. */
+function NavigationTracker() {
+  const location = useLocation();
+  useEffect(() => {
+    errorTracker.trackNavigation(location.pathname);
+  }, [location.pathname]);
+  return null;
+}
 
 // Critical path — kept static (first paint)
 import LandingPage           from "@/pages/LandingPage";
@@ -105,6 +115,7 @@ export default function App() {
             style: { borderRadius: 0, fontSize: "0.875rem", fontWeight: 500 },
           }}
         />
+        <NavigationTracker />
         <Suspense fallback={<PageLoader />}>
           <RouteErrorBoundary>
             <Routes>

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -12,7 +12,7 @@
 
 import React from "react";
 import { COLORS, FONTS, RADIUS } from "@/theme";
-import { reportFrontendError } from "@/services/errorReporting";
+import { errorTracker } from "@/services/errorTracker";
 
 interface Props {
   children: React.ReactNode;
@@ -50,7 +50,11 @@ export class ErrorBoundary extends React.Component<Props, State> {
   componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
     this.setState({ errorInfo });
     console.error("[ErrorBoundary]", error, errorInfo.componentStack);
-    reportFrontendError(error, errorInfo.componentStack ?? null);
+    errorTracker.captureError(error, {
+      level:          this.props.global ? "fatal" : "error",
+      componentStack: errorInfo.componentStack ?? undefined,
+      source:         this.props.global ? "ErrorBoundary.global" : "ErrorBoundary.route",
+    });
   }
 
   handleReset = () => {

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -4,6 +4,22 @@ import { BrowserRouter } from "react-router-dom";
 import { HelmetProvider } from "react-helmet-async";
 import App from "./App";
 import "./index.css";
+import { errorTracker } from "@/services/errorTracker";
+import { useAuthStore } from "@/store/authStore";
+
+// Install global error handlers (unhandledrejection, window.onerror,
+// click/console breadcrumb capture). Idempotent — safe to call multiple times.
+errorTracker.init();
+
+// Keep error-report context in sync with auth state changes.
+// Runs outside React so every captured error carries the right principal/tier
+// regardless of where in the component tree it originates.
+useAuthStore.subscribe((state) => {
+  errorTracker.setContext({
+    principal: state.principal  ?? undefined,
+    tier:      state.tier       ?? undefined,
+  });
+});
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>

--- a/frontend/src/services/errorReporting.ts
+++ b/frontend/src/services/errorReporting.ts
@@ -1,54 +1,19 @@
 /**
- * errorReporting — sends frontend error events to the voice agent relay for
- * structured logging and monitoring.
+ * errorReporting — thin shim kept for backward compatibility.
  *
- * Fire-and-forget: network failures are silently swallowed so the reporting
- * call never interferes with the user's recovery flow.
- *
- * Only active in production (import.meta.env.PROD). In dev the error is
- * already visible in the console via ErrorBoundary.
+ * All logic now lives in errorTracker. ErrorBoundary and any other callers
+ * that still reference reportFrontendError() are redirected here.
  */
 
-const AGENT_URL =
-  typeof import.meta !== "undefined"
-    ? (import.meta.env?.VITE_VOICE_AGENT_URL ?? "http://localhost:3001")
-    : "http://localhost:3001";
+import { errorTracker } from "./errorTracker";
 
-export interface FrontendError {
-  message:        string;
-  componentStack: string | null;
-  url:            string;
-  ts:             string;
-}
-
-/**
- * Report a caught render error to the voice agent relay.
- * Must never throw — call sites do not wrap this in try/catch.
- */
 export async function reportFrontendError(
   error: Error,
   componentStack: string | null,
 ): Promise<void> {
-  if (!import.meta.env.PROD) return;
-
-  const payload: FrontendError = {
-    message:        error.message,
-    componentStack: componentStack ?? null,
-    url:            window.location.href,
-    ts:             new Date().toISOString(),
-  };
-
-  try {
-    const { voiceAgentHeaders } = await import("./voiceAgentHeaders");
-    await fetch(`${AGENT_URL}/api/errors`, {
-      method:  "POST",
-      headers: voiceAgentHeaders(),
-      body:    JSON.stringify(payload),
-      signal:  AbortSignal.timeout(4_000),
-      // keepalive so the request outlives a page unload
-      keepalive: true,
-    });
-  } catch {
-    // Intentionally silent — error reporting must never cause secondary errors.
-  }
+  errorTracker.captureError(error, {
+    level:          "error",
+    componentStack: componentStack ?? undefined,
+    source:         "ErrorBoundary",
+  });
 }

--- a/frontend/src/services/errorTracker.ts
+++ b/frontend/src/services/errorTracker.ts
@@ -1,0 +1,264 @@
+/**
+ * errorTracker — lightweight client-side error tracking (HomeGentic internal).
+ *
+ * Captures:
+ *   - React render errors (via ErrorBoundary calling captureError)
+ *   - Unhandled promise rejections (window "unhandledrejection" event)
+ *   - Uncaught synchronous exceptions (window "error" event)
+ *   - Click breadcrumbs (document-level capture, excludes form fields)
+ *   - Console breadcrumbs (console.error / console.warn → ring buffer)
+ *   - Navigation breadcrumbs (call trackNavigation on route changes)
+ *
+ * Every report is enriched with:
+ *   - Last ≤25 breadcrumbs so we know what the user was doing before the crash
+ *   - ICP principal and subscription tier (from authStore)
+ *   - Browser user-agent and current URL
+ *   - App release (VITE_APP_VERSION env var if set)
+ *
+ * Guardrails:
+ *   - Rate-limited to 25 errors per browser session (reset on reload)
+ *   - Identical errors are deduplicated within a 60-second window
+ *   - In development: logs to console.debug only — nothing is sent over the wire
+ *   - init() is idempotent — safe to call multiple times
+ */
+
+import { useAuthStore } from "@/store/authStore";
+
+const AGENT_URL = (import.meta as any).env?.VITE_VOICE_AGENT_URL ?? "http://localhost:3001";
+const RELEASE   = (import.meta as any).env?.VITE_APP_VERSION as string | undefined;
+
+const MAX_BREADCRUMBS  = 25;
+const MAX_ERRORS       = 25;   // per session (prevents runaway reporting)
+const DEDUP_WINDOW_MS  = 60_000;
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export type BreadcrumbType = "navigation" | "click" | "console" | "custom";
+export type ErrorLevel     = "debug" | "info" | "warning" | "error" | "fatal";
+
+export interface Breadcrumb {
+  type:    BreadcrumbType;
+  message: string;
+  data?:   Record<string, unknown>;
+  ts:      number; // unix ms
+}
+
+interface TrackerContext {
+  principal?: string;
+  tier?:      string;
+}
+
+export interface ErrorReport {
+  level:           ErrorLevel;
+  message:         string;
+  errorType?:      string;
+  stack?:          string;
+  componentStack?: string;
+  url:             string;
+  ts:              string;
+  principal:       string;
+  tier?:           string;
+  release?:        string;
+  userAgent:       string;
+  breadcrumbs:     Breadcrumb[];
+  tags?:           Record<string, string>;
+}
+
+// ── Tracker ───────────────────────────────────────────────────────────────────
+
+class ErrorTracker {
+  private breadcrumbs:   Breadcrumb[]         = [];
+  private context:       TrackerContext        = {};
+  private errorCount:    number                = 0;
+  private recentFprints: Map<string, number>   = new Map(); // fingerprint → last-sent ms
+  private initialized = false;
+
+  // ── public API ──────────────────────────────────────────────────────────────
+
+  /**
+   * Call once at app startup (main.tsx). Installs global handlers.
+   * Safe to call multiple times — subsequent calls are no-ops.
+   */
+  init(): void {
+    if (this.initialized) return;
+    this.initialized = true;
+    this._installGlobalHandlers();
+    this._installClickCapture();
+    this._installConsoleCapture();
+  }
+
+  /**
+   * Update the user context. Call whenever auth state changes so every
+   * subsequent error report is attributed to the right principal/tier.
+   */
+  setContext(ctx: Partial<TrackerContext>): void {
+    this.context = { ...this.context, ...ctx };
+  }
+
+  /**
+   * Append a breadcrumb to the ring buffer (capped at MAX_BREADCRUMBS).
+   * Use this for manual "user did X" annotations in business-critical paths.
+   */
+  addBreadcrumb(bc: Omit<Breadcrumb, "ts">): void {
+    this.breadcrumbs.push({ ...bc, ts: Date.now() });
+    if (this.breadcrumbs.length > MAX_BREADCRUMBS) this.breadcrumbs.shift();
+  }
+
+  /**
+   * Record a navigation event as a breadcrumb.
+   * Call from App.tsx whenever the React Router location changes.
+   */
+  trackNavigation(pathname: string): void {
+    this.addBreadcrumb({ type: "navigation", message: pathname });
+  }
+
+  /**
+   * Capture an error and ship it to /api/errors.
+   * Deduplication and rate-limiting are applied transparently.
+   * Never throws — safe to call anywhere, including inside catch blocks.
+   */
+  captureError(
+    error:   Error | string,
+    options: {
+      level?:          ErrorLevel;
+      componentStack?: string;
+      source?:         string;
+    } = {},
+  ): void {
+    try {
+      const { level = "error", componentStack, source } = options;
+      const message   = typeof error === "string" ? error : (error.message || String(error));
+      const stack     = typeof error === "string" ? undefined : error.stack;
+      const errorType = typeof error === "string" ? "Error" : (error.constructor?.name ?? "Error");
+
+      // ── rate limit ──────────────────────────────────────────────────────────
+      if (this.errorCount >= MAX_ERRORS) return;
+
+      // ── deduplication ───────────────────────────────────────────────────────
+      const fp       = this._fingerprint(message, stack);
+      const lastSent = this.recentFprints.get(fp) ?? 0;
+      if (Date.now() - lastSent < DEDUP_WINDOW_MS) return;
+      this.recentFprints.set(fp, Date.now());
+      this.errorCount++;
+
+      // ── dev: surface locally, don't send ────────────────────────────────────
+      if (!import.meta.env.PROD) {
+        console.debug(
+          `[errorTracker] ${level} (${source ?? "manual"}):`,
+          message,
+          componentStack ? "\n" + componentStack : "",
+        );
+        return;
+      }
+
+      // ── build report ────────────────────────────────────────────────────────
+      const report: ErrorReport = {
+        level,
+        message,
+        errorType,
+        stack,
+        componentStack,
+        url:         window.location.href,
+        ts:          new Date().toISOString(),
+        principal:   this.context.principal ?? useAuthStore.getState().principal ?? "anon",
+        tier:        this.context.tier ?? (useAuthStore.getState().tier ?? undefined),
+        release:     RELEASE,
+        userAgent:   navigator.userAgent,
+        breadcrumbs: [...this.breadcrumbs],
+        tags:        { source: source ?? "manual" },
+      };
+
+      void this._send(report);
+    } catch {
+      // The tracker must never crash the app.
+    }
+  }
+
+  // ── private ─────────────────────────────────────────────────────────────────
+
+  /** Fingerprint = trimmed message + first app-owned stack frame. */
+  private _fingerprint(message: string, stack?: string): string {
+    const ownFrame = stack?.split("\n").find((l) => l.includes("/src/")) ?? "";
+    return `${message.slice(0, 100)}::${ownFrame.trim().slice(0, 100)}`;
+  }
+
+  private _installGlobalHandlers(): void {
+    // Unhandled promise rejections — the most common silent failure mode.
+    window.addEventListener("unhandledrejection", (event) => {
+      const reason  = event.reason;
+      const asError = reason instanceof Error
+        ? reason
+        : new Error(String(reason ?? "Unhandled Promise Rejection"));
+      this.captureError(asError, { level: "error", source: "unhandledrejection" });
+    });
+
+    // Uncaught synchronous exceptions that escape React's boundary.
+    // Ignore resource-load errors (img/script onerror) which have event.error = null.
+    window.addEventListener("error", (event) => {
+      if (!event.error) return;
+      this.captureError(event.error as Error, { level: "fatal", source: "window.onerror" });
+    });
+  }
+
+  private _installClickCapture(): void {
+    document.addEventListener(
+      "click",
+      (event) => {
+        const target = event.target as HTMLElement | null;
+        if (!target) return;
+        const tag = target.tagName?.toLowerCase() ?? "";
+        // Skip form fields — never capture what the user typed.
+        if (tag === "input" || tag === "textarea" || tag === "select") return;
+        const id   = target.id ? `#${target.id}` : "";
+        const role = target.getAttribute?.("role") ?? "";
+        const text = target.textContent?.trim().replace(/\s+/g, " ").slice(0, 40) ?? "";
+        this.addBreadcrumb({
+          type:    "click",
+          message: `${tag}${id}${role ? `[role=${role}]` : ""}`,
+          data:    text ? { text } : undefined,
+        });
+      },
+      { passive: true, capture: true },
+    );
+  }
+
+  private _installConsoleCapture(): void {
+    // Intercept console.error / console.warn to record them as breadcrumbs.
+    // The originals are called first so DevTools output is unchanged.
+    const origError = console.error.bind(console);
+    const origWarn  = console.warn.bind(console);
+
+    console.error = (...args: unknown[]) => {
+      origError(...args);
+      const msg = args
+        .map((a) => typeof a === "string" ? a : a instanceof Error ? a.message : "")
+        .filter(Boolean).join(" ").slice(0, 120);
+      if (msg) this.addBreadcrumb({ type: "console", message: `[error] ${msg}`, data: { level: "error" } });
+    };
+
+    console.warn = (...args: unknown[]) => {
+      origWarn(...args);
+      const msg = args
+        .map((a) => typeof a === "string" ? a : "")
+        .filter(Boolean).join(" ").slice(0, 120);
+      if (msg) this.addBreadcrumb({ type: "console", message: `[warn] ${msg}`, data: { level: "warn" } });
+    };
+  }
+
+  private async _send(report: ErrorReport): Promise<void> {
+    try {
+      const { voiceAgentHeaders } = await import("./voiceAgentHeaders");
+      await fetch(`${AGENT_URL}/api/errors`, {
+        method:    "POST",
+        headers:   voiceAgentHeaders(),
+        body:      JSON.stringify(report),
+        signal:    AbortSignal.timeout(4_000),
+        keepalive: true,
+      });
+    } catch {
+      // Intentionally silent — error reporting must never cause secondary errors.
+    }
+  }
+}
+
+export const errorTracker = new ErrorTracker();


### PR DESCRIPTION
Closes the gap where only ErrorBoundary crashes were visible in production. Now captures the full failure surface and attaches user journey context.

errorTracker.ts (new service):
- Global unhandledrejection + window.onerror handlers — catches silent promise rejections and uncaught exceptions that bypass ErrorBoundary
- Breadcrumb ring buffer (25 entries): navigation, click, console, custom
- Console interception: console.error/warn calls appended as breadcrumbs so every [SomeHook] operation failed message appears in the crash trail
- Click capture via document-level listener (excludes input/textarea/select to avoid capturing sensitive form data)
- Error deduplication: same fingerprint suppressed for 60 s
- Session rate-limit: max 25 error reports per page load
- Silent in dev (console.debug only); sends to /api/errors in production only

main.tsx:
- errorTracker.init() at startup
- Zustand subscribe syncs principal + tier to tracker context automatically

App.tsx:
- NavigationTracker component records route changes as navigation breadcrumbs

ErrorBoundary.tsx:
- Uses tracker directly; tags errors as fatal (global boundary) or error (per-route boundary) so severity is visible in logs

errorReporting.ts:
- Kept as thin shim delegating to errorTracker (backward compat)

agents/voice/server.ts /api/errors:
- Accepts enriched payload: level, errorType, stack, breadcrumbs, tier, release, userAgent, tags — all sanitised and length-bounded
- Falls back gracefully to legacy { message, componentStack, url, ts } shape

## Summary
<!-- What does this PR do? -->

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [ ] Backend tests pass (`make test`)
- [ ] Frontend builds (`cd frontend && npm run build`)
- [ ] Tested locally with dfx

## Checklist
- [ ] Code follows project conventions
- [ ] Self-review completed
- [ ] No sensitive data committed
