### PR TITLE
feat(onboarding): add baseline photos step to onboarding wizard (#134)

### DIFF
--- a/frontend/src/__tests__/pages/OnboardingWizard.test.tsx
+++ b/frontend/src/__tests__/pages/OnboardingWizard.test.tsx
@@ -1,26 +1,28 @@
 /**
- * TDD — Issue #129 (take 2): Onboarding Wizard
+ * TDD — Issue #129 / #134: Onboarding Wizard
  *
  * Steps:
  *   1 — Property address
  *   2 — Property details (type, year built, sq ft)
- *   3 — Verify ownership  (legal name + ownership document — required)
- *   4 — Document import   (optional)
- *   5 — System ages       (optional, defaults to year built, + solar toggle)
+ *   3 — Capture baseline photos  (optional, NEW — issue #134)
+ *   4 — Verify ownership  (legal name + ownership document — required)
+ *   5 — Document import   (optional)
+ *   6 — System ages       (optional, defaults to year built, + solar toggle)
  *
  * Acceptance criteria:
- *   - Step indicator ("Step X of 5") visible throughout
- *   - No Back button on step 1; Back available on steps 2–5
+ *   - Step indicator ("Step X of 6") visible throughout
+ *   - No Back button on step 1; Back available on steps 2–6
  *   - Next advances; Back retreats
  *   - "Skip setup" link navigates to /dashboard from any step
- *   - Step 5 shows "Finish" (not "Next")
+ *   - Step 6 shows "Finish" (not "Next")
  *   - Finishing navigates to /dashboard
  *   - Step 1 Next disabled until required address fields are filled
  *   - Step 2 Next disabled until type, year, and sq ft are filled
- *   - Step 3 Next disabled until legal name and document file are provided
- *   - Step 3 calls propertyService.submitVerification on advance
- *   - Step 5 system age inputs default to year built
- *   - Step 5 solar toggle hides/shows a "Year Installed" input
+ *   - Step 3 (baseline photos) Next always enabled (optional step)
+ *   - Step 4 Next disabled until legal name and document file are provided
+ *   - Step 4 calls propertyService.submitVerification on advance
+ *   - Step 6 system age inputs default to year built
+ *   - Step 6 solar toggle hides/shows a "Year Installed" input
  */
 
 import React from "react";
@@ -140,7 +142,7 @@ function fillStep2() {
   fireEvent.change(screen.getByLabelText(/square feet/i), { target: { value: "2000" } });
 }
 
-function fillStep3() {
+function fillStep4() {
   fireEvent.change(screen.getByLabelText(/legal name/i), { target: { value: "John Doe" } });
   const file = new File(["deed-content"], "deed.pdf", { type: "application/pdf" });
   fireEvent.change(screen.getByLabelText(/ownership document/i), { target: { files: [file] } });
@@ -150,26 +152,31 @@ function clickNext() {
   fireEvent.click(screen.getByRole("button", { name: /^next$/i }));
 }
 
-async function goToStep(n: 2 | 3 | 4 | 5) {
+async function goToStep(n: 2 | 3 | 4 | 5 | 6) {
   renderWizard();
   fillStep1();
   clickNext();
-  await waitFor(() => screen.getByText(/step 2 of 5/i));
+  await waitFor(() => screen.getByText(/step 2 of 6/i));
   if (n === 2) return;
 
   fillStep2();
   clickNext();
-  await waitFor(() => screen.getByText(/step 3 of 5/i));
+  await waitFor(() => screen.getByText(/step 3 of 6/i));
   if (n === 3) return;
 
-  fillStep3();
+  // Step 3 (baseline photos) is optional — Next always enabled
   clickNext();
-  await waitFor(() => screen.getByText(/step 4 of 5/i));
+  await waitFor(() => screen.getByText(/step 4 of 6/i));
   if (n === 4) return;
 
-  // Step 4 is optional
+  fillStep4();
   clickNext();
-  await waitFor(() => screen.getByText(/step 5 of 5/i));
+  await waitFor(() => screen.getByText(/step 5 of 6/i));
+  if (n === 5) return;
+
+  // Step 5 is optional document upload
+  clickNext();
+  await waitFor(() => screen.getByText(/step 6 of 6/i));
 }
 
 // ─── Step indicator ───────────────────────────────────────────────────────────
@@ -177,31 +184,36 @@ async function goToStep(n: 2 | 3 | 4 | 5) {
 describe("OnboardingWizard — step indicator", () => {
   beforeEach(() => { vi.clearAllMocks(); mockNavigate.mockReset(); });
 
-  it("shows 'Step 1 of 5' on initial render", () => {
+  it("shows 'Step 1 of 6' on initial render", () => {
     renderWizard();
-    expect(screen.getByText(/step 1 of 5/i)).toBeInTheDocument();
+    expect(screen.getByText(/step 1 of 6/i)).toBeInTheDocument();
   });
 
-  it("shows 'Step 2 of 5' after advancing from step 1", async () => {
+  it("shows 'Step 2 of 6' after advancing from step 1", async () => {
     renderWizard();
     fillStep1();
     clickNext();
-    await waitFor(() => expect(screen.getByText(/step 2 of 5/i)).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText(/step 2 of 6/i)).toBeInTheDocument());
   });
 
-  it("shows 'Step 3 of 5' after advancing from step 2", async () => {
+  it("shows 'Step 3 of 6' after advancing from step 2", async () => {
     await goToStep(3);
-    expect(screen.getByText(/step 3 of 5/i)).toBeInTheDocument();
+    expect(screen.getByText(/step 3 of 6/i)).toBeInTheDocument();
   });
 
-  it("shows 'Step 4 of 5' after advancing from step 3", async () => {
+  it("shows 'Step 4 of 6' after advancing from step 3", async () => {
     await goToStep(4);
-    expect(screen.getByText(/step 4 of 5/i)).toBeInTheDocument();
+    expect(screen.getByText(/step 4 of 6/i)).toBeInTheDocument();
   });
 
-  it("shows 'Step 5 of 5' after advancing from step 4", async () => {
+  it("shows 'Step 5 of 6' after advancing from step 4", async () => {
     await goToStep(5);
-    expect(screen.getByText(/step 5 of 5/i)).toBeInTheDocument();
+    expect(screen.getByText(/step 5 of 6/i)).toBeInTheDocument();
+  });
+
+  it("shows 'Step 6 of 6' after advancing from step 5", async () => {
+    await goToStep(6);
+    expect(screen.getByText(/step 6 of 6/i)).toBeInTheDocument();
   });
 });
 
@@ -235,28 +247,39 @@ describe("OnboardingWizard — Back button", () => {
     expect(screen.getByRole("button", { name: /^back$/i })).toBeInTheDocument();
   });
 
+  it("shows Back button on step 6", async () => {
+    await goToStep(6);
+    expect(screen.getByRole("button", { name: /^back$/i })).toBeInTheDocument();
+  });
+
   it("clicking Back on step 2 returns to step 1", async () => {
     await goToStep(2);
     fireEvent.click(screen.getByRole("button", { name: /^back$/i }));
-    await waitFor(() => expect(screen.getByText(/step 1 of 5/i)).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText(/step 1 of 6/i)).toBeInTheDocument());
   });
 
   it("clicking Back on step 3 returns to step 2", async () => {
     await goToStep(3);
     fireEvent.click(screen.getByRole("button", { name: /^back$/i }));
-    await waitFor(() => expect(screen.getByText(/step 2 of 5/i)).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText(/step 2 of 6/i)).toBeInTheDocument());
   });
 
   it("clicking Back on step 4 returns to step 3", async () => {
     await goToStep(4);
     fireEvent.click(screen.getByRole("button", { name: /^back$/i }));
-    await waitFor(() => expect(screen.getByText(/step 3 of 5/i)).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText(/step 3 of 6/i)).toBeInTheDocument());
   });
 
   it("clicking Back on step 5 returns to step 4", async () => {
     await goToStep(5);
     fireEvent.click(screen.getByRole("button", { name: /^back$/i }));
-    await waitFor(() => expect(screen.getByText(/step 4 of 5/i)).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText(/step 4 of 6/i)).toBeInTheDocument());
+  });
+
+  it("clicking Back on step 6 returns to step 5", async () => {
+    await goToStep(6);
+    fireEvent.click(screen.getByRole("button", { name: /^back$/i }));
+    await waitFor(() => expect(screen.getByText(/step 5 of 6/i)).toBeInTheDocument());
   });
 });
 
@@ -319,12 +342,47 @@ describe("OnboardingWizard — step 2 validation", () => {
   });
 });
 
-// ─── Step 3: ownership verification ──────────────────────────────────────────
+// ─── Step 3: baseline photos ──────────────────────────────────────────────────
 
-describe("OnboardingWizard — step 3 ownership verification", () => {
+describe("OnboardingWizard — step 3 capture baseline photos", () => {
   beforeEach(async () => {
     vi.clearAllMocks(); mockNavigate.mockReset();
     await goToStep(3);
+  });
+
+  it("shows the Capture Baseline Photos heading", () => {
+    expect(screen.getByRole("heading", { name: /capture baseline photos/i })).toBeInTheDocument();
+  });
+
+  it("shows all 6 baseline system categories", () => {
+    expect(screen.getAllByText(/HVAC/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Water Heater/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Electrical Panel/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Water Shut-off/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Roof/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Garage Door/i).length).toBeGreaterThan(0);
+  });
+
+  it("shows '0 / 6' progress count", () => {
+    // The counter renders as two text nodes: the count + a "/ N" span
+    expect(screen.getByText(/\/\s*6/)).toBeInTheDocument();
+  });
+
+  it("Next button is enabled without uploading anything (optional step)", () => {
+    expect(screen.getByRole("button", { name: /^next$/i })).not.toBeDisabled();
+  });
+
+  it("shows an 'Add photo' button for each of the 6 systems", () => {
+    expect(screen.getAllByRole("button", { name: /add photo/i })).toHaveLength(6);
+  });
+});
+
+// ─── Step 4: ownership verification ──────────────────────────────────────────
+
+describe("OnboardingWizard — step 4 ownership verification", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks(); mockNavigate.mockReset();
+    await goToStep(4);
   });
 
   it("shows the Verify Ownership heading", () => {
@@ -343,15 +401,15 @@ describe("OnboardingWizard — step 3 ownership verification", () => {
   });
 
   it("Next button is enabled when legal name and document are provided", () => {
-    fillStep3();
+    fillStep4();
     expect(screen.getByRole("button", { name: /^next$/i })).not.toBeDisabled();
   });
 
   it("advancing calls submitVerification with the registered property id", async () => {
     const { propertyService } = await import("@/services/property");
-    fillStep3();
+    fillStep4();
     clickNext();
-    await waitFor(() => screen.getByText(/step 4 of 5/i));
+    await waitFor(() => screen.getByText(/step 5 of 6/i));
     expect(propertyService.submitVerification).toHaveBeenCalledWith(
       BigInt(1),
       expect.any(String), // docType
@@ -360,32 +418,32 @@ describe("OnboardingWizard — step 3 ownership verification", () => {
   });
 });
 
-// ─── Step 4: optional document upload ────────────────────────────────────────
+// ─── Step 5: optional document upload ────────────────────────────────────────
 
-describe("OnboardingWizard — step 4 document upload", () => {
+describe("OnboardingWizard — step 5 document upload", () => {
   beforeEach(async () => {
     vi.clearAllMocks(); mockNavigate.mockReset();
-    await goToStep(4);
+    await goToStep(5);
   });
 
   it("renders the document upload area", () => {
     expect(screen.getByTestId("doc-upload")).toBeInTheDocument();
   });
 
-  it("Next button is enabled on step 4 without any upload (optional)", () => {
+  it("Next button is enabled on step 5 without any upload (optional)", () => {
     expect(screen.getByRole("button", { name: /^next$/i })).not.toBeDisabled();
   });
 });
 
-// ─── Step 5: Finish button ────────────────────────────────────────────────────
+// ─── Step 6: Finish button ────────────────────────────────────────────────────
 
-describe("OnboardingWizard — step 5 Finish button", () => {
+describe("OnboardingWizard — step 6 Finish button", () => {
   beforeEach(async () => {
     vi.clearAllMocks(); mockNavigate.mockReset();
-    await goToStep(5);
+    await goToStep(6);
   });
 
-  it("shows 'Finish' button on step 5 instead of 'Next'", () => {
+  it("shows 'Finish' button on step 6 instead of 'Next'", () => {
     expect(screen.getByRole("button", { name: /^finish$/i })).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /^next$/i })).not.toBeInTheDocument();
   });
@@ -396,12 +454,12 @@ describe("OnboardingWizard — step 5 Finish button", () => {
   });
 });
 
-// ─── Step 5: system ages default to year built ───────────────────────────────
+// ─── Step 6: system ages default to year built ───────────────────────────────
 
-describe("OnboardingWizard — step 5 system ages default to year built", () => {
+describe("OnboardingWizard — step 6 system ages default to year built", () => {
   beforeEach(async () => {
     vi.clearAllMocks(); mockNavigate.mockReset();
-    await goToStep(5);
+    await goToStep(6);
   });
 
   it("HVAC input defaults to year built (1990)", () => {
@@ -431,12 +489,12 @@ describe("OnboardingWizard — step 5 system ages default to year built", () => 
   });
 });
 
-// ─── Step 5: solar panels toggle ─────────────────────────────────────────────
+// ─── Step 6: solar panels toggle ─────────────────────────────────────────────
 
-describe("OnboardingWizard — step 5 solar panels", () => {
+describe("OnboardingWizard — step 6 solar panels", () => {
   beforeEach(async () => {
     vi.clearAllMocks(); mockNavigate.mockReset();
-    await goToStep(5);
+    await goToStep(6);
   });
 
   it("solar panels checkbox is unchecked by default", () => {
@@ -463,7 +521,7 @@ describe("OnboardingWizard — step 5 solar panels", () => {
     expect(screen.queryByLabelText(/year installed/i)).not.toBeInTheDocument();
   });
 
-  it("Finish button is enabled on step 5 without solar (optional)", () => {
+  it("Finish button is enabled on step 6 without solar (optional)", () => {
     expect(screen.getByRole("button", { name: /^finish$/i })).not.toBeDisabled();
   });
 });
@@ -506,28 +564,33 @@ describe("OnboardingWizard — progress bar", () => {
     expect(screen.getByRole("progressbar")).toBeInTheDocument();
   });
 
-  it("progress bar shows 20% on step 1", () => {
+  it("progress bar shows 17% on step 1", () => {
     renderWizard();
-    expect(screen.getByRole("progressbar")).toHaveAttribute("aria-valuenow", "20");
+    expect(screen.getByRole("progressbar")).toHaveAttribute("aria-valuenow", "17");
   });
 
-  it("progress bar shows 40% on step 2", async () => {
+  it("progress bar shows 33% on step 2", async () => {
     await goToStep(2);
-    expect(screen.getByRole("progressbar")).toHaveAttribute("aria-valuenow", "40");
+    expect(screen.getByRole("progressbar")).toHaveAttribute("aria-valuenow", "33");
   });
 
-  it("progress bar shows 60% on step 3", async () => {
+  it("progress bar shows 50% on step 3", async () => {
     await goToStep(3);
-    expect(screen.getByRole("progressbar")).toHaveAttribute("aria-valuenow", "60");
+    expect(screen.getByRole("progressbar")).toHaveAttribute("aria-valuenow", "50");
   });
 
-  it("progress bar shows 80% on step 4", async () => {
+  it("progress bar shows 67% on step 4", async () => {
     await goToStep(4);
-    expect(screen.getByRole("progressbar")).toHaveAttribute("aria-valuenow", "80");
+    expect(screen.getByRole("progressbar")).toHaveAttribute("aria-valuenow", "67");
   });
 
-  it("progress bar shows 100% on step 5", async () => {
+  it("progress bar shows 83% on step 5", async () => {
     await goToStep(5);
+    expect(screen.getByRole("progressbar")).toHaveAttribute("aria-valuenow", "83");
+  });
+
+  it("progress bar shows 100% on step 6", async () => {
+    await goToStep(6);
     expect(screen.getByRole("progressbar")).toHaveAttribute("aria-valuenow", "100");
   });
 });
@@ -547,18 +610,23 @@ describe("OnboardingWizard — step content headings", () => {
     expect(screen.getByRole("heading", { name: /property details/i })).toBeInTheDocument();
   });
 
-  it("step 3 shows verify ownership heading", async () => {
+  it("step 3 shows capture baseline photos heading", async () => {
     await goToStep(3);
+    expect(screen.getByRole("heading", { name: /capture baseline photos/i })).toBeInTheDocument();
+  });
+
+  it("step 4 shows verify ownership heading", async () => {
+    await goToStep(4);
     expect(screen.getByRole("heading", { name: /verify ownership/i })).toBeInTheDocument();
   });
 
-  it("step 4 shows import documents heading", async () => {
-    await goToStep(4);
+  it("step 5 shows import documents heading", async () => {
+    await goToStep(5);
     expect(screen.getByRole("heading", { name: /import documents/i })).toBeInTheDocument();
   });
 
-  it("step 5 shows system ages heading", async () => {
-    await goToStep(5);
+  it("step 6 shows system ages heading", async () => {
+    await goToStep(6);
     expect(screen.getByRole("heading", { name: /system ages/i })).toBeInTheDocument();
   });
 });

--- a/frontend/src/hooks/useVoiceAgent.ts
+++ b/frontend/src/hooks/useVoiceAgent.ts
@@ -405,7 +405,7 @@ export function useVoiceAgent(): UseVoiceAgentReturn {
             ? new Date(resetsAt).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })
             : "midnight UTC";
           // Refresh credit balance after a quota-exhausted response.
-          paymentService.getMyAgentCredits().then(setCreditBalance).catch(() => {});
+          paymentService.getMyAgentCredits().then(setCreditBalance).catch((e) => console.error("[useVoiceAgent] credit balance refresh failed:", e)); // display-only; failure does not affect the quota error already thrown
           throw new Error(
             `You've used your ${body.limit ?? ""} AI assistant calls for today. Resets at ${resetTime}.` +
             ` Buy a credit pack for instant top-up, or upgrade your plan for a higher daily limit.`

--- a/frontend/src/pages/OnboardingWizard.tsx
+++ b/frontend/src/pages/OnboardingWizard.tsx
@@ -181,7 +181,7 @@ export default function OnboardingWizard() {
     Number(details.yearBuilt) >= 1900 &&
     Number(details.yearBuilt) <= new Date().getFullYear();
 
-  const step3Valid =
+  const step4Valid =
     verify.legalName.trim().length > 0 &&
     verify.docFile !== null;
 
@@ -443,7 +443,7 @@ export default function OnboardingWizard() {
                           ref={(el) => { baselineInputRefs.current[key] = el; }}
                           onChange={(e) => {
                             const file = e.target.files?.[0];
-                            if (file) handleBaselineUpload(key, file).catch(() => {});
+                            if (file) handleBaselineUpload(key, file).catch(() => {}); // errors surfaced via toast inside handleBaselineUpload; outer catch prevents unhandled-rejection noise
                             e.target.value = "";
                           }}
                         />
@@ -608,7 +608,7 @@ export default function OnboardingWizard() {
   const isNextDisabled =
     (step === 1 && !step1Valid) ||
     (step === 2 && (!step2Valid || registering)) ||
-    (step === 4 && (!step3Valid || submittingVerify));
+    (step === 4 && (!step4Valid || submittingVerify));
 
   return (
     <div style={{

--- a/frontend/src/pages/OnboardingWizard.tsx
+++ b/frontend/src/pages/OnboardingWizard.tsx
@@ -1,6 +1,6 @@
-import React, { useState } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import { useNavigate } from "react-router-dom";
-import { ArrowLeft, ArrowRight, CheckCircle } from "lucide-react";
+import { ArrowLeft, ArrowRight, CheckCircle, Camera } from "lucide-react";
 import { propertyService } from "@/services/property";
 import { photoService, type PhotoQuota } from "@/services/photo";
 import { authService } from "@/services/auth";
@@ -16,10 +16,19 @@ import type { PropertyType } from "@/services/property";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
-const TOTAL_STEPS = 5;
+const TOTAL_STEPS = 6;
 
 const PROPERTY_TYPES: PropertyType[] = [
   "SingleFamily", "Condo", "Townhouse", "MultiFamily",
+];
+
+const BASELINE_SYSTEMS = [
+  { key: "hvac",        label: "HVAC / Air Conditioning",   prompt: "Photograph your outdoor condenser and indoor air handler" },
+  { key: "waterHeater", label: "Water Heater",              prompt: "Photograph your water heater — note the model number if visible" },
+  { key: "electrical",  label: "Electrical Panel",          prompt: "Open the panel door and capture the breaker labels" },
+  { key: "shutoff",     label: "Main Water Shut-off Valve", prompt: "Locate and photograph your main water shut-off valve" },
+  { key: "roof",        label: "Roof",                      prompt: "Photograph visible roof areas from ground level or an attic hatch" },
+  { key: "garageDoor",  label: "Garage Door Opener",        prompt: "Photograph the garage door motor unit and model label" },
 ];
 
 const SYSTEM_LABELS = [
@@ -139,12 +148,24 @@ export default function OnboardingWizard() {
   const [verify, setVerify]           = useState<VerifyForm>({ legalName: "", docType: "DeedRecord", docFile: null });
   const [submittingVerify, setSubmittingVerify] = useState(false);
 
-  // Step 4 — documents
+  // Step 3 — baseline photos
+  const [baselineCompleted, setBaselineCompleted] = useState<Set<string>>(new Set());
+  const [uploadingBaseline, setUploadingBaseline] = useState<string | null>(null);
+  const baselineInputRefs = useRef<Record<string, HTMLInputElement | null>>({});
+
+  // Step 5 — documents
   const [quota, setQuota] = useState<PhotoQuota>({ used: 0, limit: 10, tier: "Free" });
 
   // Step 5 — system ages
   const [ages, setAges]       = useState<SystemAgesForm>({});
   const [hasSolar, setHasSolar] = useState(false);
+
+  // Auto-skip baseline photos step in E2E tests
+  useEffect(() => {
+    if (step === 3 && (window as any).__e2e_skipBaselinePhotos) {
+      setStep((s) => s + 1);
+    }
+  }, [step]);
 
   // ── Validation ──────────────────────────────────────────────────────────────
 
@@ -193,7 +214,7 @@ export default function OnboardingWizard() {
       setRegistering(false);
     }
 
-    if (step === 3 && registeredId) {
+    if (step === 4 && registeredId) {
       setSubmittingVerify(true);
       try {
         const buffer      = await verify.docFile!.arrayBuffer();
@@ -217,6 +238,19 @@ export default function OnboardingWizard() {
   const handleBack   = () => setStep((s) => s - 1);
   const handleFinish = () => { authService.completeOnboarding().catch((e) => console.error("[Onboarding] completeOnboarding failed:", e)); navigate("/dashboard"); };
   const handleSkip   = () => { authService.completeOnboarding().catch((e) => console.error("[Onboarding] completeOnboarding failed:", e)); navigate("/dashboard"); };
+
+  const handleBaselineUpload = async (systemKey: string, file: File) => {
+    if (!registeredId) return;
+    setUploadingBaseline(systemKey);
+    try {
+      await photoService.upload(file, `baseline_${registeredId}`, registeredId, "PostConstruction", systemKey);
+      setBaselineCompleted((prev) => new Set(prev).add(systemKey));
+    } catch (err: any) {
+      toast.error(err.message || "Upload failed");
+    } finally {
+      setUploadingBaseline(null);
+    }
+  };
 
   const handleDocUpload = async (file: File, docType: string) => {
     if (!registeredId) return;
@@ -342,7 +376,101 @@ export default function OnboardingWizard() {
           </div>
         );
 
-      case 3:
+      case 3: {
+        const completedCount = baselineCompleted.size;
+        return (
+          <div>
+            <StepHeading>Capture Baseline Photos</StepHeading>
+            <StepSubtitle>
+              Photograph your major home systems now to create a permanent baseline record.
+              This step is optional — you can always come back later.
+            </StepSubtitle>
+
+            {/* Progress count */}
+            <div style={{
+              display: "flex", alignItems: "center", justifyContent: "space-between",
+              marginBottom: "1.25rem",
+              padding: "0.625rem 0.875rem",
+              background: COLORS.white,
+              border: `1px solid ${COLORS.rule}`,
+            }}>
+              <span style={{ fontFamily: FONTS.mono, fontSize: "0.65rem", letterSpacing: "0.1em", textTransform: "uppercase", color: COLORS.plumMid }}>
+                Baseline photos captured
+              </span>
+              <span style={{ fontFamily: FONTS.serif, fontWeight: 700, fontSize: "1rem", color: completedCount === BASELINE_SYSTEMS.length ? COLORS.sage : COLORS.plum }}>
+                {completedCount} <span style={{ fontWeight: 300, color: COLORS.plumMid }}>/ {BASELINE_SYSTEMS.length}</span>
+              </span>
+            </div>
+
+            <div style={{ display: "flex", flexDirection: "column", gap: "0.75rem" }}>
+              {BASELINE_SYSTEMS.map(({ key, label, prompt }) => {
+                const done = baselineCompleted.has(key);
+                const uploading = uploadingBaseline === key;
+                return (
+                  <div
+                    key={key}
+                    style={{
+                      display: "flex", alignItems: "flex-start", gap: "0.875rem",
+                      padding: "0.875rem",
+                      border: `1px solid ${done ? COLORS.sage : COLORS.rule}`,
+                      background: done ? "#F2FAF4" : COLORS.white,
+                    }}
+                  >
+                    <div style={{
+                      flexShrink: 0, width: "1.5rem", height: "1.5rem",
+                      display: "flex", alignItems: "center", justifyContent: "center",
+                      marginTop: "0.1rem",
+                    }}>
+                      {done
+                        ? <CheckCircle size={18} color={COLORS.sage} />
+                        : <Camera size={18} color={COLORS.plumMid} />
+                      }
+                    </div>
+                    <div style={{ flex: 1, minWidth: 0 }}>
+                      <p style={{ fontFamily: FONTS.sans, fontSize: "0.875rem", fontWeight: 600, color: COLORS.plum, margin: "0 0 0.2rem" }}>
+                        {label}
+                      </p>
+                      <p style={{ fontFamily: FONTS.sans, fontSize: "0.775rem", color: COLORS.plumMid, fontWeight: 300, margin: 0, lineHeight: 1.5 }}>
+                        {done ? "Photo captured" : prompt}
+                      </p>
+                    </div>
+                    {!done && (
+                      <div style={{ flexShrink: 0 }}>
+                        <input
+                          type="file"
+                          accept="image/*"
+                          style={{ display: "none" }}
+                          ref={(el) => { baselineInputRefs.current[key] = el; }}
+                          onChange={(e) => {
+                            const file = e.target.files?.[0];
+                            if (file) handleBaselineUpload(key, file).catch(() => {});
+                            e.target.value = "";
+                          }}
+                        />
+                        <button
+                          disabled={uploading}
+                          onClick={() => baselineInputRefs.current[key]?.click()}
+                          style={{
+                            padding: "0.375rem 0.75rem",
+                            fontFamily: FONTS.sans, fontSize: "0.7rem", fontWeight: 600,
+                            background: "none", color: COLORS.plum,
+                            border: `1px solid ${COLORS.rule}`, cursor: uploading ? "wait" : "pointer",
+                            opacity: uploading ? 0.6 : 1,
+                          }}
+                        >
+                          {uploading ? "Uploading…" : "Add photo"}
+                        </button>
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        );
+      }
+
+      case 4:
         return (
           <div>
             <StepHeading>Verify Ownership</StepHeading>
@@ -393,7 +521,7 @@ export default function OnboardingWizard() {
           </div>
         );
 
-      case 4:
+      case 5:
         return (
           <div>
             <StepHeading>Import Documents</StepHeading>
@@ -409,7 +537,7 @@ export default function OnboardingWizard() {
           </div>
         );
 
-      case 5:
+      case 6:
         return (
           <div>
             <StepHeading>System Ages</StepHeading>
@@ -480,7 +608,7 @@ export default function OnboardingWizard() {
   const isNextDisabled =
     (step === 1 && !step1Valid) ||
     (step === 2 && (!step2Valid || registering)) ||
-    (step === 3 && (!step3Valid || submittingVerify));
+    (step === 4 && (!step3Valid || submittingVerify));
 
   return (
     <div style={{

--- a/tests/e2e/onboarding.spec.ts
+++ b/tests/e2e/onboarding.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, Page } from "@playwright/test";
 import { injectTestAuth } from "./helpers/auth";
 import { injectRegisterProperty } from "./helpers/testData";
 
@@ -20,12 +20,18 @@ async function fillStep2(page: Parameters<typeof injectTestAuth>[0]) {
   await page.getByRole("button", { name: /next/i }).click();
 }
 
+/** Inject the skip-baseline flag so tests that don't test the new step pass through it automatically. */
+async function injectSkipBaseline(page: Page) {
+  await page.addInitScript(() => { (window as any).__e2e_skipBaselinePhotos = true; });
+}
+
 test.describe("OnboardingWizard — /onboarding", () => {
   test.beforeEach(async ({ page }) => {
     await injectTestAuth(page);
+    await injectSkipBaseline(page);
     await page.goto("/onboarding");
     // Wait for wizard card to render
-    await expect(page.getByText(/step 1 of 5/i)).toBeVisible();
+    await expect(page.getByText(/step 1 of 6/i)).toBeVisible();
   });
 
   // ── Page structure ──────────────────────────────────────────────────────────
@@ -38,8 +44,8 @@ test.describe("OnboardingWizard — /onboarding", () => {
     await expect(page.getByRole("progressbar")).toBeVisible();
   });
 
-  test("shows 'Step 1 of 5' label on load", async ({ page }) => {
-    await expect(page.getByText("Step 1 of 5")).toBeVisible();
+  test("shows 'Step 1 of 6' label on load", async ({ page }) => {
+    await expect(page.getByText("Step 1 of 6")).toBeVisible();
   });
 
   test("shows 'Skip setup — go to my dashboard' link", async ({ page }) => {
@@ -117,7 +123,7 @@ test.describe("OnboardingWizard — /onboarding", () => {
     await page.getByLabel(/state/i).fill("TX");
     await page.getByLabel(/zip code/i).fill("78701");
     await page.getByRole("button", { name: /next/i }).click();
-    await expect(page.getByText("Step 2 of 5")).toBeVisible();
+    await expect(page.getByText("Step 2 of 6")).toBeVisible();
   });
 
   // ── Step 2: Property Details ────────────────────────────────────────────────
@@ -168,7 +174,7 @@ test.describe("OnboardingWizard — /onboarding", () => {
   test("Back from step 2 returns to step 1", async ({ page }) => {
     await fillStep1(page);
     await page.getByRole("button", { name: /back/i }).click();
-    await expect(page.getByText("Step 1 of 5")).toBeVisible();
+    await expect(page.getByText("Step 1 of 6")).toBeVisible();
   });
 
   test("Back from step 2 preserves address values", async ({ page }) => {
@@ -182,12 +188,13 @@ test.describe("OnboardingWizard — /onboarding", () => {
   // BEFORE page.goto so addInitScript fires on the initial load.
   // These tests use their own nested describe with a dedicated beforeEach.
 
-  test.describe("step 3 — Verify Ownership", () => {
+  test.describe("step 4 — Verify Ownership", () => {
     test.beforeEach(async ({ page }) => {
       await injectTestAuth(page);
       await injectRegisterProperty(page);          // must be before goto
+      await injectSkipBaseline(page);              // auto-skip baseline photos step
       await page.goto("/onboarding");
-      await expect(page.getByText(/step 1 of 5/i)).toBeVisible();
+      await expect(page.getByText(/step 1 of 6/i)).toBeVisible();
       // Navigate through step 1
       await page.getByLabel(/street address/i).fill("100 Onboarding Lane");
       await page.getByLabel(/city/i).fill("Austin");
@@ -198,8 +205,8 @@ test.describe("OnboardingWizard — /onboarding", () => {
       await page.getByLabel(/year built/i).fill("2000");
       await page.getByLabel(/square feet/i).fill("2000");
       await page.getByRole("button", { name: /next/i }).click();
-      // Confirm we landed on step 3
-      await expect(page.getByText(/step 3 of 5/i)).toBeVisible();
+      // Step 3 (baseline) is auto-skipped, confirm we landed on step 4
+      await expect(page.getByText(/step 4 of 6/i)).toBeVisible();
     });
 
     test("shows 'Verify Ownership' heading", async ({ page }) => {
@@ -227,7 +234,57 @@ test.describe("OnboardingWizard — /onboarding", () => {
     });
   });
 
-  // ── Step 5: System Ages ─────────────────────────────────────────────────────
+  // ── Step 3: Capture Baseline Photos ────────────────────────────────────────
+  // Uses a separate beforeEach WITHOUT __e2e_skipBaselinePhotos so the step renders.
+
+  test.describe("step 3 — Capture Baseline Photos", () => {
+    test.beforeEach(async ({ page }) => {
+      await injectTestAuth(page);
+      await injectRegisterProperty(page);
+      // No injectSkipBaseline — we want the baseline step to render
+      await page.goto("/onboarding");
+      await expect(page.getByText(/step 1 of 6/i)).toBeVisible();
+      await page.getByLabel(/street address/i).fill("100 Onboarding Lane");
+      await page.getByLabel(/city/i).fill("Austin");
+      await page.getByLabel(/state/i).fill("TX");
+      await page.getByLabel(/zip code/i).fill("78701");
+      await page.getByRole("button", { name: /next/i }).click();
+      await page.getByLabel(/year built/i).fill("2000");
+      await page.getByLabel(/square feet/i).fill("2000");
+      await page.getByRole("button", { name: /next/i }).click();
+      await expect(page.getByText(/step 3 of 6/i)).toBeVisible();
+    });
+
+    test("shows 'Capture Baseline Photos' heading", async ({ page }) => {
+      await expect(page.getByRole("heading", { name: /capture baseline photos/i })).toBeVisible();
+    });
+
+    test("shows all 6 baseline system categories", async ({ page }) => {
+      await expect(page.getByText(/HVAC/i)).toBeVisible();
+      await expect(page.getByText(/Water Heater/i)).toBeVisible();
+      await expect(page.getByText(/Electrical Panel/i)).toBeVisible();
+      await expect(page.getByText(/Water Shut-off/i)).toBeVisible();
+      await expect(page.getByText(/Roof/i)).toBeVisible();
+      await expect(page.getByText(/Garage Door/i)).toBeVisible();
+    });
+
+    test("shows progress count '0 / 6'", async ({ page }) => {
+      await expect(page.getByText(/0/)).toBeVisible();
+      await expect(page.getByText(/6/)).toBeVisible();
+    });
+
+    test("Next advances to step 4 without uploading anything", async ({ page }) => {
+      await page.getByRole("button", { name: /next/i }).click();
+      await expect(page.getByText(/step 4 of 6/i)).toBeVisible();
+    });
+
+    test("shows 'Add photo' button for each system", async ({ page }) => {
+      const addPhotoButtons = page.getByRole("button", { name: /add photo/i });
+      await expect(addPhotoButtons).toHaveCount(6);
+    });
+  });
+
+  // ── Step 6: System Ages ─────────────────────────────────────────────────────
   // Steps 4 and 5 can be reached with the skip link from step 3 indirectly,
   // but we validate step 5 via direct step count progression.
 


### PR DESCRIPTION
Inserts a new step 3 "Capture Baseline Photos" between property registration and ownership verification. Presents a checklist of 6 system categories (HVAC, water heater, electrical panel, main shut-off valve, roof, garage door opener) with inline per-system file upload via photoService. All uploads are tagged with phase=PostConstruction and persisted to the property record. The step is optional — Next is always enabled and each category shows a checkmark once captured. Progress counter "X / 6" updates live. Shifts former steps 3-5 to steps 4-6 (TOTAL_STEPS 5 → 6). E2E tests auto-skip via __e2e_skipBaselinePhotos; unit tests updated across all step-count and progress-bar assertions.

## Summary
<!-- What does this PR do? -->

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [ ] Backend tests pass (`make test`)
- [ ] Frontend builds (`cd frontend && npm run build`)
- [ ] Tested locally with dfx

## Checklist
- [ ] Code follows project conventions
- [ ] Self-review completed
- [ ] No sensitive data committed
