### PR TITLE
feat(dashboard): surface baseline photo completion prompt (#135)

### DIFF
--- a/frontend/src/__tests__/components/BaselinePromptCard.test.tsx
+++ b/frontend/src/__tests__/components/BaselinePromptCard.test.tsx
@@ -1,0 +1,196 @@
+/**
+ * Unit tests for BaselinePromptCard — Issue #135
+ *
+ * Covers:
+ *   - Card renders when photos are missing and not dismissed
+ *   - Shows all 6 system labels
+ *   - Progress count "0 / 6"
+ *   - Dismiss hides the card (not all complete)
+ *   - Card hidden when dismissed and photos are missing
+ *   - "Baseline complete" badge shown when all 6 photos present (overrides dismiss)
+ *   - "Add photo" buttons rendered for each incomplete system
+ *   - Uploading a photo marks that system as captured
+ */
+
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+vi.mock("@/services/photo", () => ({
+  photoService: {
+    getByJob: vi.fn().mockResolvedValue([]),
+    upload:   vi.fn().mockResolvedValue({
+      id: "p1", jobId: "baseline_1", propertyId: "1",
+      phase: "PostConstruction", description: "hvac",
+      hash: "abc", url: "blob:fake", size: 100,
+      verified: false, createdAt: Date.now(),
+    }),
+  },
+}));
+
+vi.mock("react-hot-toast", () => ({ default: { error: vi.fn(), success: vi.fn() } }));
+
+import { photoService } from "@/services/photo";
+import { BaselinePromptCard, BASELINE_SYSTEMS } from "@/components/BaselinePromptCard";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const FAKE_PHOTO = (description: string) => ({
+  id: description, jobId: "baseline_1", propertyId: "1",
+  phase: "PostConstruction", description,
+  hash: description, url: "blob:fake", size: 100,
+  verified: false, createdAt: Date.now(),
+});
+
+const PROPERTY = {
+  id: BigInt(1), owner: "test",
+  address: "123 Maple Street", city: "Austin", state: "TX", zipCode: "78701",
+  propertyType: "SingleFamily" as const,
+  yearBuilt: BigInt(2001), squareFeet: BigInt(2400),
+  verificationLevel: "Unverified", tier: "Free",
+  createdAt: BigInt(0), updatedAt: BigInt(0), isActive: true,
+};
+
+function renderCard(opts: { dismissed?: boolean; onDismiss?: () => void } = {}) {
+  const onDismiss = opts.onDismiss ?? vi.fn();
+  return render(
+    <BaselinePromptCard
+      property={PROPERTY}
+      dismissed={opts.dismissed ?? false}
+      onDismiss={onDismiss}
+    />
+  );
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("BaselinePromptCard", () => {
+  beforeEach(() => {
+    vi.mocked(photoService.getByJob).mockResolvedValue([]);
+  });
+
+  // ── Visible card (0 photos, not dismissed) ─────────────────────────────────
+
+  it("renders 'Complete your property baseline' heading when photos are missing", async () => {
+    renderCard();
+    await waitFor(() =>
+      expect(screen.getByText(/complete your property baseline/i)).toBeInTheDocument()
+    );
+  });
+
+  it("shows all 6 system labels", async () => {
+    renderCard();
+    await waitFor(() => screen.getByText(/complete your property baseline/i));
+    for (const { label } of BASELINE_SYSTEMS) {
+      expect(screen.getAllByText(label).length).toBeGreaterThan(0);
+    }
+  });
+
+  it("shows progress count '0 / 6' when no photos are captured", async () => {
+    renderCard();
+    await waitFor(() => screen.getByText(/complete your property baseline/i));
+    expect(screen.getByText(/0/)).toBeInTheDocument();
+    expect(screen.getByText(/\/\s*6/)).toBeInTheDocument();
+  });
+
+  it("renders 6 'Add photo' buttons — one per system", async () => {
+    renderCard();
+    await waitFor(() => screen.getByText(/complete your property baseline/i));
+    expect(screen.getAllByRole("button", { name: /add photo/i })).toHaveLength(6);
+  });
+
+  it("shows a dismiss button", async () => {
+    renderCard();
+    await waitFor(() => screen.getByText(/complete your property baseline/i));
+    expect(screen.getByRole("button", { name: /dismiss/i })).toBeInTheDocument();
+  });
+
+  // ── Dismissed state ────────────────────────────────────────────────────────
+
+  it("is hidden when dismissed and photos are missing", async () => {
+    renderCard({ dismissed: true });
+    // Give the async fetch time to resolve
+    await new Promise((r) => setTimeout(r, 50));
+    expect(screen.queryByText(/complete your property baseline/i)).not.toBeInTheDocument();
+  });
+
+  it("calls onDismiss when dismiss button is clicked", async () => {
+    const onDismiss = vi.fn();
+    renderCard({ onDismiss });
+    await waitFor(() => screen.getByText(/complete your property baseline/i));
+    fireEvent.click(screen.getByRole("button", { name: /dismiss/i }));
+    expect(onDismiss).toHaveBeenCalledOnce();
+  });
+
+  // ── All 6 photos present ───────────────────────────────────────────────────
+
+  it("shows 'Baseline photos complete' badge when all 6 systems are captured", async () => {
+    const allPhotos = BASELINE_SYSTEMS.map(({ key }) => FAKE_PHOTO(key));
+    vi.mocked(photoService.getByJob).mockResolvedValue(allPhotos);
+    renderCard();
+    await waitFor(() =>
+      expect(screen.getByText(/baseline photos complete/i)).toBeInTheDocument()
+    );
+  });
+
+  it("shows 'Baseline photos complete' badge even when dismissed", async () => {
+    const allPhotos = BASELINE_SYSTEMS.map(({ key }) => FAKE_PHOTO(key));
+    vi.mocked(photoService.getByJob).mockResolvedValue(allPhotos);
+    renderCard({ dismissed: true });
+    await waitFor(() =>
+      expect(screen.getByText(/baseline photos complete/i)).toBeInTheDocument()
+    );
+  });
+
+  it("does not show the checklist when all 6 are captured", async () => {
+    const allPhotos = BASELINE_SYSTEMS.map(({ key }) => FAKE_PHOTO(key));
+    vi.mocked(photoService.getByJob).mockResolvedValue(allPhotos);
+    renderCard();
+    await waitFor(() => screen.getByText(/baseline photos complete/i));
+    expect(screen.queryByText(/complete your property baseline/i)).not.toBeInTheDocument();
+  });
+
+  // ── Partial completion ─────────────────────────────────────────────────────
+
+  it("shows progress count '2 / 6' when 2 photos are present", async () => {
+    vi.mocked(photoService.getByJob).mockResolvedValue([
+      FAKE_PHOTO("hvac"),
+      FAKE_PHOTO("roof"),
+    ]);
+    renderCard();
+    await waitFor(() => screen.getByText(/complete your property baseline/i));
+    // The counter node renders as "2 " + "/ 6" in two adjacent spans
+    expect(screen.getByText(/\/\s*6/)).toBeInTheDocument();
+    // 4 systems remain — 4 Add photo buttons
+    expect(screen.getAllByRole("button", { name: /add photo/i })).toHaveLength(4);
+  });
+
+  it("renders 'Add photo' button only for incomplete systems", async () => {
+    vi.mocked(photoService.getByJob).mockResolvedValue([FAKE_PHOTO("hvac")]);
+    renderCard();
+    await waitFor(() => screen.getByText(/complete your property baseline/i));
+    // 5 systems remaining
+    expect(screen.getAllByRole("button", { name: /add photo/i })).toHaveLength(5);
+  });
+
+  // ── Upload interaction ─────────────────────────────────────────────────────
+
+  it("marks a system as captured after upload completes", async () => {
+    renderCard();
+    await waitFor(() => screen.getByText(/complete your property baseline/i));
+
+    // Simulate a file-change event on the hidden input for 'hvac'
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+    const file = new File(["data"], "hvac.jpg", { type: "image/jpeg" });
+    Object.defineProperty(fileInput, "files", { value: [file] });
+    fireEvent.change(fileInput);
+
+    await waitFor(() =>
+      // After upload, the photoService.upload mock returns description:"hvac"
+      // so the count should show 1 captured
+      expect(screen.getByText(/1/)).toBeInTheDocument()
+    );
+  });
+});

--- a/frontend/src/__tests__/components/BaselinePromptCard.test.tsx
+++ b/frontend/src/__tests__/components/BaselinePromptCard.test.tsx
@@ -49,7 +49,8 @@ const PROPERTY = {
   address: "123 Maple Street", city: "Austin", state: "TX", zipCode: "78701",
   propertyType: "SingleFamily" as const,
   yearBuilt: BigInt(2001), squareFeet: BigInt(2400),
-  verificationLevel: "Unverified", tier: "Free",
+  verificationLevel: "Unverified" as const,
+  tier: "Free" as const,
   createdAt: BigInt(0), updatedAt: BigInt(0), isActive: true,
 };
 

--- a/frontend/src/__tests__/components/BaselinePromptCard.test.tsx
+++ b/frontend/src/__tests__/components/BaselinePromptCard.test.tsx
@@ -15,6 +15,7 @@
 import React from "react";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Property } from "@/services/property";
 
 // ─── Mocks ────────────────────────────────────────────────────────────────────
 
@@ -44,13 +45,13 @@ const FAKE_PHOTO = (description: string) => ({
   verified: false, createdAt: Date.now(),
 });
 
-const PROPERTY = {
+const PROPERTY: Property = {
   id: BigInt(1), owner: "test",
   address: "123 Maple Street", city: "Austin", state: "TX", zipCode: "78701",
-  propertyType: "SingleFamily" as const,
+  propertyType: "SingleFamily",
   yearBuilt: BigInt(2001), squareFeet: BigInt(2400),
-  verificationLevel: "Unverified" as const,
-  tier: "Free" as const,
+  verificationLevel: "Unverified",
+  tier: "Free",
   createdAt: BigInt(0), updatedAt: BigInt(0), isActive: true,
 };
 

--- a/frontend/src/components/BaselinePromptCard.tsx
+++ b/frontend/src/components/BaselinePromptCard.tsx
@@ -1,0 +1,183 @@
+import React, { useEffect, useRef, useState } from "react";
+import { Camera, CheckCircle, X } from "lucide-react";
+import { photoService, type Photo } from "@/services/photo";
+import type { Property } from "@/services/property";
+import toast from "react-hot-toast";
+import { COLORS, FONTS } from "@/theme";
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+export const BASELINE_SYSTEMS = [
+  { key: "hvac",        label: "HVAC / Air Conditioning"   },
+  { key: "waterHeater", label: "Water Heater"               },
+  { key: "electrical",  label: "Electrical Panel"           },
+  { key: "shutoff",     label: "Main Water Shut-off Valve"  },
+  { key: "roof",        label: "Roof"                       },
+  { key: "garageDoor",  label: "Garage Door Opener"         },
+] as const;
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+interface Props {
+  property:  Property;
+  dismissed: boolean;
+  onDismiss: () => void;
+}
+
+export function BaselinePromptCard({ property, dismissed, onDismiss }: Props) {
+  const [photos,    setPhotos]    = useState<Photo[]>([]);
+  const [loading,   setLoading]   = useState(true);
+  const [uploading, setUploading] = useState<string | null>(null);
+  const inputRefs = useRef<Record<string, HTMLInputElement | null>>({});
+
+  const propertyId = String(property.id);
+
+  useEffect(() => {
+    photoService.getByJob(`baseline_${propertyId}`)
+      .then(setPhotos)
+      .catch((e) => console.error("[BaselinePromptCard] photo fetch failed:", e))
+      .finally(() => setLoading(false));
+  }, [propertyId]);
+
+  const captured       = new Set(photos.map((p) => p.description));
+  const completedCount = BASELINE_SYSTEMS.filter(({ key }) => captured.has(key)).length;
+  const allComplete    = completedCount === BASELINE_SYSTEMS.length;
+
+  const handleUpload = async (key: string, file: File) => {
+    setUploading(key);
+    try {
+      const photo = await photoService.upload(
+        file,
+        `baseline_${propertyId}`,
+        propertyId,
+        "PostConstruction",
+        key,
+      );
+      setPhotos((prev) => [...prev, photo]);
+    } catch (err: any) {
+      toast.error(err.message || "Upload failed");
+    } finally {
+      setUploading(null);
+    }
+  };
+
+  if (loading) return null;
+
+  // All 6 captured — show compact success badge regardless of dismiss state
+  if (allComplete) {
+    return (
+      <div
+        data-testid={`baseline-complete-${propertyId}`}
+        style={{
+          display: "flex", alignItems: "center", gap: "0.5rem",
+          padding: "0.5rem 0.875rem",
+          border: `1px solid ${COLORS.sage}`,
+          background: "#F2FAF4",
+        }}
+      >
+        <CheckCircle size={14} color={COLORS.sage} />
+        <span style={{ fontFamily: FONTS.sans, fontSize: "0.75rem", fontWeight: 500, color: COLORS.sage }}>
+          Baseline photos complete — {property.address}
+        </span>
+      </div>
+    );
+  }
+
+  if (dismissed) return null;
+
+  return (
+    <div
+      data-testid={`baseline-prompt-${propertyId}`}
+      style={{ border: `1px solid ${COLORS.rule}`, background: COLORS.white }}
+    >
+      {/* Header */}
+      <div style={{
+        display: "flex", alignItems: "center", justifyContent: "space-between",
+        padding: "0.875rem 1.125rem",
+        borderBottom: `1px solid ${COLORS.rule}`,
+      }}>
+        <div>
+          <span style={{ fontFamily: FONTS.mono, fontSize: "0.6rem", letterSpacing: "0.1em", textTransform: "uppercase", color: COLORS.plumMid }}>
+            {property.address}
+          </span>
+          <h3 style={{ fontFamily: FONTS.serif, fontWeight: 700, fontSize: "1rem", color: COLORS.plum, margin: "0.1rem 0 0" }}>
+            Complete your property baseline
+          </h3>
+        </div>
+        <div style={{ display: "flex", alignItems: "center", gap: "0.875rem" }}>
+          <span style={{ fontFamily: FONTS.serif, fontWeight: 700, fontSize: "0.9rem", color: COLORS.plum }}>
+            {completedCount}{" "}
+            <span style={{ fontWeight: 300, color: COLORS.plumMid, fontSize: "0.8rem" }}>/ {BASELINE_SYSTEMS.length}</span>
+          </span>
+          <button
+            onClick={onDismiss}
+            aria-label="Dismiss baseline prompt"
+            style={{ background: "none", border: "none", cursor: "pointer", color: COLORS.plumMid, padding: "0.25rem", display: "flex" }}
+          >
+            <X size={15} />
+          </button>
+        </div>
+      </div>
+
+      {/* Checklist */}
+      <div style={{ padding: "0.75rem 1.125rem", display: "flex", flexDirection: "column", gap: "0.5rem" }}>
+        {BASELINE_SYSTEMS.map(({ key, label }) => {
+          const done        = captured.has(key);
+          const isUploading = uploading === key;
+          return (
+            <div
+              key={key}
+              style={{
+                display: "flex", alignItems: "center", gap: "0.75rem",
+                padding: "0.5rem 0.75rem",
+                background: done ? "#F2FAF4" : COLORS.white,
+                border: `1px solid ${done ? COLORS.sage : COLORS.rule}`,
+              }}
+            >
+              {done
+                ? <CheckCircle size={14} color={COLORS.sage} style={{ flexShrink: 0 }} />
+                : <Camera      size={14} color={COLORS.plumMid} style={{ flexShrink: 0 }} />
+              }
+              <span style={{
+                flex: 1, fontFamily: FONTS.sans, fontSize: "0.8rem",
+                fontWeight: done ? 400 : 500, color: done ? COLORS.plumMid : COLORS.plum,
+                textDecoration: done ? "line-through" : "none",
+              }}>
+                {label}
+              </span>
+              {!done && (
+                <>
+                  <input
+                    type="file"
+                    accept="image/*"
+                    style={{ display: "none" }}
+                    ref={(el) => { inputRefs.current[key] = el; }}
+                    onChange={(e) => {
+                      const file = e.target.files?.[0];
+                      if (file) handleUpload(key, file).catch(() => {}); // errors surfaced via toast inside handleUpload
+                      e.target.value = "";
+                    }}
+                  />
+                  <button
+                    disabled={isUploading}
+                    onClick={() => inputRefs.current[key]?.click()}
+                    style={{
+                      padding: "0.25rem 0.625rem",
+                      fontFamily: FONTS.sans, fontSize: "0.65rem", fontWeight: 600,
+                      background: "none", color: COLORS.plum,
+                      border: `1px solid ${COLORS.rule}`,
+                      cursor: isUploading ? "wait" : "pointer",
+                      opacity: isUploading ? 0.6 : 1, flexShrink: 0,
+                    }}
+                  >
+                    {isUploading ? "Uploading…" : "Add photo"}
+                  </button>
+                </>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/hooks/useDashboardDismissals.ts
+++ b/frontend/src/hooks/useDashboardDismissals.ts
@@ -6,6 +6,9 @@ export interface DashboardDismissals {
   bannerDismissed: boolean;
   dismissBanner(): void;
 
+  dismissedBaselinePrompts: Set<string>;
+  dismissBaselinePrompt(propertyId: string): void;
+
   milestoneDismissed: boolean;
   dismissMilestone(): void;
 
@@ -27,6 +30,14 @@ export interface DashboardDismissals {
 
 export function useDashboardDismissals(): DashboardDismissals {
   const [bannerDismissed, setBannerDismissed] = useState(false);
+
+  const [dismissedBaselinePrompts, setDismissedBaselinePrompts] = useState<Set<string>>(
+    () => new Set(
+      Object.keys(localStorage)
+        .filter((k) => k.startsWith("homegentic_baseline_prompt_dismissed_"))
+        .map((k) => k.replace("homegentic_baseline_prompt_dismissed_", ""))
+    )
+  );
 
   const [milestoneDismissed, setMilestoneDismissed] = useState(
     () => !!localStorage.getItem("homegentic_milestone_dismissed")
@@ -57,6 +68,12 @@ export function useDashboardDismissals(): DashboardDismissals {
   return {
     bannerDismissed,
     dismissBanner: () => setBannerDismissed(true),
+
+    dismissedBaselinePrompts,
+    dismissBaselinePrompt: (propertyId: string) => {
+      localStorage.setItem(`homegentic_baseline_prompt_dismissed_${propertyId}`, "1");
+      setDismissedBaselinePrompts((prev) => new Set([...prev, propertyId]));
+    },
 
     milestoneDismissed,
     dismissMilestone: () => {

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -23,7 +23,8 @@ import toast from "react-hot-toast";
 import { COLORS, FONTS, RADIUS, SHADOWS } from "@/theme";
 import { ScoreSparkline }    from "@/components/ScoreSparkline";
 import { ScoreHistoryChart } from "@/components/ScoreHistoryChart";
-import { PropertyCard }      from "@/components/PropertyCard";
+import { PropertyCard }          from "@/components/PropertyCard";
+import { BaselinePromptCard }    from "@/components/BaselinePromptCard";
 import { useBreakpoint } from "@/hooks/useBreakpoint";
 import { ResponsiveGrid } from "@/components/ResponsiveGrid";
 import { NeighborhoodBenchmark } from "@/components/NeighborhoodBenchmark";
@@ -983,11 +984,25 @@ export default function DashboardPage() {
               </div>
             </div>
           ) : (
-            <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill,minmax(280px,1fr))", gap: "1rem" }}>
-              {properties.map((property) => (
-                <PropertyCard key={String(property.id)} property={property} onClick={() => navigate(`/properties/${property.id}`)} badge={verificationBadge(property.verificationLevel)} />
-              ))}
-            </div>
+            <>
+              <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill,minmax(280px,1fr))", gap: "1rem" }}>
+                {properties.map((property) => (
+                  <PropertyCard key={String(property.id)} property={property} onClick={() => navigate(`/properties/${property.id}`)} badge={verificationBadge(property.verificationLevel)} />
+                ))}
+              </div>
+
+              {/* Baseline photo prompts — one per property, hidden once dismissed or all 6 captured */}
+              <div style={{ display: "flex", flexDirection: "column", gap: "0.75rem", marginTop: "1rem" }}>
+                {properties.map((property) => (
+                  <BaselinePromptCard
+                    key={String(property.id)}
+                    property={property}
+                    dismissed={d.dismissedBaselinePrompts.has(String(property.id))}
+                    onDismiss={() => d.dismissBaselinePrompt(String(property.id))}
+                  />
+                ))}
+              </div>
+            </>
           )}
         </div>
 

--- a/frontend/src/services/photo.ts
+++ b/frontend/src/services/photo.ts
@@ -231,6 +231,7 @@ function createPhotoService() {
       const photosMap = (window as any).__e2e_baseline_photos as Record<string, Photo[]>;
       if (jobId in photosMap) return photosMap[jobId] ?? [];
     }
+    if (!PHOTO_CANISTER_ID) return [];
     const a = await getActor();
     return (await a.getPhotosByJob(jobId) as any[]).map(fromPhoto);
   },

--- a/frontend/src/services/photo.ts
+++ b/frontend/src/services/photo.ts
@@ -227,6 +227,10 @@ function createPhotoService() {
   },
 
   async getByJob(jobId: string): Promise<Photo[]> {
+    if (typeof window !== "undefined" && (window as any).__e2e_baseline_photos) {
+      const photosMap = (window as any).__e2e_baseline_photos as Record<string, Photo[]>;
+      if (jobId in photosMap) return photosMap[jobId] ?? [];
+    }
     const a = await getActor();
     return (await a.getPhotosByJob(jobId) as any[]).map(fromPhoto);
   },

--- a/frontend/src/services/photo.ts
+++ b/frontend/src/services/photo.ts
@@ -231,7 +231,6 @@ function createPhotoService() {
       const photosMap = (window as any).__e2e_baseline_photos as Record<string, Photo[]>;
       if (jobId in photosMap) return photosMap[jobId] ?? [];
     }
-    if (!PHOTO_CANISTER_ID) return [];
     const a = await getActor();
     return (await a.getPhotosByJob(jobId) as any[]).map(fromPhoto);
   },

--- a/tests/e2e/dashboard.spec.ts
+++ b/tests/e2e/dashboard.spec.ts
@@ -184,14 +184,11 @@ test.describe("DashboardPage — /dashboard", () => {
     });
 
     test("dismiss button hides the card for that property", async ({ page }) => {
-      const cards = page.getByText(/complete your property baseline/i);
-      const firstCard = cards.first();
-      await expect(firstCard).toBeVisible();
-      // Click dismiss on the first card's parent
-      await firstCard.locator("..").locator("..").getByRole("button", { name: /dismiss/i }).click();
-      await expect(page.getByText(/complete your property baseline/i).first()).not.toBeVisible({ timeout: 3000 }).catch(() => {
-        // If second property card still shows, that's expected — just verify first is gone
-      });
+      // Property 1's card has data-testid="baseline-prompt-1"
+      const card = page.locator('[data-testid="baseline-prompt-1"]');
+      await expect(card).toBeVisible();
+      await card.getByRole("button", { name: /dismiss/i }).click();
+      await expect(card).not.toBeVisible();
     });
   });
 

--- a/tests/e2e/dashboard.spec.ts
+++ b/tests/e2e/dashboard.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from "@playwright/test";
 import { injectTestAuth } from "./helpers/auth";
+import { injectBaselinePhotos } from "./helpers/testData";
 
 // Dashboard requires 2+ properties — a single property triggers an immediate
 // redirect to the property detail page (DashboardPage line 83-85).
@@ -152,5 +153,65 @@ test.describe("DashboardPage — /dashboard", () => {
   test("Log a Job opens the log job modal", async ({ page }) => {
     await page.getByRole("button", { name: /log a job/i }).first().click();
     await expect(page.getByRole("heading", { name: /log a job/i })).toBeVisible();
+  });
+
+  // ── Baseline photo prompt ───────────────────────────────────────────────────
+
+  test.describe("baseline prompt — zero photos", () => {
+    test.beforeEach(async ({ page }) => {
+      // No __e2e_baseline_photos injected → getByJob returns [] for all properties
+      await setup(page);
+      await page.goto("/dashboard");
+      await expect(page.getByRole("heading", { name: "Dashboard" })).toBeVisible();
+    });
+
+    test("shows 'Complete your property baseline' card for first property", async ({ page }) => {
+      await expect(page.getByText(/complete your property baseline/i).first()).toBeVisible();
+    });
+
+    test("shows all 6 system labels in the baseline card", async ({ page }) => {
+      await expect(page.getByText(/HVAC \/ Air Conditioning/i).first()).toBeVisible();
+      await expect(page.getByText(/Water Heater/i).first()).toBeVisible();
+      await expect(page.getByText(/Electrical Panel/i).first()).toBeVisible();
+      await expect(page.getByText(/Main Water Shut-off Valve/i).first()).toBeVisible();
+      await expect(page.getByText(/Roof/i).first()).toBeVisible();
+      await expect(page.getByText(/Garage Door Opener/i).first()).toBeVisible();
+    });
+
+    test("shows '0 / 6' progress count", async ({ page }) => {
+      await expect(page.getByText(/0/).first()).toBeVisible();
+      await expect(page.getByText(/\/\s*6/).first()).toBeVisible();
+    });
+
+    test("dismiss button hides the card for that property", async ({ page }) => {
+      const cards = page.getByText(/complete your property baseline/i);
+      const firstCard = cards.first();
+      await expect(firstCard).toBeVisible();
+      // Click dismiss on the first card's parent
+      await firstCard.locator("..").locator("..").getByRole("button", { name: /dismiss/i }).click();
+      await expect(page.getByText(/complete your property baseline/i).first()).not.toBeVisible({ timeout: 3000 }).catch(() => {
+        // If second property card still shows, that's expected — just verify first is gone
+      });
+    });
+  });
+
+  test.describe("baseline prompt — all 6 photos present", () => {
+    test.beforeEach(async ({ page }) => {
+      await injectBaselinePhotos(page, {
+        "1": ["hvac", "waterHeater", "electrical", "shutoff", "roof", "garageDoor"],
+        "2": ["hvac", "waterHeater", "electrical", "shutoff", "roof", "garageDoor"],
+      });
+      await setup(page);
+      await page.goto("/dashboard");
+      await expect(page.getByRole("heading", { name: "Dashboard" })).toBeVisible();
+    });
+
+    test("shows 'Baseline photos complete' badge when all 6 are captured", async ({ page }) => {
+      await expect(page.getByText(/baseline photos complete/i).first()).toBeVisible();
+    });
+
+    test("does not show the checklist card when all 6 are captured", async ({ page }) => {
+      await expect(page.getByText(/complete your property baseline/i)).not.toBeVisible();
+    });
   });
 });

--- a/tests/e2e/dashboard.spec.ts
+++ b/tests/e2e/dashboard.spec.ts
@@ -159,7 +159,8 @@ test.describe("DashboardPage — /dashboard", () => {
 
   test.describe("baseline prompt — zero photos", () => {
     test.beforeEach(async ({ page }) => {
-      // No __e2e_baseline_photos injected → getByJob returns [] for all properties
+      // Inject empty arrays so getByJob returns [] without hitting the canister
+      await injectBaselinePhotos(page, { "1": [], "2": [] });
       await setup(page);
       await page.goto("/dashboard");
       await expect(page.getByRole("heading", { name: "Dashboard" })).toBeVisible();

--- a/tests/e2e/helpers/testData.ts
+++ b/tests/e2e/helpers/testData.ts
@@ -301,6 +301,39 @@ export async function injectFsboPhotos(page: Page, propertyId: string = "1") {
 }
 
 /**
+ * Injects mock baseline photos into window.__e2e_baseline_photos.
+ * photoService.getByJob() checks this map (keyed by jobId = "baseline_<propertyId>")
+ * before making canister calls.
+ *
+ * Pass an array of system keys already photographed for each property.
+ * All 6 keys: "hvac" | "waterHeater" | "electrical" | "shutoff" | "roof" | "garageDoor"
+ */
+export async function injectBaselinePhotos(
+  page: Page,
+  byProperty: Record<string, string[]>   // { propertyId: systemKey[] }
+) {
+  await page.addInitScript((map: Record<string, string[]>) => {
+    const FAKE_URL = "data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==";
+    const result: Record<string, object[]> = {};
+    for (const [pid, keys] of Object.entries(map)) {
+      result[`baseline_${pid}`] = keys.map((k, i) => ({
+        id:          `bp_${pid}_${k}`,
+        jobId:       `baseline_${pid}`,
+        propertyId:  pid,
+        phase:       "PostConstruction",
+        description: k,
+        hash:        `hash_${k}`,
+        url:         FAKE_URL,
+        size:        128,
+        verified:    false,
+        createdAt:   Date.now() - i * 1000,
+      }));
+    }
+    (window as any).__e2e_baseline_photos = result;
+  }, byProperty);
+}
+
+/**
  * Injects a mock return value for propertyService.registerProperty().
  * Without this, the onboarding wizard's step 2→3 transition calls the canister
  * and fails in E2E (no replica running).  The injected property is returned

--- a/tests/e2e/onboarding.spec.ts
+++ b/tests/e2e/onboarding.spec.ts
@@ -241,7 +241,9 @@ test.describe("OnboardingWizard — /onboarding", () => {
     test.beforeEach(async ({ page }) => {
       await injectTestAuth(page);
       await injectRegisterProperty(page);
-      // No injectSkipBaseline — we want the baseline step to render
+      // The outer beforeEach adds __e2e_skipBaselinePhotos via addInitScript; that
+      // script persists across navigations. Override it here so step 3 actually renders.
+      await page.addInitScript(() => { delete (window as any).__e2e_skipBaselinePhotos; });
       await page.goto("/onboarding");
       await expect(page.getByText(/step 1 of 6/i)).toBeVisible();
       await page.getByLabel(/street address/i).fill("100 Onboarding Lane");
@@ -260,17 +262,17 @@ test.describe("OnboardingWizard — /onboarding", () => {
     });
 
     test("shows all 6 baseline system categories", async ({ page }) => {
-      await expect(page.getByText(/HVAC/i)).toBeVisible();
-      await expect(page.getByText(/Water Heater/i)).toBeVisible();
-      await expect(page.getByText(/Electrical Panel/i)).toBeVisible();
-      await expect(page.getByText(/Water Shut-off/i)).toBeVisible();
-      await expect(page.getByText(/Roof/i)).toBeVisible();
-      await expect(page.getByText(/Garage Door/i)).toBeVisible();
+      await expect(page.getByText(/HVAC/i).first()).toBeVisible();
+      await expect(page.getByText(/Water Heater/i).first()).toBeVisible();
+      await expect(page.getByText(/Electrical Panel/i).first()).toBeVisible();
+      await expect(page.getByText(/Water Shut-off/i).first()).toBeVisible();
+      await expect(page.getByText(/Roof/i).first()).toBeVisible();
+      await expect(page.getByText(/Garage Door/i).first()).toBeVisible();
     });
 
     test("shows progress count '0 / 6'", async ({ page }) => {
-      await expect(page.getByText(/0/)).toBeVisible();
-      await expect(page.getByText(/6/)).toBeVisible();
+      // Progress counter renders as "0 / 6" — match the fraction span
+      await expect(page.getByText(/\/\s*6/).first()).toBeVisible();
     });
 
     test("Next advances to step 4 without uploading anything", async ({ page }) => {


### PR DESCRIPTION
- Add BaselinePromptCard component: per-property checklist of the 6 core home systems (HVAC, Water Heater, Electrical Panel, Shut-off Valve, Roof, Garage Door) with inline file upload and per-system progress tracking
- Card is dismissible per-property (localStorage key per propertyId); auto-hides to a "Baseline complete ✓" badge once all 6 are captured
- Wire card into DashboardPage My Properties section (renders after the property grid, one card per property)
- Extend useDashboardDismissals with dismissedBaselinePrompts / dismissBaselinePrompt(propertyId)
- Add __e2e_baseline_photos mock hook to photoService.getByJob so E2E tests can inject photo state without a running canister
- Add injectBaselinePhotos helper in tests/e2e/helpers/testData.ts
- Add baseline prompt E2E tests to dashboard.spec.ts (zero-photos → card visible; all-6 → badge visible, checklist hidden)
- Fix pre-existing E2E regression: outer beforeEach's addInitScript for __e2e_skipBaselinePhotos persisted across navigations into the nested "step 3" describe; inner beforeEach now explicitly deletes the flag
- Fix overly broad getByText(/0/) and /Water Heater/ E2E assertions

## Summary
<!-- What does this PR do? -->

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [ ] Backend tests pass (`make test`)
- [ ] Frontend builds (`cd frontend && npm run build`)
- [ ] Tested locally with dfx

## Checklist
- [ ] Code follows project conventions
- [ ] Self-review completed
- [ ] No sensitive data committed
