### PR TITLE
feat(sensor): expand IoT device sources from 4 to 12 (#161)

### DIFF
--- a/frontend/src/__tests__/contracts/__snapshots__/candid.contract.test.ts.snap
+++ b/frontend/src/__tests__/contracts/__snapshots__/candid.contract.test.ts.snap
@@ -1428,7 +1428,7 @@ exports[`sensor IDL factory > full signature snapshot 1`] = `
       "query",
     ],
     "rets": [
-      "vec record {id:text; externalDeviceId:text; source:variant {Nest; MoenFlo; Ecobee; Manual}; name:text; propertyId:text; isActive:bool; homeowner:principal; registeredAt:int}",
+      "vec record {id:text; externalDeviceId:text; source:variant {Sense; Nest; HomeAssistant; MoenFlo; HoneywellHome; SmartThings; RheemEcoNet; RingAlarm; Ecobee; Rachio; Manual; EmporiaVue}; name:text; propertyId:text; isActive:bool; homeowner:principal; registeredAt:int}",
     ],
   },
   "getEventsForProperty": {
@@ -1471,12 +1471,12 @@ exports[`sensor IDL factory > full signature snapshot 1`] = `
     "args": [
       "text",
       "text",
-      "variant {Nest; MoenFlo; Ecobee; Manual}",
+      "variant {Sense; Nest; HomeAssistant; MoenFlo; HoneywellHome; SmartThings; RheemEcoNet; RingAlarm; Ecobee; Rachio; Manual; EmporiaVue}",
       "text",
     ],
     "mode": [],
     "rets": [
-      "variant {ok:record {id:text; externalDeviceId:text; source:variant {Nest; MoenFlo; Ecobee; Manual}; name:text; propertyId:text; isActive:bool; homeowner:principal; registeredAt:int}; err:variant {InvalidInput:text; NotFound; Unauthorized; AlreadyExists}}",
+      "variant {ok:record {id:text; externalDeviceId:text; source:variant {Sense; Nest; HomeAssistant; MoenFlo; HoneywellHome; SmartThings; RheemEcoNet; RingAlarm; Ecobee; Rachio; Manual; EmporiaVue}; name:text; propertyId:text; isActive:bool; homeowner:principal; registeredAt:int}; err:variant {InvalidInput:text; NotFound; Unauthorized; AlreadyExists}}",
     ],
   },
 }

--- a/frontend/src/__tests__/services/sensor.test.ts
+++ b/frontend/src/__tests__/services/sensor.test.ts
@@ -230,8 +230,12 @@ describe("sensorService mock path", () => {
       expect(device.registeredAt).toBeLessThanOrEqual(after);
     });
 
-    it("accepts all four DeviceSource values", async () => {
-      const sources = ["Nest", "Ecobee", "MoenFlo", "Manual"] as const;
+    it("accepts all twelve DeviceSource values", async () => {
+      const sources = [
+        "Nest", "Ecobee", "MoenFlo", "Manual",
+        "RingAlarm", "HoneywellHome", "RheemEcoNet", "Sense",
+        "EmporiaVue", "Rachio", "SmartThings", "HomeAssistant",
+      ] as const;
       for (const source of sources) {
         const d = await sensorService.registerDevice("p", "e", source, "Dev");
         expect(d.source).toBe(source);
@@ -327,11 +331,13 @@ describe("sensorService mock path", () => {
 // ─── DeviceSource type coverage ───────────────────────────────────────────────
 
 describe("DeviceSource values", () => {
-  it("SOURCES list covers all four platform values", async () => {
-    // We import the type — if the type changes, the test below would need updating.
-    // This test documents the expected set.
-    const expected = new Set(["Nest", "Ecobee", "MoenFlo", "Manual"]);
-    expect(expected.size).toBe(4);
+  it("SOURCES list covers all twelve platform values", async () => {
+    const expected = new Set([
+      "Nest", "Ecobee", "MoenFlo", "Manual",
+      "RingAlarm", "HoneywellHome", "RheemEcoNet", "Sense",
+      "EmporiaVue", "Rachio", "SmartThings", "HomeAssistant",
+    ]);
+    expect(expected.size).toBe(12);
   });
 });
 

--- a/frontend/src/components/RegisterDeviceModal.tsx
+++ b/frontend/src/components/RegisterDeviceModal.tsx
@@ -16,10 +16,18 @@ const UI = {
 };
 
 const SOURCES: { value: DeviceSource; label: string }[] = [
-  { value: "Nest",    label: "Google Nest"  },
-  { value: "Ecobee",  label: "Ecobee"       },
-  { value: "MoenFlo", label: "Moen Flo"     },
-  { value: "Manual",  label: "Manual Entry" },
+  { value: "Nest",          label: "Google Nest"             },
+  { value: "Ecobee",        label: "Ecobee"                  },
+  { value: "MoenFlo",       label: "Moen Flo"                },
+  { value: "RingAlarm",     label: "Ring Alarm"              },
+  { value: "HoneywellHome", label: "Honeywell Home"          },
+  { value: "RheemEcoNet",   label: "Rheem EcoNet"            },
+  { value: "Sense",         label: "Sense Energy Monitor"    },
+  { value: "EmporiaVue",    label: "Emporia Vue"             },
+  { value: "Rachio",        label: "Rachio Smart Sprinkler"  },
+  { value: "SmartThings",   label: "Samsung SmartThings"     },
+  { value: "HomeAssistant", label: "Home Assistant"          },
+  { value: "Manual",        label: "Manual Entry"            },
 ];
 
 const BLANK = {

--- a/frontend/src/components/RegisterDeviceModal.tsx
+++ b/frontend/src/components/RegisterDeviceModal.tsx
@@ -125,8 +125,8 @@ export function RegisterDeviceModal({ isOpen, onClose, onSuccess, propertyId }: 
         <form onSubmit={handleSubmit} style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
           {/* Source */}
           <div>
-            <label style={labelStyle}>Device Type</label>
-            <select value={form.source} onChange={set("source")} style={inputStyle}>
+            <label htmlFor="register-device-source" style={labelStyle}>Device Type</label>
+            <select id="register-device-source" value={form.source} onChange={set("source")} style={inputStyle}>
               {SOURCES.map((s) => (
                 <option key={s.value} value={s.value}>{s.label}</option>
               ))}

--- a/frontend/src/pages/SensorPage.tsx
+++ b/frontend/src/pages/SensorPage.tsx
@@ -27,10 +27,18 @@ const UI = {
 };
 
 const SOURCES: { value: string; label: string }[] = [
-  { value: "Nest",    label: "Google Nest"  },
-  { value: "Ecobee",  label: "Ecobee"       },
-  { value: "MoenFlo", label: "Moen Flo"     },
-  { value: "Manual",  label: "Manual Entry" },
+  { value: "Nest",          label: "Google Nest"             },
+  { value: "Ecobee",        label: "Ecobee"                  },
+  { value: "MoenFlo",       label: "Moen Flo"                },
+  { value: "RingAlarm",     label: "Ring Alarm"              },
+  { value: "HoneywellHome", label: "Honeywell Home"          },
+  { value: "RheemEcoNet",   label: "Rheem EcoNet"            },
+  { value: "Sense",         label: "Sense Energy Monitor"    },
+  { value: "EmporiaVue",    label: "Emporia Vue"             },
+  { value: "Rachio",        label: "Rachio Smart Sprinkler"  },
+  { value: "SmartThings",   label: "Samsung SmartThings"     },
+  { value: "HomeAssistant", label: "Home Assistant"          },
+  { value: "Manual",        label: "Manual Entry"            },
 ];
 
 export default function SensorPage() {
@@ -182,7 +190,7 @@ export default function SensorPage() {
               <Wifi size={36} color={UI.rule} style={{ margin: "0 auto 1rem" }} />
               <p style={{ fontFamily: UI.serif, fontWeight: 700, marginBottom: "0.375rem" }}>No devices registered</p>
               <p style={{ fontFamily: UI.mono, fontSize: "0.65rem", letterSpacing: "0.06em", color: UI.inkLight, marginBottom: "1.25rem" }}>
-                Connect a Nest, Ecobee, or Moen Flo device to automatically log critical home events.
+                Connect a Nest, Ecobee, Moen Flo, Ring Alarm, Honeywell Home, or other smart device to automatically log critical home events.
               </p>
               <Button icon={<Plus size={14} />} onClick={() => setModalOpen(true)}>
                 Register Your First Device
@@ -228,9 +236,10 @@ export default function SensorPage() {
             How it works
           </p>
           <p style={{ fontSize: "0.8rem", fontWeight: 300, lineHeight: 1.6, color: UI.inkLight }}>
-            Your IoT gateway forwards events from Nest, Ecobee, and Moen Flo to HomeGentic.
-            Critical events — water leaks, HVAC faults, pipe-freeze risk — automatically open a pending job
-            on your property record so nothing falls through the cracks.
+            Your IoT gateway forwards events from Nest, Ecobee, Moen Flo, Ring Alarm, Honeywell Home,
+            Rheem EcoNet, Sense, Emporia Vue, Rachio, Samsung SmartThings, Home Assistant, and manually
+            entered devices to HomeGentic. Critical events — water leaks, HVAC faults, pipe-freeze risk —
+            automatically open a pending job on your property record so nothing falls through the cracks.
           </p>
         </div>
 

--- a/frontend/src/pages/SensorPage.tsx
+++ b/frontend/src/pages/SensorPage.tsx
@@ -7,6 +7,7 @@ import { Badge } from "@/components/Badge";
 import { RegisterDeviceModal } from "@/components/RegisterDeviceModal";
 import { usePropertyStore } from "@/store/propertyStore";
 import { sensorService, SensorDevice, SensorEvent } from "@/services/sensor";
+import { propertyService } from "@/services/property";
 import toast from "react-hot-toast";
 import { COLORS, FONTS, RADIUS, SHADOWS } from "@/theme";
 
@@ -43,12 +44,21 @@ const SOURCES: { value: string; label: string }[] = [
 
 export default function SensorPage() {
   const navigate = useNavigate();
-  const { properties } = usePropertyStore();
+  const { properties, setProperties } = usePropertyStore();
   const [selectedPropertyId, setSelectedPropertyId] = useState<string>("");
   const [devices,       setDevices]       = useState<SensorDevice[]>([]);
   const [alerts,        setAlerts]        = useState<SensorEvent[]>([]);
   const [loading,       setLoading]       = useState(false);
   const [modalOpen,     setModalOpen]     = useState(false);
+
+  // Seed the property store when navigating directly to this page
+  useEffect(() => {
+    if (properties.length === 0) {
+      propertyService.getMyProperties()
+        .then((list) => { if (list.length > 0) setProperties(list); })
+        .catch((e) => console.error("[SensorPage] property load failed:", e));
+    }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Pick the first property by default
   useEffect(() => {

--- a/frontend/src/services/sensor.ts
+++ b/frontend/src/services/sensor.ts
@@ -7,7 +7,12 @@ const SENSOR_CANISTER_ID = (process.env as any).SENSOR_CANISTER_ID || "";
 
 export const idlFactory = ({ IDL }: any) => {
   const DeviceSource = IDL.Variant({
-    Nest: IDL.Null, Ecobee: IDL.Null, MoenFlo: IDL.Null, Manual: IDL.Null,
+    Nest:          IDL.Null, Ecobee:        IDL.Null,
+    MoenFlo:       IDL.Null, Manual:        IDL.Null,
+    RingAlarm:     IDL.Null, HoneywellHome: IDL.Null,
+    RheemEcoNet:   IDL.Null, Sense:         IDL.Null,
+    EmporiaVue:    IDL.Null, Rachio:        IDL.Null,
+    SmartThings:   IDL.Null, HomeAssistant: IDL.Null,
   });
   const SensorEventType = IDL.Variant({
     WaterLeak:       IDL.Null,
@@ -73,7 +78,10 @@ export const idlFactory = ({ IDL }: any) => {
 
 // ─── TypeScript types ─────────────────────────────────────────────────────────
 
-export type DeviceSource = "Nest" | "Ecobee" | "MoenFlo" | "Manual";
+export type DeviceSource =
+  | "Nest" | "Ecobee" | "MoenFlo" | "Manual"
+  | "RingAlarm" | "HoneywellHome" | "RheemEcoNet" | "Sense"
+  | "EmporiaVue" | "Rachio" | "SmartThings" | "HomeAssistant";
 export type SensorEventType =
   | "WaterLeak" | "LeakDetected" | "FloodRisk"
   | "LowTemperature" | "HvacAlert" | "HvacFilterDue"
@@ -172,6 +180,10 @@ function createSensorService() {
   },
 
   async getDevicesForProperty(propertyId: string): Promise<SensorDevice[]> {
+    if (typeof window !== "undefined" && (window as any).__e2e_devices) {
+      const map = (window as any).__e2e_devices as Record<string, SensorDevice[]>;
+      return map[propertyId] ?? [];
+    }
     const a = await getActor();
     return (await a.getDevicesForProperty(propertyId) as any[]).map(fromDevice);
   },
@@ -182,6 +194,10 @@ function createSensorService() {
   },
 
   async getPendingAlerts(propertyId: string): Promise<SensorEvent[]> {
+    if (typeof window !== "undefined" && (window as any).__e2e_alerts) {
+      const map = (window as any).__e2e_alerts as Record<string, SensorEvent[]>;
+      return map[propertyId] ?? [];
+    }
     const a = await getActor();
     return (await a.getPendingAlerts(propertyId) as any[]).map(fromEvent);
   },

--- a/tests/e2e/helpers/testData.ts
+++ b/tests/e2e/helpers/testData.ts
@@ -301,6 +301,38 @@ export async function injectFsboPhotos(page: Page, propertyId: string = "1") {
 }
 
 /**
+ * Injects mock sensor devices into window.__e2e_devices (keyed by propertyId)
+ * and mock pending alerts into window.__e2e_alerts (keyed by propertyId).
+ * sensorService.getDevicesForProperty() and getPendingAlerts() check these
+ * maps before making canister calls.
+ */
+export async function injectSensorDevices(
+  page: Page,
+  devicesByProperty: Record<string, Array<{
+    id: string; externalDeviceId: string; source: string; name: string; isActive: boolean;
+  }>>
+) {
+  await page.addInitScript((map: Record<string, any[]>) => {
+    const now = Date.now();
+    const result: Record<string, object[]> = {};
+    for (const [pid, devices] of Object.entries(map)) {
+      result[pid] = devices.map((d) => ({
+        id:               d.id,
+        propertyId:       pid,
+        homeowner:        "test-e2e-principal",
+        externalDeviceId: d.externalDeviceId,
+        source:           d.source,
+        name:             d.name,
+        registeredAt:     now - 86_400_000,
+        isActive:         d.isActive,
+      }));
+    }
+    (window as any).__e2e_devices = result;
+    (window as any).__e2e_alerts  = {};   // no pending alerts by default
+  }, devicesByProperty);
+}
+
+/**
  * Injects mock baseline photos into window.__e2e_baseline_photos.
  * photoService.getByJob() checks this map (keyed by jobId = "baseline_<propertyId>")
  * before making canister calls.

--- a/tests/e2e/sensor.spec.ts
+++ b/tests/e2e/sensor.spec.ts
@@ -1,0 +1,163 @@
+import { test, expect } from "@playwright/test";
+import { injectTestAuth } from "./helpers/auth";
+import { injectSensorDevices } from "./helpers/testData";
+
+async function setup(page: Parameters<typeof injectTestAuth>[0]) {
+  await injectTestAuth(page);
+  await page.addInitScript(() => {
+    (window as any).__e2e_subscription = { tier: "Pro", expiresAt: null };
+    (window as any).__e2e_properties = [
+      {
+        id: 1, owner: "test-e2e-principal",
+        address: "123 Maple Street", city: "Austin", state: "TX", zipCode: "78701",
+        propertyType: "SingleFamily", yearBuilt: 2001, squareFeet: 2400,
+        verificationLevel: "Unverified", tier: "Pro",
+        createdAt: 0, updatedAt: 0, isActive: true,
+      },
+    ];
+  });
+}
+
+test.describe("SensorPage — /sensor", () => {
+  test.beforeEach(async ({ page }) => {
+    await injectSensorDevices(page, { "1": [] });
+    await setup(page);
+    await page.goto("/sensor");
+    await expect(page.getByRole("heading", { name: /smart home sensors/i })).toBeVisible();
+  });
+
+  // ── Page structure ───────────────────────────────────────────────────────────
+
+  test("shows 'IoT Gateway' eyebrow label", async ({ page }) => {
+    await expect(page.getByText("IoT Gateway")).toBeVisible();
+  });
+
+  test("shows 'Register Device' button", async ({ page }) => {
+    await expect(page.getByRole("button", { name: /register device/i }).first()).toBeVisible();
+  });
+
+  test("shows empty state when no devices registered", async ({ page }) => {
+    await expect(page.getByText(/no devices registered/i)).toBeVisible();
+  });
+
+  // ── Register Device modal — source dropdown ──────────────────────────────────
+
+  test.describe("Register Device modal", () => {
+    test.beforeEach(async ({ page }) => {
+      await page.getByRole("button", { name: /register device/i }).first().click();
+      await expect(page.getByRole("heading", { name: /register device/i })).toBeVisible();
+    });
+
+    test("shows Device Type selector", async ({ page }) => {
+      await expect(page.getByLabel(/device type/i)).toBeVisible();
+    });
+
+    test("dropdown includes Google Nest", async ({ page }) => {
+      await expect(page.getByLabel(/device type/i).locator("option", { hasText: /google nest/i })).toHaveCount(1);
+    });
+
+    test("dropdown includes Ecobee", async ({ page }) => {
+      await expect(page.getByLabel(/device type/i).locator("option", { hasText: /ecobee/i })).toHaveCount(1);
+    });
+
+    test("dropdown includes Moen Flo", async ({ page }) => {
+      await expect(page.getByLabel(/device type/i).locator("option", { hasText: /moen flo/i })).toHaveCount(1);
+    });
+
+    test("dropdown includes Ring Alarm", async ({ page }) => {
+      await expect(page.getByLabel(/device type/i).locator("option", { hasText: /ring alarm/i })).toHaveCount(1);
+    });
+
+    test("dropdown includes Honeywell Home", async ({ page }) => {
+      await expect(page.getByLabel(/device type/i).locator("option", { hasText: /honeywell home/i })).toHaveCount(1);
+    });
+
+    test("dropdown includes Rheem EcoNet", async ({ page }) => {
+      await expect(page.getByLabel(/device type/i).locator("option", { hasText: /rheem econet/i })).toHaveCount(1);
+    });
+
+    test("dropdown includes Sense Energy Monitor", async ({ page }) => {
+      await expect(page.getByLabel(/device type/i).locator("option", { hasText: /sense energy/i })).toHaveCount(1);
+    });
+
+    test("dropdown includes Emporia Vue", async ({ page }) => {
+      await expect(page.getByLabel(/device type/i).locator("option", { hasText: /emporia vue/i })).toHaveCount(1);
+    });
+
+    test("dropdown includes Rachio Smart Sprinkler", async ({ page }) => {
+      await expect(page.getByLabel(/device type/i).locator("option", { hasText: /rachio/i })).toHaveCount(1);
+    });
+
+    test("dropdown includes Samsung SmartThings", async ({ page }) => {
+      await expect(page.getByLabel(/device type/i).locator("option", { hasText: /smartthings/i })).toHaveCount(1);
+    });
+
+    test("dropdown includes Home Assistant", async ({ page }) => {
+      await expect(page.getByLabel(/device type/i).locator("option", { hasText: /home assistant/i })).toHaveCount(1);
+    });
+
+    test("dropdown includes Manual Entry", async ({ page }) => {
+      await expect(page.getByLabel(/device type/i).locator("option", { hasText: /manual entry/i })).toHaveCount(1);
+    });
+
+    test("dropdown has 12 source options in total", async ({ page }) => {
+      const options = page.getByLabel(/device type/i).locator("option");
+      await expect(options).toHaveCount(12);
+    });
+
+    test("Cancel button closes the modal", async ({ page }) => {
+      await page.getByRole("button", { name: /cancel/i }).click();
+      await expect(page.getByRole("heading", { name: /register device/i })).not.toBeVisible();
+    });
+  });
+
+  // ── Pre-registered devices with new sources ──────────────────────────────────
+
+  test.describe("device list — new source labels", () => {
+    test.beforeEach(async ({ page }) => {
+      await injectSensorDevices(page, {
+        "1": [
+          { id: "d1", externalDeviceId: "RING-001", source: "RingAlarm",     name: "Front Door Sensor", isActive: true  },
+          { id: "d2", externalDeviceId: "HW-002",   source: "HoneywellHome", name: "Thermostat",        isActive: true  },
+          { id: "d3", externalDeviceId: "HA-003",   source: "HomeAssistant", name: "Hub",               isActive: false },
+        ],
+      });
+      await setup(page);
+      await page.goto("/sensor");
+      await expect(page.getByRole("heading", { name: /smart home sensors/i })).toBeVisible();
+    });
+
+    test("shows device name for RingAlarm device", async ({ page }) => {
+      await expect(page.getByText("Front Door Sensor")).toBeVisible();
+    });
+
+    test("shows 'Ring Alarm' label for RingAlarm source", async ({ page }) => {
+      await expect(page.getByText(/ring alarm/i).first()).toBeVisible();
+    });
+
+    test("shows device name for HoneywellHome device", async ({ page }) => {
+      await expect(page.getByText("Thermostat")).toBeVisible();
+    });
+
+    test("shows 'Honeywell Home' label for HoneywellHome source", async ({ page }) => {
+      await expect(page.getByText(/honeywell home/i).first()).toBeVisible();
+    });
+
+    test("shows device name for HomeAssistant device", async ({ page }) => {
+      await expect(page.getByText("Hub")).toBeVisible();
+    });
+
+    test("shows 'Home Assistant' label for HomeAssistant source", async ({ page }) => {
+      await expect(page.getByText(/home assistant/i).first()).toBeVisible();
+    });
+
+    test("shows Active badge for active device", async ({ page }) => {
+      // At least one Active badge rendered for the two active devices
+      await expect(page.getByText("Active").first()).toBeVisible();
+    });
+
+    test("shows Inactive badge for deactivated device", async ({ page }) => {
+      await expect(page.getByText("Inactive").first()).toBeVisible();
+    });
+  });
+});

--- a/tests/e2e/sensor.spec.ts
+++ b/tests/e2e/sensor.spec.ts
@@ -29,7 +29,7 @@ test.describe("SensorPage — /sensor", () => {
   // ── Page structure ───────────────────────────────────────────────────────────
 
   test("shows 'IoT Gateway' eyebrow label", async ({ page }) => {
-    await expect(page.getByText("IoT Gateway")).toBeVisible();
+    await expect(page.getByText("IoT Gateway", { exact: true })).toBeVisible();
   });
 
   test("shows 'Register Device' button", async ({ page }) => {
@@ -131,33 +131,33 @@ test.describe("SensorPage — /sensor", () => {
       await expect(page.getByText("Front Door Sensor")).toBeVisible();
     });
 
-    test("shows 'Ring Alarm' label for RingAlarm source", async ({ page }) => {
-      await expect(page.getByText(/ring alarm/i).first()).toBeVisible();
+    test("shows 'Ring Alarm' source label for RingAlarm device", async ({ page }) => {
+      // Source label rendered as "Ring Alarm · RING-001"
+      await expect(page.getByText(/ring alarm.*ring-001/i)).toBeVisible();
     });
 
     test("shows device name for HoneywellHome device", async ({ page }) => {
       await expect(page.getByText("Thermostat")).toBeVisible();
     });
 
-    test("shows 'Honeywell Home' label for HoneywellHome source", async ({ page }) => {
-      await expect(page.getByText(/honeywell home/i).first()).toBeVisible();
+    test("shows 'Honeywell Home' source label for HoneywellHome device", async ({ page }) => {
+      await expect(page.getByText(/honeywell home.*hw-002/i)).toBeVisible();
     });
 
     test("shows device name for HomeAssistant device", async ({ page }) => {
       await expect(page.getByText("Hub")).toBeVisible();
     });
 
-    test("shows 'Home Assistant' label for HomeAssistant source", async ({ page }) => {
-      await expect(page.getByText(/home assistant/i).first()).toBeVisible();
+    test("shows 'Home Assistant' source label for HomeAssistant device", async ({ page }) => {
+      await expect(page.getByText(/home assistant.*ha-003/i)).toBeVisible();
     });
 
-    test("shows Active badge for active device", async ({ page }) => {
-      // At least one Active badge rendered for the two active devices
+    test("shows Active badge for active devices", async ({ page }) => {
       await expect(page.getByText("Active").first()).toBeVisible();
     });
 
     test("shows Inactive badge for deactivated device", async ({ page }) => {
-      await expect(page.getByText("Inactive").first()).toBeVisible();
+      await expect(page.getByText("Inactive")).toBeVisible();
     });
   });
 });

--- a/tests/e2e/sensor.spec.ts
+++ b/tests/e2e/sensor.spec.ts
@@ -22,7 +22,7 @@ test.describe("SensorPage — /sensor", () => {
   test.beforeEach(async ({ page }) => {
     await injectSensorDevices(page, { "1": [] });
     await setup(page);
-    await page.goto("/sensor");
+    await page.goto("/sensors");
     await expect(page.getByRole("heading", { name: /smart home sensors/i })).toBeVisible();
   });
 
@@ -123,7 +123,7 @@ test.describe("SensorPage — /sensor", () => {
         ],
       });
       await setup(page);
-      await page.goto("/sensor");
+      await page.goto("/sensors");
       await expect(page.getByRole("heading", { name: /smart home sensors/i })).toBeVisible();
     });
 


### PR DESCRIPTION
Adds Ring Alarm, Honeywell Home, Rheem EcoNet, Sense Energy Monitor, Emporia Vue, Rachio Smart Sprinkler, Samsung SmartThings, and Home Assistant as supported device sources alongside the existing Nest, Ecobee, Moen Flo, and Manual options. Updates IDL variant, TypeScript type, both SOURCES constants, and adds E2E coverage for the new sources.

## Summary
<!-- What does this PR do? -->

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [ ] Backend tests pass (`make test`)
- [ ] Frontend builds (`cd frontend && npm run build`)
- [ ] Tested locally with dfx

## Checklist
- [ ] Code follows project conventions
- [ ] Self-review completed
- [ ] No sensitive data committed
