### PR TITLE
fix(e2e): add canister guard to contractorService.getContractor

### DIFF
--- a/frontend/src/services/contractor.ts
+++ b/frontend/src/services/contractor.ts
@@ -229,6 +229,11 @@ function createContractorService() {
   },
 
   async getContractor(principalText: string): Promise<ContractorProfile | null> {
+    if (typeof window !== "undefined" && (window as any).__e2e_contractors) {
+      const all = (window as any).__e2e_contractors as ContractorProfile[];
+      return all.find((c) => c.id === principalText) ?? null;
+    }
+    if (!CONTRACTOR_CANISTER_ID) return null;
     const a = await getActor();
     const { Principal: P } = await import("@icp-sdk/core/principal");
     const result = await a.getContractor(P.fromText(principalText));


### PR DESCRIPTION
getContractor was the only method in contractorService without a CONTRACTOR_CANISTER_ID early-return guard.  In E2E mock mode (no replica), it called getActor() which invoked HttpAgent.create() with shouldFetchRootKey:true and attempted to connect to localhost:4943. This occasionally hung long enough to keep the QuoteDetailPage spinner visible for the entire 5 s assertion timeout, preventing the "Best Value" badge from ever rendering.

Add the same __e2e_contractors check and !CONTRACTOR_CANISTER_ID guard that every other method in the service already has.

## Summary
<!-- What does this PR do? -->

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [ ] Backend tests pass (`make test`)
- [ ] Frontend builds (`cd frontend && npm run build`)
- [ ] Tested locally with dfx

## Checklist
- [ ] Code follows project conventions
- [ ] Self-review completed
- [ ] No sensitive data committed
