### PR TITLE
fix(audit): address critical, high, and medium code quality findings

### DIFF
--- a/backend/agent/main.mo
+++ b/backend/agent/main.mo
@@ -372,7 +372,9 @@ persistent actor Agent {
 
   public shared(msg) func addAdmin(newAdmin: Principal) : async Result.Result<(), Error> {
     if (adminInitialized and not isAdmin(msg.caller)) return #err(#Unauthorized);
-    adminListEntries := Array.concat(adminListEntries, [newAdmin]);
+    if (not isAdmin(newAdmin)) {
+      adminListEntries := Array.concat(adminListEntries, [newAdmin]);
+    };
     adminInitialized := true;
     #ok(())
   };

--- a/backend/ai_proxy/main.mo
+++ b/backend/ai_proxy/main.mo
@@ -716,7 +716,9 @@ persistent actor AiProxy {
 
   public shared(msg) func addAdmin(newAdmin: Principal) : async Result.Result<(), Error> {
     if (adminInitialized and not isAdmin(msg.caller)) return #err(#Unauthorized);
-    adminListEntries := Array.concat(adminListEntries, [newAdmin]);
+    if (not isAdmin(newAdmin)) {
+      adminListEntries := Array.concat(adminListEntries, [newAdmin]);
+    };
     adminInitialized := true;
     #ok(())
   };

--- a/backend/bills/main.mo
+++ b/backend/bills/main.mo
@@ -387,7 +387,9 @@ persistent actor Bills {
 
   public shared(msg) func addAdmin(newAdmin: Principal) : async Result.Result<(), Error> {
     if (adminInitialized and not isAdmin(msg.caller)) return #err(#Unauthorized);
-    adminListEntries := Array.concat(adminListEntries, [newAdmin]);
+    if (not isAdmin(newAdmin)) {
+      adminListEntries := Array.concat(adminListEntries, [newAdmin]);
+    };
     adminInitialized := true;
     #ok(())
   };

--- a/backend/job/main.mo
+++ b/backend/job/main.mo
@@ -502,11 +502,16 @@ persistent actor Job {
                 case (#Windows)     { "Windows"     };
                 case (#Landscaping) { "Landscaping" };
               };
-              let contrActor = actor(contrCanisterId) : actor {
-                recordJobVerified : (Principal, Text, Text, Principal) -> async { #ok : (); #err : {} };
+              type ContrError = {
+                #NotFound; #AlreadyExists; #Unauthorized;
+                #Paused; #RateLimitExceeded; #InvalidInput : Text;
               };
-              // Await so rejections don't silently fail; job verification is already
-              // committed above — trust-score notification is best-effort.
+              let contrActor = actor(contrCanisterId) : actor {
+                recordJobVerified : (Principal, Text, Text, Principal) -> async { #ok : (); #err : ContrError };
+              };
+              // Await with try/catch so canister traps or network errors don't
+              // propagate. #err results (e.g. #Unauthorized) are valid values
+              // and are simply discarded — job verification is already committed.
               try {
                 ignore await contrActor.recordJobVerified(con, jobId, svcText, existing.homeowner);
               } catch (_e) {};

--- a/backend/job/main.mo
+++ b/backend/job/main.mo
@@ -505,7 +505,11 @@ persistent actor Job {
               let contrActor = actor(contrCanisterId) : actor {
                 recordJobVerified : (Principal, Text, Text, Principal) -> async { #ok : (); #err : {} };
               };
-              ignore contrActor.recordJobVerified(con, jobId, svcText, existing.homeowner);
+              // Await so rejections don't silently fail; job verification is already
+              // committed above — trust-score notification is best-effort.
+              try {
+                ignore await contrActor.recordJobVerified(con, jobId, svcText, existing.homeowner);
+              } catch (_e) {};
             };
             case null {};
           };
@@ -622,7 +626,9 @@ persistent actor Job {
 
   public shared(msg) func addAdmin(newAdmin: Principal) : async Result.Result<(), Error> {
     if (adminInitialized and not isAdmin(msg.caller)) return #err(#Unauthorized);
-    adminListEntries := Array.concat(adminListEntries, [newAdmin]);
+    if (not isAdmin(newAdmin)) {
+      adminListEntries := Array.concat(adminListEntries, [newAdmin]);
+    };
     adminInitialized := true;
     #ok(())
   };

--- a/backend/listing/main.mo
+++ b/backend/listing/main.mo
@@ -482,7 +482,9 @@ persistent actor Listing {
 
   public shared(msg) func addAdmin(newAdmin: Principal) : async Result.Result<(), Error> {
     if (adminInitialized and not isAdmin(msg.caller)) return #err(#Unauthorized);
-    adminListEntries := Array.concat(adminListEntries, [newAdmin]);
+    if (not isAdmin(newAdmin)) {
+      adminListEntries := Array.concat(adminListEntries, [newAdmin]);
+    };
     adminInitialized := true;
     #ok(())
   };

--- a/backend/maintenance/main.mo
+++ b/backend/maintenance/main.mo
@@ -388,7 +388,9 @@ persistent actor Maintenance {
   public shared(msg) func addAdmin(newAdmin: Principal) : async Result.Result<(), Error> {
     if (adminListEntries.size() > 0 and not isAdmin(msg.caller))
       return #err(#Unauthorized);
-    adminListEntries := Array.concat(adminListEntries, [newAdmin]);
+    if (not isAdmin(newAdmin)) {
+      adminListEntries := Array.concat(adminListEntries, [newAdmin]);
+    };
     #ok(())
   };
 

--- a/backend/market/main.mo
+++ b/backend/market/main.mo
@@ -741,7 +741,9 @@ persistent actor MarketIntelligence {
   public shared(msg) func addAdmin(newAdmin: Principal) : async Result.Result<(), Error> {
     if (adminListEntries.size() > 0 and not isAdmin(msg.caller))
       return #err(#Unauthorized);
-    adminListEntries := Array.concat(adminListEntries, [newAdmin]);
+    if (not isAdmin(newAdmin)) {
+      adminListEntries := Array.concat(adminListEntries, [newAdmin]);
+    };
     #ok(())
   };
 

--- a/backend/monitoring/main.mo
+++ b/backend/monitoring/main.mo
@@ -685,7 +685,9 @@ persistent actor Monitoring {
   public shared(msg) func addAdmin(newAdmin: Principal) : async Result.Result<(), Error> {
     if (adminListEntries.size() > 0 and not isAdmin(msg.caller))
       return #err(#Unauthorized);
-    adminListEntries := Array.concat(adminListEntries, [newAdmin]);
+    if (not isAdmin(newAdmin)) {
+      adminListEntries := Array.concat(adminListEntries, [newAdmin]);
+    };
     #ok(())
   };
 

--- a/backend/photo/main.mo
+++ b/backend/photo/main.mo
@@ -11,6 +11,7 @@ import Nat       "mo:core/Nat";
 import Option    "mo:core/Option";
 import Principal "mo:core/Principal";
 import Result    "mo:core/Result";
+import Runtime   "mo:core/Runtime";
 import Text      "mo:core/Text";
 import Time      "mo:core/Time";
 
@@ -155,16 +156,15 @@ persistent actor Photo {
   };
 
   /// Delegate property-ownership check to the property canister.
-  /// Falls back to direct principal comparison when propCanisterId is unset (local dev).
+  /// Traps if propCanisterId is unset — auth must never silently degrade.
   private func checkPropertyAuth(propertyId: Text, owner: Principal, caller: Principal, requireWrite: Bool) : async Bool {
-    if (Text.size(propCanisterId) > 0) {
-      let propActor = actor(propCanisterId) : actor {
-        isAuthorized : (Text, Principal, Bool) -> async Bool;
-      };
-      await propActor.isAuthorized(propertyId, caller, requireWrite)
-    } else {
-      caller == owner
-    }
+    if (Text.size(propCanisterId) == 0) {
+      Runtime.trap("photo: propCanisterId not configured — call setPropertyCanisterId first");
+    };
+    let propActor = actor(propCanisterId) : actor {
+      isAuthorized : (Text, Principal, Bool) -> async Bool;
+    };
+    await propActor.isAuthorized(propertyId, caller, requireWrite)
   };
 
   private func nextPhotoId() : Text {
@@ -513,7 +513,9 @@ persistent actor Photo {
   public shared(msg) func addAdmin(newAdmin: Principal) : async Result.Result<(), Error> {
     if (adminListEntries.size() > 0 and not isAdmin(msg.caller))
       return #err(#Unauthorized);
-    adminListEntries := Array.concat(adminListEntries, [newAdmin]);
+    if (not isAdmin(newAdmin)) {
+      adminListEntries := Array.concat(adminListEntries, [newAdmin]);
+    };
     #ok(())
   };
 

--- a/backend/property/main.mo
+++ b/backend/property/main.mo
@@ -385,6 +385,7 @@ persistent actor Property {
   // ─── Rate Limit (cycle-drain protection) ────────────────────────────────────
 
   private transient let updateCallLimits : Map.Map<Text, (Nat, Int)> = Map.empty();
+  private transient var rateLimitSweepTick : Nat = 0;
   /// Admin-adjustable rate limit — default 30/min.
   private var maxUpdatesPerMin : Nat = 30;
   private let ONE_MINUTE_NS       : Int = 60_000_000_000;
@@ -396,11 +397,24 @@ persistent actor Property {
     not Principal.isAnonymous(caller) and arg.size() > 0
   };
 
+  private func sweepRateLimits(now: Int) {
+    let stale = Iter.toArray(
+      Iter.filter(Map.keys(updateCallLimits), func(k: Text) : Bool {
+        switch (Map.get(updateCallLimits, Text.compare, k)) {
+          case (?(_, ws)) { now - ws >= ONE_MINUTE_NS };
+          case null       { false };
+        }
+      })
+    );
+    for (k in stale.vals()) { ignore Map.remove(updateCallLimits, Text.compare, k) };
+  };
 
   private func tryConsumeUpdateSlot(caller: Principal) : Bool {
     if (isAdmin(caller) or isTrustedCanister(caller)) return true;
     let key = Principal.toText(caller);
     let now = Time.now();
+    rateLimitSweepTick += 1;
+    if (rateLimitSweepTick >= 200) { rateLimitSweepTick := 0; sweepRateLimits(now) };
     switch (Map.get(updateCallLimits, Text.compare, key)) {
       case null { Map.add(updateCallLimits, Text.compare, key, (1, now)); true };
       case (?(count, windowStart)) {

--- a/backend/quote/main.mo
+++ b/backend/quote/main.mo
@@ -889,7 +889,9 @@ persistent actor Quote {
   public shared(msg) func addAdmin(newAdmin: Principal) : async Result.Result<(), Error> {
     if (adminListEntries.size() > 0 and not isAdmin(msg.caller))
       return #err(#Unauthorized);
-    adminListEntries := Array.concat(adminListEntries, [newAdmin]);
+    if (not isAdmin(newAdmin)) {
+      adminListEntries := Array.concat(adminListEntries, [newAdmin]);
+    };
     #ok(())
   };
 

--- a/backend/recurring/main.mo
+++ b/backend/recurring/main.mo
@@ -366,7 +366,9 @@ persistent actor Recurring {
 
   public shared(msg) func addAdmin(newAdmin: Principal) : async Result.Result<(), Error> {
     if (adminInitialized and not isAdmin(msg.caller)) return #err(#Unauthorized);
-    adminListEntries := Array.concat(adminListEntries, [newAdmin]);
+    if (not isAdmin(newAdmin)) {
+      adminListEntries := Array.concat(adminListEntries, [newAdmin]);
+    };
     adminInitialized := true;
     #ok(())
   };

--- a/backend/report/main.mo
+++ b/backend/report/main.mo
@@ -557,7 +557,9 @@ persistent actor Report {
 
   public shared(msg) func addAdmin(newAdmin: Principal) : async Result.Result<(), Error> {
     if (adminInitialized and not isAdmin(msg.caller)) return #err(#Unauthorized);
-    adminListEntries := Array.concat(adminListEntries, [newAdmin]);
+    if (not isAdmin(newAdmin)) {
+      adminListEntries := Array.concat(adminListEntries, [newAdmin]);
+    };
     adminInitialized := true;
     #ok(())
   };

--- a/backend/sensor/main.mo
+++ b/backend/sensor/main.mo
@@ -458,7 +458,9 @@ persistent actor Sensor {
   public shared(msg) func addAdmin(newAdmin: Principal) : async Result.Result<(), Error> {
     if (adminListEntries.size() > 0 and not isAdmin(msg.caller))
       return #err(#Unauthorized);
-    adminListEntries := Array.concat(adminListEntries, [newAdmin]);
+    if (not isAdmin(newAdmin)) {
+      adminListEntries := Array.concat(adminListEntries, [newAdmin]);
+    };
     #ok(())
   };
 

--- a/frontend/src/__tests__/security/fetchRootKey1445.test.ts
+++ b/frontend/src/__tests__/security/fetchRootKey1445.test.ts
@@ -1,13 +1,20 @@
 /**
  * TDD — 14.4.5: Verify fetchRootKey is never called in production
  *
- * shouldFetchRootKey: true is safe only in local dev — it disables certificate
- * verification and must never appear in production code paths.
+ * shouldFetchRootKey: true disables certificate verification and must never
+ * appear unconditionally in production code paths.
+ *
+ * getAgent() now fetches the root key explicitly with a 2 s timeout instead
+ * of relying on the shouldFetchRootKey flag, which caused hangs when no
+ * replica was reachable (E2E mock mode, CI without dfx).
  *
  * Checks:
- *  1. The production getAgent() path uses shouldFetchRootKey: IS_LOCAL (not true)
- *  2. Any occurrence of shouldFetchRootKey: true is inside a DEV-guarded block
- *  3. No file other than actor.ts uses fetchRootKey: true outside a DEV guard
+ *  1. getAgent() does NOT pass shouldFetchRootKey: true to HttpAgent.create()
+ *  2. getAgent() calls fetchRootKey() only inside an IS_LOCAL guard
+ *  3. The explicit fetchRootKey call has a timeout (prevents hangs in mock mode)
+ *  4. Any occurrence of shouldFetchRootKey: true is inside a DEV-guarded block
+ *  5. loginWithLocalIdentity() is hard-blocked in production
+ *  6. No other TS/TSX source file uses fetchRootKey: true outside actor.ts
  */
 
 import { describe, it, expect } from "vitest";
@@ -37,17 +44,28 @@ function walk(dir: string): string[] {
 describe("14.4.5: fetchRootKey production safety", () => {
   const actor = read("frontend/src/services/actor.ts");
 
-  it("production getAgent() uses shouldFetchRootKey: IS_LOCAL (not hardcoded true)", () => {
-    // Extract the getAgent function body (up to the first closing brace after its open)
+  it("getAgent() does not pass shouldFetchRootKey: true to HttpAgent.create()", () => {
+    // shouldFetchRootKey: true disables cert verification — must never be hardcoded.
+    // getAgent() now fetches root key explicitly with a timeout instead of using this flag.
     const start = actor.indexOf("async function getAgent");
     expect(start).toBeGreaterThan(-1);
-    // Grab up to 600 chars — enough to cover the whole function
-    const snippet = actor.slice(start, start + 600);
-    expect(snippet).toMatch(/shouldFetchRootKey:\s*IS_LOCAL/);
+    const snippet = actor.slice(start, start + 800);
     expect(snippet).not.toMatch(/shouldFetchRootKey:\s*true/);
   });
 
-  it("every shouldFetchRootKey: true in actor.ts is inside a DEV-guarded block", () => {
+  it("getAgent() calls fetchRootKey() inside an IS_LOCAL guard with a timeout", () => {
+    const start = actor.indexOf("async function getAgent");
+    expect(start).toBeGreaterThan(-1);
+    const snippet = actor.slice(start, start + 800);
+    // Must be gated on IS_LOCAL — never called unconditionally
+    expect(snippet).toMatch(/if\s*\(IS_LOCAL\)/);
+    // Must use an explicit fetchRootKey() call (not the flag)
+    expect(snippet).toMatch(/fetchRootKey\(\)/);
+    // Must have a timeout to prevent indefinite hangs when no replica is reachable
+    expect(snippet).toMatch(/setTimeout/);
+  });
+
+  it("every shouldFetchRootKey: true in actor.ts is inside a local-only guard", () => {
     const trueOccurrences: number[] = [];
     let pos = 0;
     while (true) {

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -106,8 +106,16 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         const pending = sessionStorage.getItem("pendingCheckout");
         if (pending) {
           sessionStorage.removeItem("pendingCheckout");
-          const { tier, billing } = JSON.parse(pending);
-          navigate(`/checkout?tier=${tier}&billing=${billing}`);
+          try {
+            const { tier, billing } = JSON.parse(pending);
+            if (typeof tier === "string" && typeof billing === "string") {
+              navigate(`/checkout?tier=${tier}&billing=${billing}`);
+              return;
+            }
+          } catch {
+            // Malformed session data — fall through to normal destination
+          }
+          navigate(await homeownerDestination(profile));
         } else {
           navigate(await homeownerDestination(profile));
         }
@@ -140,8 +148,16 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         const pending = sessionStorage.getItem("pendingCheckout");
         if (pending) {
           sessionStorage.removeItem("pendingCheckout");
-          const { tier, billing } = JSON.parse(pending);
-          navigate(`/checkout?tier=${tier}&billing=${billing}`);
+          try {
+            const { tier, billing } = JSON.parse(pending);
+            if (typeof tier === "string" && typeof billing === "string") {
+              navigate(`/checkout?tier=${tier}&billing=${billing}`);
+              return;
+            }
+          } catch {
+            // Malformed session data — fall through to normal destination
+          }
+          navigate(await homeownerDestination(profile));
         } else {
           navigate(await homeownerDestination(profile));
         }

--- a/frontend/src/services/actor.ts
+++ b/frontend/src/services/actor.ts
@@ -30,11 +30,24 @@ export async function getAgent(): Promise<HttpAgent> {
     const client = getAuthClient();
     // v6: getIdentity() is now async
     const identity = await client.getIdentity();
+    // Do NOT pass shouldFetchRootKey to HttpAgent.create() — on @icp-sdk/core/agent
+    // that flag triggers an eager synchronous root-key fetch that hangs when no
+    // replica is reachable (e.g. E2E mock mode, CI without dfx).  Instead, fetch
+    // explicitly with a timeout, matching the pattern in loginWithLocalIdentity().
     _agent = await HttpAgent.create({
       identity,
       host: IS_LOCAL ? "http://localhost:4943" : "https://ic0.app",
-      shouldFetchRootKey: IS_LOCAL,
     });
+    if (IS_LOCAL) {
+      await Promise.race([
+        _agent.fetchRootKey(),
+        new Promise<void>((_, reject) =>
+          setTimeout(() => reject(new Error("fetchRootKey timeout")), 2000)
+        ),
+      ]).catch((err: unknown) => {
+        console.warn("[actor] getAgent fetchRootKey failed — running in mock mode:", err);
+      });
+    }
   }
   return _agent;
 }

--- a/frontend/src/services/auth.ts
+++ b/frontend/src/services/auth.ts
@@ -68,7 +68,7 @@ export const idlFactory = ({ IDL }: any) => {
   });
 };
 
-export type UserRole = "Homeowner" | "Contractor" | "Realtor";
+export type UserRole = "Homeowner" | "Contractor" | "Realtor" | "Builder";
 
 export interface UserProfile {
   principal:          string;
@@ -98,10 +98,14 @@ async function getActor() {
   return _actor;
 }
 
+const VALID_ROLES = new Set<string>(["Homeowner", "Contractor", "Realtor", "Builder"]);
+
 function fromProfile(raw: any): UserProfile {
+  const roleKey = Object.keys(raw.role)[0];
+  if (!VALID_ROLES.has(roleKey)) throw new Error(`Unknown user role from canister: "${roleKey}"`);
   return {
     principal:    raw.principal.toText(),
-    role:         Object.keys(raw.role)[0] as UserRole,
+    role:         roleKey as UserRole,
     email:        raw.email,
     phone:        raw.phone,
     createdAt:    raw.createdAt,

--- a/frontend/src/services/contractor.ts
+++ b/frontend/src/services/contractor.ts
@@ -211,9 +211,15 @@ function createContractorService() {
   },
 
   async getTopRated(): Promise<ContractorProfile[]> {
-    const a = await getActor();
-    const all = (await a.getAll() as any[]).map(fromProfile);
-    return all.sort((a, b) => b.trustScore - a.trustScore);
+    if (!CONTRACTOR_CANISTER_ID) return [];
+    try {
+      const a = await getActor();
+      const all = (await a.getAll() as any[]).map(fromProfile);
+      return all.sort((a, b) => b.trustScore - a.trustScore);
+    } catch (err) {
+      console.warn("[contractorService] getTopRated failed:", err);
+      return [];
+    }
   },
 
   async getMyProfile(): Promise<ContractorProfile | null> {
@@ -229,9 +235,20 @@ function createContractorService() {
   },
 
   async getContractor(principalText: string): Promise<ContractorProfile | null> {
-    const a = await getActor();
+    if (typeof window !== "undefined" && (window as any).__e2e_contractors) {
+      const all = (window as any).__e2e_contractors as ContractorProfile[];
+      return all.find((c) => c.id === principalText) ?? null;
+    }
+    if (!CONTRACTOR_CANISTER_ID) return null;
     const { Principal: P } = await import("@icp-sdk/core/principal");
-    const result = await a.getContractor(P.fromText(principalText));
+    let principal;
+    try {
+      principal = P.fromText(principalText);
+    } catch {
+      return null;
+    }
+    const a = await getActor();
+    const result = await a.getContractor(principal);
     if ("err" in result) return null;
     return fromProfile(result.ok);
   },

--- a/frontend/src/services/payment.ts
+++ b/frontend/src/services/payment.ts
@@ -262,7 +262,16 @@ export const paymentService = {
     }
     const a = await getActor();
     const result = await a.getMySubscription();
-    if ("err" in result) return { tier: "Free", expiresAt: null, cancelledAt: null };
+    if ("err" in result) {
+      // NotFound = user has no subscription record → Free tier is correct.
+      // Any other error (Unauthorized, Paused, etc.) is a real failure: throw
+      // so callers don't silently treat a paid user as Free.
+      if (!("NotFound" in (result.err as any))) {
+        const key = Object.keys(result.err as any)[0];
+        throw new Error(`getMySubscription: ${key}`);
+      }
+      return { tier: "Free", expiresAt: null, cancelledAt: null };
+    }
     const sub = result.ok;
     const tierKey       = Object.keys(sub.tier)[0] as PlanTier;
     const expiresNs     = Number(sub.expiresAt);

--- a/frontend/src/services/quote.ts
+++ b/frontend/src/services/quote.ts
@@ -132,6 +132,13 @@ const QUOTE_STATUS_MAP: Record<string, QuoteStatus> = {
   Pending: "pending", Accepted: "accepted", Rejected: "rejected", Expired: "expired",
 };
 
+function mapVariant<T>(map: Record<string, T>, raw: any, field: string): T {
+  const key = Object.keys(raw)[0];
+  const val = map[key];
+  if (val === undefined) throw new Error(`Unknown canister variant for ${field}: "${key}"`);
+  return val;
+}
+
 function fromRequest(raw: any): QuoteRequest {
   const closeAtArr = raw.closeAt as bigint[] | undefined;
   return {
@@ -139,9 +146,9 @@ function fromRequest(raw: any): QuoteRequest {
     propertyId:  raw.propertyId,
     homeowner:   raw.homeowner.toText(),
     serviceType: Object.keys(raw.serviceType)[0],
-    urgency:     URGENCY_MAP[Object.keys(raw.urgency)[0]] ?? "medium",
+    urgency:     mapVariant(URGENCY_MAP, raw.urgency, "urgency"),
     description: raw.description,
-    status:      REQUEST_STATUS_MAP[Object.keys(raw.status)[0]] ?? "open",
+    status:      mapVariant(REQUEST_STATUS_MAP, raw.status, "requestStatus"),
     createdAt:   Number(raw.createdAt) / 1_000_000,
     closeAt:     closeAtArr && closeAtArr.length > 0
                    ? Number(closeAtArr[0]) / 1_000_000
@@ -157,7 +164,7 @@ function fromQuote(raw: any): Quote {
     amount:     Number(raw.amount),
     timeline:   Number(raw.timeline),
     validUntil: Number(raw.validUntil) / 1_000_000,
-    status:     QUOTE_STATUS_MAP[Object.keys(raw.status)[0]] ?? "pending",
+    status:     mapVariant(QUOTE_STATUS_MAP, raw.status, "quoteStatus"),
     createdAt:  Number(raw.createdAt) / 1_000_000,
   };
 }
@@ -275,8 +282,8 @@ function createQuoteService() {
   },
 
   async getMyBids(): Promise<Quote[]> {
-    // No dedicated canister endpoint yet — return empty; canister can add getMyQuotes later
-    return [];
+    // TODO(#xxx): canister does not expose getMyQuotes yet; implement when added.
+    throw new Error("getMyBids: not implemented — canister endpoint pending");
   },
 
   async getQuotesForRequest(requestId: string): Promise<Quote[]> {

--- a/frontend/src/services/sealedBid.ts
+++ b/frontend/src/services/sealedBid.ts
@@ -56,8 +56,16 @@ function mockIbeEncrypt(amountCents: number, requestId: string): string {
 }
 
 function mockIbeDecrypt(ciphertext: string): { amountCents: number; requestId: string } {
-  const { a, r } = JSON.parse(atob(ciphertext));
-  return { amountCents: a, requestId: r };
+  let parsed: any;
+  try {
+    parsed = JSON.parse(atob(ciphertext));
+  } catch {
+    throw new Error("sealedBid: invalid ciphertext — cannot decode bid");
+  }
+  if (typeof parsed?.a !== "number" || typeof parsed?.r !== "string") {
+    throw new Error("sealedBid: malformed bid payload");
+  }
+  return { amountCents: parsed.a, requestId: parsed.r };
 }
 
 // ─── Service factory ──────────────────────────────────────────────────────────

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -204,6 +204,7 @@ fi
 
 CANISTERS=(auth property job contractor quote payment photo report maintenance market sensor monitoring listing agent recurring bills ai_proxy)
 LOG_DIR=$(mktemp -d /tmp/icp-deploy-XXXXXX)
+trap 'rm -rf "$LOG_DIR"' EXIT
 DEPLOY_PRINCIPAL=$(icp identity principal)
 
 if [ "$ENV" = "local" ]; then


### PR DESCRIPTION
CRITICAL
- AuthContext: wrap both JSON.parse(sessionStorage) calls in try/catch with shape validation; fall through to homeownerDestination on malformed data
- quote.ts: replace silent ?? fallbacks with mapVariant() helper that throws on unknown canister enum variants (urgency, requestStatus, quoteStatus)
- contractor.ts: add __e2e_contractors check, !CANISTER_ID guard, and try/catch around Principal.fromText() in getContractor()
- job/main.mo: await cross-canister recordJobVerified with try/catch instead of fire-and-forget ignore (per multi-canister skill: unhandled rejections trap the caller canister)
- photo/main.mo: checkPropertyAuth() traps when propCanisterId is unset instead of falling back to caller==owner (fail closed, not open)

HIGH
- payment.ts: getMySubscription() only returns Free for #NotFound; all other canister errors throw so paid users are never silently downgraded to Free
- auth.ts: add Builder to UserRole union type and validate role key in fromProfile() to match IDL (which declares #Builder)
- sealedBid.ts: wrap atob/JSON.parse in try/catch with shape validation
- actor.ts: remove shouldFetchRootKey from HttpAgent.create(); fetch root key explicitly with 2 s timeout (matches loginWithLocalIdentity pattern)

MEDIUM
- job/main.mo + 12 other canisters: addAdmin() now deduplicates before appending (prevents bloating adminListEntries with repeated principals)
- contractor.ts: getTopRated() adds !CANISTER_ID guard and try/catch
- quote.ts: getMyBids() throws NotImplemented instead of silently returning []
- scripts/deploy.sh: add trap 'rm -rf "$LOG_DIR"' EXIT for reliable cleanup
- property/main.mo: tryConsumeUpdateSlot() sweeps expired rate-limit entries every 200 calls to prevent unbounded map growth

## Summary
<!-- What does this PR do? -->

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [ ] Backend tests pass (`make test`)
- [ ] Frontend builds (`cd frontend && npm run build`)
- [ ] Tested locally with dfx

## Checklist
- [ ] Code follows project conventions
- [ ] Self-review completed
- [ ] No sensitive data committed
