### PR TITLE
fix(#181): jobService.getAll() always returning [] — score delta alwa…

### DIFF
--- a/frontend/src/__tests__/services/job.test.ts
+++ b/frontend/src/__tests__/services/job.test.ts
@@ -198,6 +198,7 @@ vi.mock("@icp-sdk/core/principal", () => ({
 
 import { jobService, isInsuranceRelevant, INSURANCE_SERVICE_TYPES } from "@/services/job";
 import { jobToInput } from "@/services/report";
+import { computeScore } from "@/services/scoreService";
 import type { Job } from "@/services/job";
 
 // Ensure Date.now() always increments so consecutive create() calls get unique IDs.
@@ -293,28 +294,54 @@ describe("jobService.isDiy", () => {
   });
 });
 
-// ─── mock data integrity ─────────────────────────────────────────────────────
+// ─── score delta path (regression: #181 — getAll always returned []) ─────────
+// JobCreatePage now calls getByProperty(propertyId) after a successful create.
+// These tests verify that path produces a real score, not the old always-0 result.
 
-describe("mock data", () => {
-  it("all amounts are in cents (≥ 1000)", async () => {
-    const jobs = await jobService.getAll();
-    jobs.forEach((j) => {
-      expect(j.amount).toBeGreaterThanOrEqual(1_000);
+describe("score delta — getByProperty feeds computeScore", () => {
+  beforeEach(() => jobService.reset());
+
+  it("computeScore returns > 0 after creating a valued job", async () => {
+    await jobService.create({
+      propertyId:  "score-delta-prop",
+      serviceType: "HVAC",
+      amount:      500_000,   // $5,000
+      date:        "2024-01-01",
+      description: "New HVAC unit",
+      isDiy:       false,
     });
+    const jobs = await jobService.getByProperty("score-delta-prop");
+    expect(jobs).toHaveLength(1);
+    expect(computeScore(jobs, [])).toBeGreaterThan(0);
   });
 
-  it("all jobs have an isDiy field", async () => {
-    const jobs = await jobService.getAll();
-    jobs.forEach((j) => {
-      expect(typeof j.isDiy).toBe("boolean");
-    });
+  it("computeScore returns 0 for a property with no jobs", async () => {
+    const jobs = await jobService.getByProperty("score-delta-empty");
+    expect(jobs).toHaveLength(0);
+    expect(computeScore(jobs, [])).toBe(0);
   });
 
-  it("DIY jobs have no contractorName", async () => {
-    const jobs = await jobService.getAll();
-    jobs.filter((j) => j.isDiy).forEach((j) => {
-      expect(j.contractorName).toBeUndefined();
-    });
+  it("score increases as more jobs are added to a property", async () => {
+    await jobService.create({ propertyId: "score-grow", serviceType: "HVAC",    amount: 250_000, date: "2024-01-01", description: "d", isDiy: false });
+    const after1 = computeScore(await jobService.getByProperty("score-grow"), []);
+
+    await jobService.create({ propertyId: "score-grow", serviceType: "Roofing", amount: 500_000, date: "2024-02-01", description: "d", isDiy: false });
+    const after2 = computeScore(await jobService.getByProperty("score-grow"), []);
+
+    expect(after2).toBeGreaterThan(after1);
+  });
+
+  it("jobs for a different property do not affect the score", async () => {
+    await jobService.create({ propertyId: "score-iso-A", serviceType: "HVAC", amount: 500_000, date: "2024-01-01", description: "d", isDiy: false });
+    await jobService.create({ propertyId: "score-iso-B", serviceType: "HVAC", amount: 500_000, date: "2024-01-01", description: "d", isDiy: false });
+
+    const scoreA = computeScore(await jobService.getByProperty("score-iso-A"), []);
+    const scoreB = computeScore(await jobService.getByProperty("score-iso-B"), []);
+    const scoreEmpty = computeScore(await jobService.getByProperty("score-iso-none"), []);
+
+    expect(scoreA).toBeGreaterThan(0);
+    expect(scoreB).toBeGreaterThan(0);
+    expect(scoreEmpty).toBe(0);
   });
 });
 

--- a/frontend/src/hooks/useJobSummary.ts
+++ b/frontend/src/hooks/useJobSummary.ts
@@ -26,7 +26,7 @@ export function useJobSummary(properties: Property[], propLoading: boolean): Job
         propList.map((p) => jobService.getByProperty(String(p.id)).catch(() => [] as Job[]))
       );
       const merged = perProp.flat();
-      setAllJobs(merged.length > 0 ? merged : await jobService.getAll().catch(() => []));
+      setAllJobs(merged);
     } catch { /* canister not deployed */ }
   }, []);
 

--- a/frontend/src/pages/JobCreatePage.tsx
+++ b/frontend/src/pages/JobCreatePage.tsx
@@ -55,7 +55,6 @@ export default function JobCreatePage() {
   const [loading, setLoading] = useState(false);
   const [quota, setQuota] = useState<PhotoQuota>({ used: 0, limit: 10, tier: "Free" });
   const [userTier, setUserTier] = useState<PlanTier>("Free");
-  const [jobCount, setJobCount] = useState<number | null>(null);
   const [uploadedFiles, setUploadedFiles] = useState<{ file: File; phase: string }[]>([]);
   const [submitted, setSubmitted] = useState(false);
   const [loggedServiceType, setLoggedServiceType] = useState("");
@@ -83,7 +82,6 @@ export default function JobCreatePage() {
   useEffect(() => {
     photoService.getQuota().then(setQuota);
     paymentService.getMySubscription().then((s) => setUserTier(s.tier)).catch((e) => console.error("[JobCreate] subscription load failed:", e));
-    jobService.getAll().then((js) => setJobCount(js.length)).catch((e) => console.error("[JobCreate] job count load failed:", e));
     if (!editJob && properties.length > 0) setForm((f) => ({ ...f, propertyId: String(properties[0].id) }));
   }, [properties]); // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -124,8 +122,9 @@ export default function JobCreatePage() {
           warrantyMonths: form.warrantyMonths ? parseInt(form.warrantyMonths, 10) : undefined,
         });
         setLoggedServiceType(form.serviceType);
-        // Snapshot score for job-value delta display
-        jobService.getAll().then((js) => setScoreAtSubmit(computeScore(js, []))).catch(() => {}); // score delta is display-only; failure does not affect job creation
+        // Snapshot score for job-value delta display — use getByProperty so the
+        // newly created job is included in the score (getAll was always returning []).
+        jobService.getByProperty(form.propertyId).then((js) => setScoreAtSubmit(computeScore(js, []))).catch(() => {}); // score delta is display-only; failure does not affect job creation
         setSubmitted(true);
         return; // don't navigate — show success state
       }

--- a/frontend/src/services/job.ts
+++ b/frontend/src/services/job.ts
@@ -309,8 +309,24 @@ function createJobService() {
     if (typeof window !== "undefined" && (window as any).__e2e_jobs) {
       return (window as any).__e2e_jobs as Job[];
     }
-    // No canister equivalent for getAll — callers should use getByProperty
-    return [];
+    // Aggregate across all properties the authenticated user owns.
+    // Dynamic import avoids a circular dependency (property.ts ← job.ts).
+    try {
+      const { propertyService } = await import("./property");
+      const properties = await propertyService.getMyProperties();
+      if (properties.length === 0) return [];
+      const results = await Promise.all(
+        properties.map(async (p) => {
+          const a = await getActor();
+          const result = await a.getJobsForProperty(String(p.id));
+          if ("ok" in result) return (result.ok as any[]).map(fromJob);
+          return [] as Job[];
+        })
+      );
+      return results.flat();
+    } catch {
+      return [];
+    }
   },
 
   async create(job: Omit<Job, "id" | "createdAt" | "status" | "photos" | "verified" | "homeownerSigned" | "contractorSigned" | "homeowner" | "contractor">): Promise<Job> {


### PR DESCRIPTION
…ys 0

getAll() had no canister equivalent and unconditionally returned []. JobCreatePage used it after job creation to compute the score delta, so the delta was always 0 regardless of the job just logged.

- job.ts: implement getAll() as an aggregation over the user's properties via a dynamic import of propertyService (avoids circular dep); falls back to [] on error so existing callers degrade gracefully
- JobCreatePage: replace getAll() score-delta call with getByProperty(form.propertyId) — the propertyId is already in scope and this is a single canister call vs one-per-property; also remove the dead jobCount state (was set but never rendered)
- useJobSummary: remove the dead getAll() fallback (was a no-op since getAll always returned []; merged already contains the union of all per-property results)
- job.test.ts: replace trivially-true mock-data describe (iterated over []) with four score-delta path tests that verify getByProperty + computeScore produce a real non-zero score

## Summary
<!-- What does this PR do? -->

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [ ] Backend tests pass (`make test`)
- [ ] Frontend builds (`cd frontend && npm run build`)
- [ ] Tested locally with dfx

## Checklist
- [ ] Code follows project conventions
- [ ] Self-review completed
- [ ] No sensitive data committed
