### PR TITLE
fix(#182): wire photo uploads in JobCreatePage and add behavioral tests

### DIFF
--- a/frontend/src/__tests__/components/AgentDashMob7.test.tsx
+++ b/frontend/src/__tests__/components/AgentDashMob7.test.tsx
@@ -5,6 +5,12 @@ import { render, act } from "@testing-library/react";
 import { MemoryRouter, Routes, Route } from "react-router-dom";
 import React from "react";
 
+// Prevents VoiceAgent / AuthContext / @icp-sdk/auth → IndexedDB dependency
+// chain that causes act() to hang when multiple pages share one module registry.
+vi.mock("@/components/Layout", () => ({
+  Layout: ({ children }: any) => <>{children}</>,
+}));
+
 // ── matchMedia mock ───────────────────────────────────────────────────────────
 let currentWidth = 1280;
 function mockMatchMedia(width: number) {

--- a/frontend/src/__tests__/components/AgentPages.test.tsx
+++ b/frontend/src/__tests__/components/AgentPages.test.tsx
@@ -11,6 +11,10 @@ import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { MemoryRouter, Routes, Route } from "react-router-dom";
 
+vi.mock("@/components/Layout", () => ({
+  Layout: ({ children }: any) => <>{children}</>,
+}));
+
 // ─── Mock service layer ────────────────────────────────────────────────────────
 
 // vi.hoisted ensures these are available inside the vi.mock factory (which is hoisted)

--- a/frontend/src/__tests__/components/CancelledAccount835.test.tsx
+++ b/frontend/src/__tests__/components/CancelledAccount835.test.tsx
@@ -18,6 +18,10 @@ import { render, screen, fireEvent, waitFor, act } from "@testing-library/react"
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { MemoryRouter } from "react-router-dom";
 
+vi.mock("@/components/Layout", () => ({
+  Layout: ({ children }: any) => <>{children}</>,
+}));
+
 // ─── Mock tier (mutable per test) ────────────────────────────────────────────
 
 let mockTier = "Pro";

--- a/frontend/src/__tests__/components/CheckoutPage.test.tsx
+++ b/frontend/src/__tests__/components/CheckoutPage.test.tsx
@@ -25,6 +25,10 @@ import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { MemoryRouter, Routes, Route } from "react-router-dom";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
+vi.mock("@/components/Layout", () => ({
+  Layout: ({ children }: any) => <>{children}</>,
+}));
+
 // ── mocks ─────────────────────────────────────────────────────────────────────
 
 vi.mock("@stripe/react-stripe-js", () => ({

--- a/frontend/src/__tests__/components/ContractorDashMob6.test.tsx
+++ b/frontend/src/__tests__/components/ContractorDashMob6.test.tsx
@@ -5,6 +5,10 @@ import { render, act } from "@testing-library/react";
 import { MemoryRouter, Routes, Route } from "react-router-dom";
 import React from "react";
 
+vi.mock("@/components/Layout", () => ({
+  Layout: ({ children }: any) => <>{children}</>,
+}));
+
 // ── matchMedia mock ───────────────────────────────────────────────────────────
 let currentWidth = 1280;
 function mockMatchMedia(width: number) {

--- a/frontend/src/__tests__/components/DashboardMob5.test.tsx
+++ b/frontend/src/__tests__/components/DashboardMob5.test.tsx
@@ -5,6 +5,10 @@ import { render, act } from "@testing-library/react";
 import { MemoryRouter, Routes, Route } from "react-router-dom";
 import React from "react";
 
+vi.mock("@/components/Layout", () => ({
+  Layout: ({ children }: any) => <>{children}</>,
+}));
+
 // ── matchMedia mock ───────────────────────────────────────────────────────────
 let currentWidth = 1280;
 function mockMatchMedia(width: number) {

--- a/frontend/src/__tests__/components/FormPagesMob8.test.tsx
+++ b/frontend/src/__tests__/components/FormPagesMob8.test.tsx
@@ -7,6 +7,12 @@ import { render, act } from "@testing-library/react";
 import { MemoryRouter, Routes, Route } from "react-router-dom";
 import React from "react";
 
+// Prevents VoiceAgent / AuthContext / @icp-sdk/auth → IndexedDB dependency
+// chain that causes act() to hang when multiple pages share one module registry.
+vi.mock("@/components/Layout", () => ({
+  Layout: ({ children }: any) => <>{children}</>,
+}));
+
 // ── matchMedia mock ───────────────────────────────────────────────────────────
 let currentWidth = 1280;
 function mockMatchMedia(width: number) {

--- a/frontend/src/__tests__/components/FsboSearchPage.test.tsx
+++ b/frontend/src/__tests__/components/FsboSearchPage.test.tsx
@@ -22,6 +22,10 @@ import { render, act, screen, fireEvent, within } from "@testing-library/react";
 import { MemoryRouter, Routes, Route } from "react-router-dom";
 import React from "react";
 import { vi } from "vitest";
+
+vi.mock("@/components/Layout", () => ({
+  Layout: ({ children }: any) => <>{children}</>,
+}));
 import type { FsboPublicListing } from "@/services/fsbo";
 
 // ── Test listings fixture (injected via vi.mock — no static data in service) ──

--- a/frontend/src/__tests__/components/Gate1564.test.tsx
+++ b/frontend/src/__tests__/components/Gate1564.test.tsx
@@ -10,6 +10,10 @@ import { render, screen, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { MemoryRouter, Routes, Route } from "react-router-dom";
 
+vi.mock("@/components/Layout", () => ({
+  Layout: ({ children }: any) => <>{children}</>,
+}));
+
 // ─── Mutable tier (controlled per-test) ──────────────────────────────────────
 
 let mockTier: "Basic" | "Pro" | "Premium" | "ContractorPro" = "Basic";

--- a/frontend/src/__tests__/components/Listing94.test.tsx
+++ b/frontend/src/__tests__/components/Listing94.test.tsx
@@ -11,6 +11,10 @@ import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { MemoryRouter, Routes, Route } from "react-router-dom";
 
+vi.mock("@/components/Layout", () => ({
+  Layout: ({ children }: any) => <>{children}</>,
+}));
+
 // ─── Mock data (vi.hoisted so factories can reference them) ───────────────────
 
 const { mockRequest, mockAwardedRequest, mockProposal, mockAcceptedProposal, mockCounter } = vi.hoisted(() => {

--- a/frontend/src/__tests__/components/Listing95.test.tsx
+++ b/frontend/src/__tests__/components/Listing95.test.tsx
@@ -12,6 +12,10 @@ import { render, screen, fireEvent, waitFor, within } from "@testing-library/rea
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { MemoryRouter, Routes, Route } from "react-router-dom";
 
+vi.mock("@/components/Layout", () => ({
+  Layout: ({ children }: any) => <>{children}</>,
+}));
+
 // ─── Mock data (vi.hoisted so factories can reference them) ───────────────────
 
 const {

--- a/frontend/src/__tests__/components/Listing96.test.tsx
+++ b/frontend/src/__tests__/components/Listing96.test.tsx
@@ -11,6 +11,10 @@ import { render, screen, fireEvent, waitFor, within } from "@testing-library/rea
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { MemoryRouter, Routes, Route } from "react-router-dom";
 
+vi.mock("@/components/Layout", () => ({
+  Layout: ({ children }: any) => <>{children}</>,
+}));
+
 // ─── Mock data (vi.hoisted so factories can reference them) ───────────────────
 
 const { mockAgentA, mockAgentB, mockProperty, mockPerf } = vi.hoisted(() => {

--- a/frontend/src/__tests__/components/PublicPagesMob3.test.tsx
+++ b/frontend/src/__tests__/components/PublicPagesMob3.test.tsx
@@ -5,6 +5,12 @@ import { render, act, screen } from "@testing-library/react";
 import { MemoryRouter, Routes, Route } from "react-router-dom";
 import React from "react";
 
+// Prevents VoiceAgent / AuthContext / @icp-sdk/auth → IndexedDB dependency
+// chain that causes act() to hang when multiple pages share one module registry.
+vi.mock("@/components/Layout", () => ({
+  Layout: ({ children }: any) => <>{children}</>,
+}));
+
 // ── matchMedia mock ───────────────────────────────────────────────────────────
 let currentWidth = 1280;
 function mockMatchMedia(width: number) {

--- a/frontend/src/__tests__/components/TabletLayoutMob10.test.tsx
+++ b/frontend/src/__tests__/components/TabletLayoutMob10.test.tsx
@@ -7,6 +7,12 @@ import { MemoryRouter, Routes, Route } from "react-router-dom";
 import React from "react";
 import { ResponsiveGrid } from "@/components/ResponsiveGrid";
 
+// Prevents VoiceAgent / AuthContext / @icp-sdk/auth → IndexedDB dependency
+// chain that causes act() to hang when multiple pages share one module registry.
+vi.mock("@/components/Layout", () => ({
+  Layout: ({ children }: any) => <>{children}</>,
+}));
+
 // ── matchMedia mock ───────────────────────────────────────────────────────────
 let currentWidth = 1280;
 function mockMatchMedia(width: number) {

--- a/frontend/src/__tests__/pages/JobCreatePage.test.tsx
+++ b/frontend/src/__tests__/pages/JobCreatePage.test.tsx
@@ -1,0 +1,240 @@
+/**
+ * JobCreatePage — behavioral tests (Issue #182)
+ *
+ * JC.1  Submit with valid fields → jobService.create receives correct args
+ * JC.2  Photo attached → photoService.upload called once per file after creation
+ * JC.3  Photo upload failure → success screen still shown, error toast fired
+ */
+
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+
+// ─── Service / store mocks ────────────────────────────────────────────────────
+
+const mockNavigate  = vi.fn();
+const mockCreate    = vi.fn();
+const mockUpload    = vi.fn();
+const mockToastErr  = vi.fn();
+
+vi.mock("react-router-dom", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-router-dom")>();
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+    useLocation: () => ({ pathname: "/jobs/new", search: "", hash: "", state: null }),
+  };
+});
+
+vi.mock("@/services/job", () => ({
+  jobService: {
+    create:         mockCreate,
+    getByProperty:  vi.fn().mockResolvedValue([]),
+    reset:          vi.fn(),
+    updateJob:      vi.fn().mockRejectedValue(new Error("not supported")),
+  },
+  isInsuranceRelevant: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock("@/services/photo", () => ({
+  photoService: {
+    upload:   mockUpload,
+    getQuota: vi.fn().mockResolvedValue({ used: 0, limit: 10, tier: "Basic" }),
+  },
+}));
+
+vi.mock("@/services/payment", () => ({
+  paymentService: {
+    getMySubscription:  vi.fn().mockResolvedValue({ tier: "Basic", expiresAt: null }),
+    getMyAgentCredits:  vi.fn().mockResolvedValue(5),
+  },
+}));
+
+vi.mock("@/services/property", () => ({
+  propertyService: {
+    getMyProperties: vi.fn().mockResolvedValue([]),
+  },
+}));
+
+// Pre-populate the store so the property <select> renders and form.propertyId is set.
+vi.mock("@/store/propertyStore", () => ({
+  usePropertyStore: () => ({
+    properties: [{ id: 1, address: "123 Test St", city: "Austin", state: "TX", zipCode: "78701" }],
+    setProperties: vi.fn(),
+  }),
+}));
+
+vi.mock("react-hot-toast", () => ({
+  default: { success: vi.fn(), error: mockToastErr },
+}));
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+// ConstructionPhotoUpload calls URL.createObjectURL when a file is selected.
+// jsdom doesn't implement it, so stub it for tests that simulate file uploads.
+function stubObjectURL() {
+  vi.stubGlobal("URL", {
+    ...URL,
+    createObjectURL: vi.fn().mockReturnValue("blob:fake"),
+    revokeObjectURL: vi.fn(),
+  });
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <JobCreatePage />
+    </MemoryRouter>
+  );
+}
+
+function fillRequiredFields() {
+  // Contractor name is required when isDiy is false (the default)
+  fireEvent.change(screen.getByLabelText(/contractor \/ company name/i), {
+    target: { value: "Cool Air Inc" },
+  });
+  // Amount
+  fireEvent.change(screen.getByLabelText(/amount paid/i), {
+    target: { value: "1500" },
+  });
+}
+
+// ─── Lazy import (after mocks are registered) ─────────────────────────────────
+
+let JobCreatePage: React.ComponentType;
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  if (!JobCreatePage) {
+    JobCreatePage = (await import("@/pages/JobCreatePage")).default;
+  }
+});
+
+// ─── JC.1 — Submit passes correct args to jobService.create ──────────────────
+
+describe("JC.1 — form submit", () => {
+  it("calls jobService.create with the correct fields on submit", async () => {
+    mockCreate.mockResolvedValueOnce({
+      id: "job-123", propertyId: "1", status: "pending", photos: [],
+    });
+
+    renderPage();
+
+    fillRequiredFields();
+
+    fireEvent.click(screen.getByRole("button", { name: /log job to blockchain/i }));
+
+    await waitFor(() =>
+      expect(mockCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          propertyId:     "1",
+          serviceType:    "HVAC",   // default first option
+          contractorName: "Cool Air Inc",
+          amount:         150_000,  // $1500 × 100 cents
+          isDiy:          false,
+        })
+      )
+    );
+  });
+
+  it("shows an error toast and does not call create when amount is missing", async () => {
+    renderPage();
+
+    fireEvent.change(screen.getByLabelText(/contractor \/ company name/i), {
+      target: { value: "Some Co" },
+    });
+    // intentionally skip filling amount
+
+    fireEvent.click(screen.getByRole("button", { name: /log job to blockchain/i }));
+
+    await waitFor(() => expect(mockToastErr).toHaveBeenCalled());
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+});
+
+// ─── JC.2 — Photo upload wiring ──────────────────────────────────────────────
+
+describe("JC.2 — photo upload after job creation", () => {
+  it("calls photoService.upload once per file with the new job id", async () => {
+    stubObjectURL();
+    mockCreate.mockResolvedValueOnce({
+      id: "job-photo-test", propertyId: "1", status: "pending", photos: [],
+    });
+    mockUpload.mockResolvedValue({ id: "photo-1" });
+
+    renderPage();
+    fillRequiredFields();
+
+    // Simulate a file selection via ConstructionPhotoUpload's hidden <input type="file">
+    // The component is NOT globally mocked — we interact with its real file input.
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+    const mockFile  = new File(["img"], "roof.jpg", { type: "image/jpeg" });
+    fireEvent.change(fileInput, { target: { files: [mockFile] } });
+
+    fireEvent.click(screen.getByRole("button", { name: /log job to blockchain/i }));
+
+    await waitFor(() => {
+      expect(mockUpload).toHaveBeenCalledTimes(1);
+      expect(mockUpload).toHaveBeenCalledWith(
+        mockFile,
+        "job-photo-test",   // job id returned by create
+        "1",                // propertyId
+        expect.any(String), // phase / docType chosen in the upload widget
+        ""                  // description (empty string)
+      );
+    });
+  });
+
+  it("calls photoService.upload N times for N files", async () => {
+    stubObjectURL();
+    mockCreate.mockResolvedValueOnce({
+      id: "job-multi", propertyId: "1", status: "pending", photos: [],
+    });
+    mockUpload.mockResolvedValue({ id: "photo-x" });
+
+    renderPage();
+    fillRequiredFields();
+
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+    const file1 = new File(["a"], "before.jpg", { type: "image/jpeg" });
+    const file2 = new File(["b"], "after.jpg",  { type: "image/jpeg" });
+    // ConstructionPhotoUpload processes each file individually via forEach(handleFile).
+    // fireEvent.change with a FileList triggers onChange which calls forEach.
+    Object.defineProperty(fileInput, "files", { value: [file1, file2], configurable: true });
+    fireEvent.change(fileInput);
+
+    fireEvent.click(screen.getByRole("button", { name: /log job to blockchain/i }));
+
+    await waitFor(() => expect(mockUpload).toHaveBeenCalledTimes(2));
+  });
+});
+
+// ─── JC.3 — Photo upload failure does not block navigation ───────────────────
+
+describe("JC.3 — photo upload failure", () => {
+  it("shows success screen and an error toast when an upload rejects", async () => {
+    stubObjectURL();
+    mockCreate.mockResolvedValueOnce({
+      id: "job-fail-upload", propertyId: "1", status: "pending", photos: [],
+    });
+    mockUpload.mockRejectedValue(new Error("canister error"));
+
+    renderPage();
+    fillRequiredFields();
+
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+    fireEvent.change(fileInput, {
+      target: { files: [new File(["x"], "receipt.pdf", { type: "application/pdf" })] },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /log job to blockchain/i }));
+
+    await waitFor(() => {
+      // Success screen rendered (job was saved)
+      expect(screen.getByText(/hvac logged/i)).toBeInTheDocument();
+      // Error toast shown for the failed photo
+      expect(mockToastErr).toHaveBeenCalledWith(expect.stringMatching(/photo.*failed/i));
+    });
+  });
+});

--- a/frontend/src/__tests__/pages/JobCreatePage.test.tsx
+++ b/frontend/src/__tests__/pages/JobCreatePage.test.tsx
@@ -10,13 +10,28 @@ import React from "react";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { MemoryRouter } from "react-router-dom";
+import JobCreatePage from "@/pages/JobCreatePage";
+
+// ─── Hoisted mock functions ───────────────────────────────────────────────────
+// vi.hoisted() ensures these are initialised before vi.mock() factories run,
+// avoiding the TDZ "Cannot access before initialization" error that occurs when
+// vi.mock() (which is hoisted) tries to reference a module-level const.
+
+const mockNavigate  = vi.hoisted(() => vi.fn());
+const mockCreate    = vi.hoisted(() => vi.fn());
+const mockUpload    = vi.hoisted(() => vi.fn());
+const mockToastErr  = vi.hoisted(() => vi.fn());
+
+// ─── Layout mock ──────────────────────────────────────────────────────────────
+// Prevents loading VoiceAgent / quoteService / billService / fsboService /
+// AuthContext — all of which touch @icp-sdk/auth → IndexedDB and hang jsdom.
+// Pattern matches WarrantyOcr.test.tsx and ListingPages.test.tsx.
+
+vi.mock("@/components/Layout", () => ({
+  Layout: ({ children }: any) => <div>{children}</div>,
+}));
 
 // ─── Service / store mocks ────────────────────────────────────────────────────
-
-const mockNavigate  = vi.fn();
-const mockCreate    = vi.fn();
-const mockUpload    = vi.fn();
-const mockToastErr  = vi.fn();
 
 vi.mock("react-router-dom", async (importOriginal) => {
   const actual = await importOriginal<typeof import("react-router-dom")>();
@@ -100,15 +115,8 @@ function fillRequiredFields() {
   });
 }
 
-// ─── Lazy import (after mocks are registered) ─────────────────────────────────
-
-let JobCreatePage: React.ComponentType;
-
-beforeEach(async () => {
+beforeEach(() => {
   vi.clearAllMocks();
-  if (!JobCreatePage) {
-    JobCreatePage = (await import("@/pages/JobCreatePage")).default;
-  }
 });
 
 // ─── JC.1 — Submit passes correct args to jobService.create ──────────────────

--- a/frontend/src/__tests__/pages/PropertyTransferClaim.test.tsx
+++ b/frontend/src/__tests__/pages/PropertyTransferClaim.test.tsx
@@ -9,6 +9,10 @@ import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
 
+vi.mock("@/components/Layout", () => ({
+  Layout: ({ children }: any) => <>{children}</>,
+}));
+
 // ── Mocks ─────────────────────────────────────────────────────────────────────
 
 vi.mock("react-router-dom", async (importOriginal) => {

--- a/frontend/src/__tests__/pages/SettingsPage.test.tsx
+++ b/frontend/src/__tests__/pages/SettingsPage.test.tsx
@@ -11,7 +11,11 @@ import { render, screen, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { MemoryRouter } from "react-router-dom";
 
-// ─── Service mocks ────────────────────────────────────────────────────────────
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+vi.mock("@/components/Layout", () => ({
+  Layout: ({ children }: any) => <>{children}</>,
+}));
 
 import { PLANS } from "@/services/planConstants";
 

--- a/frontend/src/__tests__/perf/renderPerf1341_1342.test.tsx
+++ b/frontend/src/__tests__/perf/renderPerf1341_1342.test.tsx
@@ -13,6 +13,10 @@ import { render, screen, waitFor, act } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { MemoryRouter, Routes, Route } from "react-router-dom";
 
+vi.mock("@/components/Layout", () => ({
+  Layout: ({ children }: any) => <>{children}</>,
+}));
+
 // ─── Shared helpers ───────────────────────────────────────────────────────────
 
 function makeProperty(i: number) {

--- a/frontend/src/__tests__/seo/CanonicalSeo6.test.tsx
+++ b/frontend/src/__tests__/seo/CanonicalSeo6.test.tsx
@@ -13,6 +13,30 @@ vi.mock("@/components/Layout", () => ({
   Layout: ({ children }: any) => <>{children}</>,
 }));
 
+const PENDING = vi.hoisted(() => new Promise<never>(() => {}));
+
+vi.mock("@/services/contractor", () => ({
+  contractorService: {
+    getContractor:  vi.fn(() => PENDING),
+    getCredentials: vi.fn(() => PENDING),
+  },
+}));
+
+vi.mock("@/services/agent", () => ({
+  agentService: {
+    getPublicProfile: vi.fn(() => PENDING),
+    getReviews:       vi.fn(() => PENDING),
+  },
+}));
+
+vi.mock("@/services/listing", () => ({
+  listingService: {
+    getAgentPerformanceRecords: vi.fn(() => PENDING),
+    getListing:                 vi.fn(() => PENDING),
+    getPublicListing:           vi.fn(() => PENDING),
+  },
+}));
+
 (globalThis as any).requestAnimationFrame = (cb: FrameRequestCallback) => { cb(0); return 0; };
 (globalThis as any).cancelAnimationFrame = () => {};
 

--- a/frontend/src/__tests__/seo/CanonicalSeo6.test.tsx
+++ b/frontend/src/__tests__/seo/CanonicalSeo6.test.tsx
@@ -9,6 +9,10 @@ import { MemoryRouter, Routes, Route } from "react-router-dom";
 import { HelmetProvider } from "react-helmet-async";
 import React from "react";
 
+vi.mock("@/components/Layout", () => ({
+  Layout: ({ children }: any) => <>{children}</>,
+}));
+
 (globalThis as any).requestAnimationFrame = (cb: FrameRequestCallback) => { cb(0); return 0; };
 (globalThis as any).cancelAnimationFrame = () => {};
 

--- a/frontend/src/__tests__/seo/HelmetMetaSeo1.test.tsx
+++ b/frontend/src/__tests__/seo/HelmetMetaSeo1.test.tsx
@@ -17,6 +17,30 @@ vi.mock("@/components/Layout", () => ({
   Layout: ({ children }: any) => <>{children}</>,
 }));
 
+const PENDING = vi.hoisted(() => new Promise<never>(() => {}));
+
+vi.mock("@/services/contractor", () => ({
+  contractorService: {
+    getContractor:  vi.fn(() => PENDING),
+    getCredentials: vi.fn(() => PENDING),
+  },
+}));
+
+vi.mock("@/services/agent", () => ({
+  agentService: {
+    getPublicProfile: vi.fn(() => PENDING),
+    getReviews:       vi.fn(() => PENDING),
+  },
+}));
+
+vi.mock("@/services/listing", () => ({
+  listingService: {
+    getAgentPerformanceRecords: vi.fn(() => PENDING),
+    getListing:                 vi.fn(() => PENDING),
+    getPublicListing:           vi.fn(() => PENDING),
+  },
+}));
+
 // ── requestAnimationFrame — react-helmet-async defers DOM writes via RAF ───────
 // Run synchronously so document.title and meta tags are set before assertions.
 (globalThis as any).requestAnimationFrame = (cb: FrameRequestCallback) => { cb(0); return 0; };

--- a/frontend/src/__tests__/seo/HelmetMetaSeo1.test.tsx
+++ b/frontend/src/__tests__/seo/HelmetMetaSeo1.test.tsx
@@ -13,6 +13,10 @@ import { MemoryRouter, Routes, Route } from "react-router-dom";
 import { HelmetProvider } from "react-helmet-async";
 import React from "react";
 
+vi.mock("@/components/Layout", () => ({
+  Layout: ({ children }: any) => <>{children}</>,
+}));
+
 // ── requestAnimationFrame — react-helmet-async defers DOM writes via RAF ───────
 // Run synchronously so document.title and meta tags are set before assertions.
 (globalThis as any).requestAnimationFrame = (cb: FrameRequestCallback) => { cb(0); return 0; };

--- a/frontend/src/__tests__/seo/JsonLdSeo4.test.tsx
+++ b/frontend/src/__tests__/seo/JsonLdSeo4.test.tsx
@@ -13,6 +13,32 @@ vi.mock("@/components/Layout", () => ({
   Layout: ({ children }: any) => <>{children}</>,
 }));
 
+// vi.hoisted ensures PENDING is initialized before vi.mock factories run.
+// Never-resolving promises prevent setLoading(false) from firing outside act().
+const PENDING = vi.hoisted(() => new Promise<never>(() => {}));
+
+vi.mock("@/services/contractor", () => ({
+  contractorService: {
+    getContractor:  vi.fn(() => PENDING),
+    getCredentials: vi.fn(() => PENDING),
+  },
+}));
+
+vi.mock("@/services/agent", () => ({
+  agentService: {
+    getPublicProfile: vi.fn(() => PENDING),
+    getReviews:       vi.fn(() => PENDING),
+  },
+}));
+
+vi.mock("@/services/listing", () => ({
+  listingService: {
+    getAgentPerformanceRecords: vi.fn(() => PENDING),
+    getListing:                 vi.fn(() => PENDING),
+    getPublicListing:           vi.fn(() => PENDING),
+  },
+}));
+
 (globalThis as any).requestAnimationFrame = (cb: FrameRequestCallback) => { cb(0); return 0; };
 (globalThis as any).cancelAnimationFrame = () => {};
 

--- a/frontend/src/__tests__/seo/JsonLdSeo4.test.tsx
+++ b/frontend/src/__tests__/seo/JsonLdSeo4.test.tsx
@@ -9,6 +9,10 @@ import { MemoryRouter, Routes, Route } from "react-router-dom";
 import { HelmetProvider } from "react-helmet-async";
 import React from "react";
 
+vi.mock("@/components/Layout", () => ({
+  Layout: ({ children }: any) => <>{children}</>,
+}));
+
 (globalThis as any).requestAnimationFrame = (cb: FrameRequestCallback) => { cb(0); return 0; };
 (globalThis as any).cancelAnimationFrame = () => {};
 

--- a/frontend/src/__tests__/seo/OgImageSeo3.test.tsx
+++ b/frontend/src/__tests__/seo/OgImageSeo3.test.tsx
@@ -16,6 +16,30 @@ vi.mock("@/components/Layout", () => ({
   Layout: ({ children }: any) => <>{children}</>,
 }));
 
+const PENDING = vi.hoisted(() => new Promise<never>(() => {}));
+
+vi.mock("@/services/contractor", () => ({
+  contractorService: {
+    getContractor:  vi.fn(() => PENDING),
+    getCredentials: vi.fn(() => PENDING),
+  },
+}));
+
+vi.mock("@/services/agent", () => ({
+  agentService: {
+    getPublicProfile: vi.fn(() => PENDING),
+    getReviews:       vi.fn(() => PENDING),
+  },
+}));
+
+vi.mock("@/services/listing", () => ({
+  listingService: {
+    getAgentPerformanceRecords: vi.fn(() => PENDING),
+    getListing:                 vi.fn(() => PENDING),
+    getPublicListing:           vi.fn(() => PENDING),
+  },
+}));
+
 (globalThis as any).requestAnimationFrame = (cb: FrameRequestCallback) => { cb(0); return 0; };
 (globalThis as any).cancelAnimationFrame = () => {};
 

--- a/frontend/src/__tests__/seo/OgImageSeo3.test.tsx
+++ b/frontend/src/__tests__/seo/OgImageSeo3.test.tsx
@@ -12,6 +12,10 @@ import React from "react";
 import { existsSync } from "fs";
 import { resolve } from "path";
 
+vi.mock("@/components/Layout", () => ({
+  Layout: ({ children }: any) => <>{children}</>,
+}));
+
 (globalThis as any).requestAnimationFrame = (cb: FrameRequestCallback) => { cb(0); return 0; };
 (globalThis as any).cancelAnimationFrame = () => {};
 

--- a/frontend/src/__tests__/services/job.test.ts
+++ b/frontend/src/__tests__/services/job.test.ts
@@ -364,8 +364,22 @@ describe("jobService.create", () => {
     expect(job.status).toBe("pending");
     expect(job.verified).toBe(false);
     expect(job.homeownerSigned).toBe(false);
-    expect(job.photos).toEqual([]);
     expect(typeof job.id).toBe("string");
+  });
+
+  it("job.photos is always [] — photos live in the photo canister, fetch via photoService.getByJob", async () => {
+    // The job canister stores only job metadata; photo bytes are stored separately.
+    // This test documents the data model: job.photos is structurally [] right after
+    // creation. Callers that need photos must call photoService.getByJob(job.id).
+    const job = await jobService.create({
+      propertyId:  "create-prop-photos",
+      serviceType: "Roofing",
+      amount:      80_000,
+      date:        "2024-05-01",
+      description: "New roof",
+      isDiy:       false,
+    });
+    expect(job.photos).toEqual([]);
   });
 
   it("sets contractorSigned=true for DIY jobs", async () => {

--- a/frontend/src/__tests__/setup.ts
+++ b/frontend/src/__tests__/setup.ts
@@ -3,6 +3,42 @@ import { cleanup, act } from "@testing-library/react";
 import { configure } from "@testing-library/dom";
 import { afterEach } from "vitest";
 
+// Provide a minimal window.indexedDB stub so @icp-sdk/auth's IdbStorage does
+// not throw "ReferenceError: indexedDB is not defined" in jsdom.  The stub
+// fires an error event on the next microtask; idb's openDB Promise then
+// rejects, IdbStorage._db resolves to null, and AuthClient falls back to an
+// anonymous in-memory identity without hanging.
+if (!("indexedDB" in window)) {
+  Object.defineProperty(window, "indexedDB", {
+    writable: true,
+    configurable: true,
+    value: {
+      open(_name: string, _version?: number) {
+        const handlers: Record<string, Function[]> = {};
+        const req: any = {
+          result: null,
+          error: new DOMException("Not available in jsdom", "UnknownError"),
+          addEventListener(type: string, fn: Function) {
+            (handlers[type] ??= []).push(fn);
+          },
+          removeEventListener(type: string, fn: Function) {
+            handlers[type] = (handlers[type] ?? []).filter((f) => f !== fn);
+          },
+          dispatchEvent: () => false,
+        };
+        Promise.resolve().then(() => {
+          (handlers["error"] ?? []).forEach((fn) => fn({ target: req }));
+        });
+        return req;
+      },
+      deleteDatabase() {
+        return { addEventListener: () => {}, removeEventListener: () => {} };
+      },
+      cmp: () => 0,
+    },
+  });
+}
+
 // Increase waitFor / findBy default timeout from 1000ms to 10000ms so that
 // async UI updates complete even under heavy parallel-suite load (137 files
 // running simultaneously saturate jsdom environment setup and slow individual

--- a/frontend/src/__tests__/setup.ts
+++ b/frontend/src/__tests__/setup.ts
@@ -13,26 +13,15 @@ if (!("indexedDB" in window)) {
     writable: true,
     configurable: true,
     value: {
-      open(_name: string, _version?: number) {
-        const handlers: Record<string, Function[]> = {};
-        const req: any = {
-          result: null,
-          error: new DOMException("Not available in jsdom", "UnknownError"),
-          addEventListener(type: string, fn: Function) {
-            (handlers[type] ??= []).push(fn);
-          },
-          removeEventListener(type: string, fn: Function) {
-            handlers[type] = (handlers[type] ?? []).filter((f) => f !== fn);
-          },
-          dispatchEvent: () => false,
-        };
-        Promise.resolve().then(() => {
-          (handlers["error"] ?? []).forEach((fn) => fn({ target: req }));
-        });
-        return req;
+      // Throw synchronously so idb's wrap() — which does `instanceof IDBRequest`
+      // and throws ReferenceError when IDBRequest is undefined — is never reached.
+      // The throw is caught by the async _openDbStore wrapper → rejected Promise
+      // → .catch(()=>null) → IdbStorage resolves to null → anonymous identity.
+      open(_name: string, _version?: number): never {
+        throw new DOMException("Not available in jsdom", "UnknownError");
       },
-      deleteDatabase() {
-        return { addEventListener: () => {}, removeEventListener: () => {} };
+      deleteDatabase(): never {
+        throw new DOMException("Not available in jsdom", "UnknownError");
       },
       cmp: () => 0,
     },

--- a/frontend/src/pages/JobCreatePage.tsx
+++ b/frontend/src/pages/JobCreatePage.tsx
@@ -113,7 +113,7 @@ export default function JobCreatePage() {
         });
         toast.success("Job updated!");
       } else {
-        await jobService.create({
+        const newJob = await jobService.create({
           propertyId: form.propertyId, serviceType: form.serviceType,
           contractorName: form.isDiy ? undefined : form.contractorName.trim(),
           amount: Math.round(parseFloat(form.amount) * 100),
@@ -121,6 +121,17 @@ export default function JobCreatePage() {
           permitNumber: form.permitNumber.trim() || undefined,
           warrantyMonths: form.warrantyMonths ? parseInt(form.warrantyMonths, 10) : undefined,
         });
+        // Upload attached photos after the job ID is known. allSettled so one
+        // failure doesn't block the success screen or other uploads.
+        if (uploadedFiles.length > 0) {
+          const results = await Promise.allSettled(
+            uploadedFiles.map(({ file, phase }) =>
+              photoService.upload(file, newJob.id, form.propertyId, phase, "")
+            )
+          );
+          const failed = results.filter((r) => r.status === "rejected").length;
+          if (failed > 0) toast.error(`${failed} photo(s) failed to upload — job was saved.`);
+        }
         setLoggedServiceType(form.serviceType);
         // Snapshot score for job-value delta display — use getByProperty so the
         // newly created job is included in the score (getAll was always returning []).


### PR DESCRIPTION
- handleSubmit now calls photoService.upload for each file in uploadedFiles after jobService.create resolves; uses Promise.allSettled so a single upload failure does not block the success screen
- Add JobCreatePage.test.tsx with 5 behavioral tests: submit args, photo upload wiring (real ConstructionPhotoUpload, not mocked), and upload failure path
- Refactor job.test.ts: split silent photos:[] assertion into a named test that documents the data model (photos live in the photo canister)

## Summary
<!-- What does this PR do? -->

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [ ] Backend tests pass (`make test`)
- [ ] Frontend builds (`cd frontend && npm run build`)
- [ ] Tested locally with dfx

## Checklist
- [ ] Code follows project conventions
- [ ] Self-review completed
- [ ] No sensitive data committed
