### PR TITLE
fix(git): prevent Claude agent worktrees from being staged as gitlinks (#192)

### DIFF
--- a/.claude/worktrees/.gitignore
+++ b/.claude/worktrees/.gitignore
@@ -1,0 +1,5 @@
+# Claude Code agent worktrees live here.
+# Each subdirectory is a temporary git worktree (contains a .git file).
+# Ignore everything so git never stages a nested repo as a gitlink.
+*
+!.gitignore

--- a/.gitignore
+++ b/.gitignore
@@ -38,5 +38,12 @@ Thumbs.db
 *.swp
 *.swo
 
-# Claude Code local settings
-.claude/
+# Claude Code local settings (memory, project config, conversation state).
+# Use .claude/* rather than .claude/ so negation rules for children work.
+.claude/*
+# Worktrees created by Claude Code's isolation mode are nested git repos.
+# Gitlinks (mode 160000) bypass parent .gitignore, so we commit a sentinel
+# .gitignore inside worktrees/ that makes git ignore every subdirectory there.
+!.claude/worktrees/
+.claude/worktrees/*
+!.claude/worktrees/.gitignore


### PR DESCRIPTION
## Summary
- Replaces `.claude/` with `.claude/*` in `.gitignore` so negation rules for children work correctly
- Adds `.claude/worktrees/*` ignore rule with `!.claude/worktrees/.gitignore` exception
- Commits a sentinel `.gitignore` inside `.claude/worktrees/` that ignores every subdirectory (`*` + `!.gitignore`), preventing git from staging worktree directories as gitlinks (mode 160000)

## Why
Git won't apply negation rules to children of an already-ignored parent directory. The previous `.claude/` rule silently blocked all child rules. The two-layer approach — parent `.gitignore` controls which paths are tracked, sentinel `.gitignore` inside the directory prevents gitlinks — is the correct fix.

## Test plan
- [ ] `git check-ignore -v .claude/worktrees/some-worktree` → ignored by sentinel
- [ ] `git check-ignore -v .claude/worktrees/.gitignore` → not ignored (sentinel commits itself)
- [ ] `git status` after creating a new agent worktree shows no untracked gitlink entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)