### PR TITLE
fix(tests): eliminate act() warnings and IDB hangs in CI (#191)

### DIFF
--- a/frontend/src/__tests__/components/AgentPages.test.tsx
+++ b/frontend/src/__tests__/components/AgentPages.test.tsx
@@ -88,6 +88,9 @@ vi.mock("@/store/authStore", () => {
   };
   return { useAuthStore: Object.assign(() => state, { getState: () => state }) };
 });
+vi.mock("@/components/Layout", () => ({
+  Layout: ({ children }: any) => <>{children}</>,
+}));
 
 import AgentProfileEditPage from "@/pages/AgentProfileEditPage";
 import AgentPublicPage      from "@/pages/AgentPublicPage";

--- a/frontend/src/__tests__/components/CancelledAccount835.test.tsx
+++ b/frontend/src/__tests__/components/CancelledAccount835.test.tsx
@@ -68,6 +68,9 @@ vi.mock("@/services/job", () => ({
 vi.mock("react-hot-toast", () => ({
   default: { success: vi.fn(), error: vi.fn() },
 }));
+vi.mock("@/components/Layout", () => ({
+  Layout: ({ children }: any) => <>{children}</>,
+}));
 
 // ─── Imports ──────────────────────────────────────────────────────────────────
 

--- a/frontend/src/__tests__/components/ContractorDashMob6.test.tsx
+++ b/frontend/src/__tests__/components/ContractorDashMob6.test.tsx
@@ -4,6 +4,11 @@
 import { render, act } from "@testing-library/react";
 import { MemoryRouter, Routes, Route } from "react-router-dom";
 import React from "react";
+import { vi } from "vitest";
+
+vi.mock("@/components/Layout", () => ({
+  Layout: ({ children }: any) => <>{children}</>,
+}));
 
 // ── matchMedia mock ───────────────────────────────────────────────────────────
 let currentWidth = 1280;

--- a/frontend/src/__tests__/components/DashboardMob5.test.tsx
+++ b/frontend/src/__tests__/components/DashboardMob5.test.tsx
@@ -4,6 +4,11 @@
 import { render, act } from "@testing-library/react";
 import { MemoryRouter, Routes, Route } from "react-router-dom";
 import React from "react";
+import { vi } from "vitest";
+
+vi.mock("@/components/Layout", () => ({
+  Layout: ({ children }: any) => <>{children}</>,
+}));
 
 // ── matchMedia mock ───────────────────────────────────────────────────────────
 let currentWidth = 1280;

--- a/frontend/src/__tests__/components/Gate1564.test.tsx
+++ b/frontend/src/__tests__/components/Gate1564.test.tsx
@@ -115,6 +115,9 @@ vi.mock("@/services/property", () => ({
     getMyProperties: vi.fn().mockResolvedValue([]),
   },
 }));
+vi.mock("@/components/Layout", () => ({
+  Layout: ({ children }: any) => <>{children}</>,
+}));
 
 // ─── Imports ──────────────────────────────────────────────────────────────────
 

--- a/frontend/src/__tests__/components/Listing94.test.tsx
+++ b/frontend/src/__tests__/components/Listing94.test.tsx
@@ -118,6 +118,9 @@ vi.mock("@/store/propertyStore", () => ({
 vi.mock("@/store/jobStore", () => ({
   useJobStore: () => ({ jobs: [] }),
 }));
+vi.mock("@/components/Layout", () => ({
+  Layout: ({ children }: any) => <>{children}</>,
+}));
 
 import ListingDetailPage  from "@/pages/ListingDetailPage";
 import AgentMarketplacePage from "@/pages/AgentMarketplacePage";

--- a/frontend/src/__tests__/components/Listing95.test.tsx
+++ b/frontend/src/__tests__/components/Listing95.test.tsx
@@ -182,6 +182,9 @@ vi.mock("@/services/agent", () => ({
   },
   computeAverageRating: () => 0,
 }));
+vi.mock("@/components/Layout", () => ({
+  Layout: ({ children }: any) => <>{children}</>,
+}));
 
 import ListingDetailPage  from "@/pages/ListingDetailPage";
 import AgentPublicPage    from "@/pages/AgentPublicPage";

--- a/frontend/src/__tests__/components/Listing96.test.tsx
+++ b/frontend/src/__tests__/components/Listing96.test.tsx
@@ -88,6 +88,9 @@ vi.mock("@/store/propertyStore", () => ({
 vi.mock("@/store/jobStore", () => ({
   useJobStore: () => ({ jobs: [] }),
 }));
+vi.mock("@/components/Layout", () => ({
+  Layout: ({ children }: any) => <>{children}</>,
+}));
 
 import AgentBrowsePage from "@/pages/AgentBrowsePage";
 import AgentPublicPage  from "@/pages/AgentPublicPage";

--- a/frontend/src/__tests__/pages/SettingsPage.test.tsx
+++ b/frontend/src/__tests__/pages/SettingsPage.test.tsx
@@ -73,6 +73,9 @@ vi.mock("react-router-dom", async (importOriginal) => {
   const actual = await importOriginal<typeof import("react-router-dom")>();
   return { ...actual, useNavigate: () => vi.fn() };
 });
+vi.mock("@/components/Layout", () => ({
+  Layout: ({ children }: any) => <>{children}</>,
+}));
 
 import SettingsPage from "@/pages/SettingsPage";
 import { paymentService } from "@/services/payment";

--- a/frontend/src/__tests__/perf/renderPerf1341_1342.test.tsx
+++ b/frontend/src/__tests__/perf/renderPerf1341_1342.test.tsx
@@ -279,6 +279,9 @@ vi.mock("@/services/agentProfile", () => ({
     appendToUrl: vi.fn((url: string) => url),
   },
 }));
+vi.mock("@/components/Layout", () => ({
+  Layout: ({ children }: any) => <>{children}</>,
+}));
 
 // ─── 13.4.1 tests ─────────────────────────────────────────────────────────────
 

--- a/frontend/src/__tests__/seo/CanonicalSeo6.test.tsx
+++ b/frontend/src/__tests__/seo/CanonicalSeo6.test.tsx
@@ -8,9 +8,44 @@ import { render } from "@testing-library/react";
 import { MemoryRouter, Routes, Route } from "react-router-dom";
 import { HelmetProvider } from "react-helmet-async";
 import React from "react";
+import { vi } from "vitest";
 
 (globalThis as any).requestAnimationFrame = (cb: FrameRequestCallback) => { cb(0); return 0; };
 (globalThis as any).cancelAnimationFrame = () => {};
+
+const PENDING = vi.hoisted(() => new Promise<never>(() => {}));
+
+vi.mock("@/components/Layout", () => ({
+  Layout: ({ children }: any) => <>{children}</>,
+}));
+vi.mock("@/services/contractor", () => ({
+  contractorService: {
+    getContractor:  vi.fn(() => PENDING),
+    getCredentials: vi.fn(() => PENDING),
+  },
+}));
+vi.mock("@/services/agent", () => ({
+  agentService: {
+    getPublicProfile: vi.fn(() => PENDING),
+    getReviews:       vi.fn(() => PENDING),
+  },
+}));
+vi.mock("@/services/listing", () => ({
+  listingService: {
+    getAgentPerformanceRecords: vi.fn(() => PENDING),
+    getListing:                 vi.fn(() => PENDING),
+    getPublicListing:           vi.fn(() => PENDING),
+  },
+}));
+vi.mock("@/services/property", () => ({
+  propertyService: { getProperty: vi.fn(() => PENDING) },
+}));
+vi.mock("@/services/job", () => ({
+  jobService: { getByProperty: vi.fn(() => PENDING) },
+}));
+vi.mock("@/services/fsbo", () => ({
+  fsboService: { getRecord: vi.fn(() => null) },
+}));
 
 Object.defineProperty(window, "matchMedia", {
   writable: true, configurable: true,

--- a/frontend/src/__tests__/seo/HelmetMetaSeo1.test.tsx
+++ b/frontend/src/__tests__/seo/HelmetMetaSeo1.test.tsx
@@ -12,11 +12,46 @@ import { render } from "@testing-library/react";
 import { MemoryRouter, Routes, Route } from "react-router-dom";
 import { HelmetProvider } from "react-helmet-async";
 import React from "react";
+import { vi } from "vitest";
 
 // ── requestAnimationFrame — react-helmet-async defers DOM writes via RAF ───────
 // Run synchronously so document.title and meta tags are set before assertions.
 (globalThis as any).requestAnimationFrame = (cb: FrameRequestCallback) => { cb(0); return 0; };
 (globalThis as any).cancelAnimationFrame = () => {};
+
+const PENDING = vi.hoisted(() => new Promise<never>(() => {}));
+
+vi.mock("@/components/Layout", () => ({
+  Layout: ({ children }: any) => <>{children}</>,
+}));
+vi.mock("@/services/contractor", () => ({
+  contractorService: {
+    getContractor:  vi.fn(() => PENDING),
+    getCredentials: vi.fn(() => PENDING),
+  },
+}));
+vi.mock("@/services/agent", () => ({
+  agentService: {
+    getPublicProfile: vi.fn(() => PENDING),
+    getReviews:       vi.fn(() => PENDING),
+  },
+}));
+vi.mock("@/services/listing", () => ({
+  listingService: {
+    getAgentPerformanceRecords: vi.fn(() => PENDING),
+    getListing:                 vi.fn(() => PENDING),
+    getPublicListing:           vi.fn(() => PENDING),
+  },
+}));
+vi.mock("@/services/property", () => ({
+  propertyService: { getProperty: vi.fn(() => PENDING) },
+}));
+vi.mock("@/services/job", () => ({
+  jobService: { getByProperty: vi.fn(() => PENDING) },
+}));
+vi.mock("@/services/fsbo", () => ({
+  fsboService: { getRecord: vi.fn(() => null) },
+}));
 
 // ── matchMedia stub (required by useBreakpoint) ───────────────────────────────
 Object.defineProperty(window, "matchMedia", {

--- a/frontend/src/__tests__/seo/JsonLdSeo4.test.tsx
+++ b/frontend/src/__tests__/seo/JsonLdSeo4.test.tsx
@@ -8,9 +8,46 @@ import { render } from "@testing-library/react";
 import { MemoryRouter, Routes, Route } from "react-router-dom";
 import { HelmetProvider } from "react-helmet-async";
 import React from "react";
+import { vi } from "vitest";
 
 (globalThis as any).requestAnimationFrame = (cb: FrameRequestCallback) => { cb(0); return 0; };
 (globalThis as any).cancelAnimationFrame = () => {};
+
+// Never-resolving promise — prevents async setState calls (setLoading, setProfile, etc.)
+// from firing outside act() while still allowing synchronous Helmet tag rendering.
+const PENDING = vi.hoisted(() => new Promise<never>(() => {}));
+
+vi.mock("@/components/Layout", () => ({
+  Layout: ({ children }: any) => <>{children}</>,
+}));
+vi.mock("@/services/contractor", () => ({
+  contractorService: {
+    getContractor:  vi.fn(() => PENDING),
+    getCredentials: vi.fn(() => PENDING),
+  },
+}));
+vi.mock("@/services/agent", () => ({
+  agentService: {
+    getPublicProfile: vi.fn(() => PENDING),
+    getReviews:       vi.fn(() => PENDING),
+  },
+}));
+vi.mock("@/services/listing", () => ({
+  listingService: {
+    getAgentPerformanceRecords: vi.fn(() => PENDING),
+    getListing:                 vi.fn(() => PENDING),
+    getPublicListing:           vi.fn(() => PENDING),
+  },
+}));
+vi.mock("@/services/property", () => ({
+  propertyService: { getProperty: vi.fn(() => PENDING) },
+}));
+vi.mock("@/services/job", () => ({
+  jobService: { getByProperty: vi.fn(() => PENDING) },
+}));
+vi.mock("@/services/fsbo", () => ({
+  fsboService: { getRecord: vi.fn(() => null) },
+}));
 
 Object.defineProperty(window, "matchMedia", {
   writable: true, configurable: true,

--- a/frontend/src/__tests__/seo/OgImageSeo3.test.tsx
+++ b/frontend/src/__tests__/seo/OgImageSeo3.test.tsx
@@ -11,9 +11,44 @@ import { HelmetProvider } from "react-helmet-async";
 import React from "react";
 import { existsSync } from "fs";
 import { resolve } from "path";
+import { vi } from "vitest";
 
 (globalThis as any).requestAnimationFrame = (cb: FrameRequestCallback) => { cb(0); return 0; };
 (globalThis as any).cancelAnimationFrame = () => {};
+
+const PENDING = vi.hoisted(() => new Promise<never>(() => {}));
+
+vi.mock("@/components/Layout", () => ({
+  Layout: ({ children }: any) => <>{children}</>,
+}));
+vi.mock("@/services/contractor", () => ({
+  contractorService: {
+    getContractor:  vi.fn(() => PENDING),
+    getCredentials: vi.fn(() => PENDING),
+  },
+}));
+vi.mock("@/services/agent", () => ({
+  agentService: {
+    getPublicProfile: vi.fn(() => PENDING),
+    getReviews:       vi.fn(() => PENDING),
+  },
+}));
+vi.mock("@/services/listing", () => ({
+  listingService: {
+    getAgentPerformanceRecords: vi.fn(() => PENDING),
+    getListing:                 vi.fn(() => PENDING),
+    getPublicListing:           vi.fn(() => PENDING),
+  },
+}));
+vi.mock("@/services/property", () => ({
+  propertyService: { getProperty: vi.fn(() => PENDING) },
+}));
+vi.mock("@/services/job", () => ({
+  jobService: { getByProperty: vi.fn(() => PENDING) },
+}));
+vi.mock("@/services/fsbo", () => ({
+  fsboService: { getRecord: vi.fn(() => null) },
+}));
 
 Object.defineProperty(window, "matchMedia", {
   writable: true, configurable: true,

--- a/frontend/src/__tests__/setup.ts
+++ b/frontend/src/__tests__/setup.ts
@@ -40,6 +40,28 @@ if (typeof HTMLCanvasElement !== "undefined") {
   HTMLCanvasElement.prototype.getContext = () => null;
 }
 
+// window.indexedDB stub — jsdom provides no IDB implementation.
+// AuthContext (and ICP auth-client) calls indexedDB.open() at mount; without
+// this stub the call returns undefined and the promise-chain hangs, causing
+// parallel test suites to time-out waiting on IDB-dependent async effects.
+// Throwing a DOMException makes the error path run immediately so the
+// component reaches a settled state before assertions run.
+if (!("indexedDB" in window) || (window as any).indexedDB == null) {
+  Object.defineProperty(window, "indexedDB", {
+    writable: true,
+    configurable: true,
+    value: {
+      open(_name: string, _version?: number): never {
+        throw new DOMException("Not available in jsdom", "UnknownError");
+      },
+      deleteDatabase(): never {
+        throw new DOMException("Not available in jsdom", "UnknownError");
+      },
+      cmp: () => 0,
+    },
+  });
+}
+
 // Default requestAnimationFrame stub — react-helmet-async defers DOM writes
 // via RAF; this makes those writes synchronous in tests.
 if (typeof (globalThis as any).requestAnimationFrame !== "function") {


### PR DESCRIPTION
## Summary
- Adds `window.indexedDB` stub in `setup.ts` that throws `DOMException` on `open()`, so `AuthContext`'s IDB initialisation fails fast instead of hanging parallel test suites
- Adds `vi.mock("@/components/Layout")` to 10 test files (AgentPages, CancelledAccount835, ContractorDashMob6, DashboardMob5, Gate1564, Listing94/95/96, SettingsPage, renderPerf1341_1342) — prevents Layout's own auth/IDB effects from firing in tests that only exercise page-level behaviour
- Adds Layout mock + never-resolving `PENDING` service stubs (`vi.hoisted` pattern) to all 4 SEO test files (HelmetMetaSeo1, OgImageSeo3, JsonLdSeo4, CanonicalSeo6) — service calls never settle outside `act()` while Helmet tags still render synchronously for SEO assertions

## Why
Async effects in Layout (auth check, IDB open) and in ContractorPublicPage/AgentPublicPage/FsboListingPage triggered React's "not wrapped in act()" warning and caused CI parallelism hangs. This is a direct implementation rather than a branch merge (per #191 scope).

## Test plan
- [ ] `npm run test:unit` — all 3253 tests pass with no act() warnings or IDB errors in stderr
- [ ] No test timeouts in CI parallel run

🤖 Generated with [Claude Code](https://claude.com/claude-code)