### PR TITLE
ops(#103): add BACKUP_CONTROLLER_PRINCIPAL to testnet deploy workflow

### DIFF
--- a/.github/workflows/deploy-testnet.yml
+++ b/.github/workflows/deploy-testnet.yml
@@ -41,3 +41,4 @@ jobs:
         run: bash scripts/deploy.sh testnet
         env:
           DFX_IDENTITY_PEM: ${{ secrets.DFX_IDENTITY_PEM }}
+          BACKUP_CONTROLLER_PRINCIPAL: ${{ secrets.BACKUP_CONTROLLER_PRINCIPAL }}


### PR DESCRIPTION
## Summary

- Mainnet deploy workflow already had `BACKUP_CONTROLLER_PRINCIPAL` wired — testnet was missing it
- Without a backup controller, a lost/rotated `DFX_IDENTITY_PEM` leaves all testnet canisters permanently unmanageable
- One-line addition to `deploy-testnet.yml`; `deploy.sh` already calls `dfx canister update-settings --add-controller` for all canisters when the env var is present — no script changes needed

## Pre-requisite

Add `BACKUP_CONTROLLER_PRINCIPAL` to GitHub Secrets (repo Settings → Secrets → Actions) with the principal from your offline backup identity.

## Test plan

- [ ] Add `BACKUP_CONTROLLER_PRINCIPAL` secret to GitHub repo settings
- [ ] Merge and confirm next testnet deploy shows the backup controller added in `dfx canister info` output for each canister

Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)