### PR TITLE
ops(#102): wallet cycles pre-flight check for testnet deploy

### DIFF
--- a/.github/workflows/deploy-testnet.yml
+++ b/.github/workflows/deploy-testnet.yml
@@ -37,6 +37,13 @@ jobs:
       - name: Install mops
         run: npm install -g ic-mops
 
+      - name: Wallet cycles pre-flight
+        run: bash scripts/check-wallet-balance.sh
+        env:
+          DFX_IDENTITY_PEM: ${{ secrets.DFX_IDENTITY_PEM }}
+          DFX_NETWORK: ic
+          MIN_WALLET_CYCLES: '5000000000000'
+
       - name: Deploy to testnet
         run: bash scripts/deploy.sh testnet
         env:

--- a/scripts/check-wallet-balance.sh
+++ b/scripts/check-wallet-balance.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# HomeGentic — Wallet Cycles Pre-flight Check (issue #102)
+#
+# Verifies the deploy identity's cycles wallet has enough cycles to create
+# all 18 canisters before deploy begins. Fails fast rather than crashing
+# mid-deploy and leaving the app partially deployed.
+#
+# Usage (pre-deploy in CI):
+#   bash scripts/check-wallet-balance.sh
+#
+# Environment:
+#   DFX_NETWORK       — target network (default: ic)
+#   MIN_WALLET_CYCLES — minimum required cycles (default: 5T)
+
+set -uo pipefail
+
+DFX_NETWORK="${DFX_NETWORK:-ic}"
+MIN_WALLET_CYCLES="${MIN_WALLET_CYCLES:-5000000000000}"   # 5T
+
+echo "============================================"
+echo "  HomeGentic — Wallet Pre-flight Check"
+echo "  Network  : $DFX_NETWORK"
+echo "  Minimum  : $MIN_WALLET_CYCLES cycles ($(( MIN_WALLET_CYCLES / 1000000000000 ))T)"
+echo "============================================"
+
+BALANCE_OUT=$(dfx wallet balance --network "$DFX_NETWORK" 2>&1)
+if [ $? -ne 0 ]; then
+  echo "❌  Could not query wallet balance: $BALANCE_OUT"
+  echo "    Ensure DFX_IDENTITY_PEM is set and the wallet exists."
+  exit 1
+fi
+
+# Parse output like "8.338 TC (trillion cycles)." or "8338000000000 cycles."
+# Handle both TC (trillion) and raw cycle formats.
+if echo "$BALANCE_OUT" | grep -qi "TC\|trillion"; then
+  TC=$(echo "$BALANCE_OUT" | grep -oE '[0-9]+\.[0-9]+|[0-9]+' | head -1)
+  BALANCE=$(echo "$TC * 1000000000000" | bc | cut -d. -f1)
+else
+  BALANCE=$(echo "$BALANCE_OUT" | grep -oE '[0-9]+' | head -1)
+fi
+
+if [ -z "$BALANCE" ] || ! [[ "$BALANCE" =~ ^[0-9]+$ ]]; then
+  echo "❌  Could not parse wallet balance from: $BALANCE_OUT"
+  exit 1
+fi
+
+echo "  Wallet balance: $BALANCE cycles ($(echo "scale=3; $BALANCE / 1000000000000" | bc)T)"
+
+if [ "$BALANCE" -lt "$MIN_WALLET_CYCLES" ]; then
+  echo ""
+  echo "❌  INSUFFICIENT CYCLES — need at least ${MIN_WALLET_CYCLES} cycles to deploy."
+  echo "    Top up via: dfx wallet --network $DFX_NETWORK send <amount>"
+  echo "    Or via the NNS dapp: https://nns.ic0.app"
+  exit 1
+fi
+
+echo ""
+echo "✅  Wallet pre-flight passed — sufficient cycles to deploy."
+exit 0


### PR DESCRIPTION
## Summary

- Adds `scripts/check-wallet-balance.sh` — queries the deploy identity's cycles wallet balance before any canister creation begins
- Wires it as a pre-deploy step in `deploy-testnet.yml` with a 5T cycle minimum threshold
- Fails fast with a clear top-up message instead of crashing mid-deploy and leaving canisters partially created

## Setup completed

- CI deploy identity `ci-deploy` created (principal: `4chvf-wp2yd-5iqka-h2rvb-islz5-nmlnz-72vbn-aw35i-cmdts-4eebd-eqe`)
- Cycles wallet `h4jao-bqaaa-aaaao-ba3lq-cai` funded with ~8.3T cycles
- `DFX_IDENTITY_PEM` added to GitHub repository secrets

## Test plan

- [ ] Merge and confirm next CI run passes the pre-flight step
- [ ] Optionally test failure path: temporarily set `MIN_WALLET_CYCLES` to an impossibly high value and confirm the workflow fails at the pre-flight step with the expected error message

Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)