### PR TITLE
ops: wire testnet GitHub environment and missing deploy secrets

### DIFF
--- a/.github/workflows/deploy-testnet.yml
+++ b/.github/workflows/deploy-testnet.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    environment: testnet
     if: github.event.workflow_run.conclusion == 'success'
     steps:
       - uses: actions/checkout@v6
@@ -49,3 +50,8 @@ jobs:
         env:
           DFX_IDENTITY_PEM: ${{ secrets.DFX_IDENTITY_PEM }}
           BACKUP_CONTROLLER_PRINCIPAL: ${{ secrets.BACKUP_CONTROLLER_PRINCIPAL }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          VOICE_AGENT_API_KEY: ${{ secrets.VOICE_AGENT_API_KEY }}
+          VITE_VOICE_AGENT_API_KEY: ${{ secrets.VITE_VOICE_AGENT_API_KEY }}
+          STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
+          VITE_STRIPE_PUBLISHABLE_KEY: ${{ secrets.VITE_STRIPE_PUBLISHABLE_KEY }}


### PR DESCRIPTION
## Summary

- Adds `environment: testnet` to the deploy job so environment-scoped secrets are available
- Wires the 5 secrets that were missing and causing pre-flight warnings:
  - `ANTHROPIC_API_KEY` — Claude API calls
  - `VOICE_AGENT_API_KEY` — voice agent endpoint auth
  - `VITE_VOICE_AGENT_API_KEY` — frontend auth header to voice agent
  - `STRIPE_SECRET_KEY` — payment processing
  - `VITE_STRIPE_PUBLISHABLE_KEY` — Stripe.js initialization

## Pre-requisite

All 5 secrets must be added under the `testnet` environment in GitHub (Settings → Environments → testnet → Environment secrets) before merging.

## Test plan

- [ ] Merge and confirm next CI deploy run shows no missing-secret warnings in the pre-flight output

🤖 Generated with [Claude Code](https://claude.com/claude-code)