### PR TITLE
fix(ci): skip dfx deps pull — deploy backend canisters explicitly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,11 +133,12 @@ jobs:
           # canisters that import ic:aaaaa-aa (e.g. caffeineai-http-outcalls).
           mkdir -p .dfx/local/canisters/idl/
           cp did/aaaaa-aa.did .dfx/local/canisters/idl/
-          # Fetch candid interfaces for pull-type canisters (e.g. internet_identity).
-          # dfx deploy fails if deps/candid/<canister>.did is absent.
-          dfx deps pull
+          # Deploy backend canisters explicitly — internet_identity and frontend are
+          # excluded because: (a) no backend canister imports II, (b) dfx deps pull
+          # fails on dfx 0.24.x with "dfx metadata not found" for the II canister.
           dfx deploy auth --argument "(principal \"$DEPLOYER\")"
-          dfx deploy
+          dfx deploy ai_proxy property job contractor quote payment photo \
+            monitoring market report maintenance sensor listing agent bills recurring
 
           # ── Bootstrap admin lists ────────────────────────────────────────────
           for canister in property job contractor quote photo report maintenance market sensor listing agent recurring bills monitoring; do

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,8 +137,10 @@ jobs:
           # excluded because: (a) no backend canister imports II, (b) dfx deps pull
           # fails on dfx 0.24.x with "dfx metadata not found" for the II canister.
           dfx deploy auth --argument "(principal \"$DEPLOYER\")"
-          dfx deploy ai_proxy property job contractor quote payment photo \
-            monitoring market report maintenance sensor listing agent bills recurring
+          for canister in ai_proxy property job contractor quote payment photo \
+            monitoring market report maintenance sensor listing agent bills recurring; do
+            dfx deploy "$canister"
+          done
 
           # ── Bootstrap admin lists ────────────────────────────────────────────
           for canister in property job contractor quote photo report maintenance market sensor listing agent recurring bills monitoring; do


### PR DESCRIPTION
## Problem

CI was failing with:
```
Error: Failed to get dependencies of canister rdmx6-jaaaa-aaaaa-aaadq-cai.
Caused by: `dfx` metadata not found in canister rdmx6-jaaaa-aaaaa-aaadq-cai.
```

`dfx 0.24.3` requires the `dfx` metadata section to be present in any pull-type canister. The Internet Identity canister on mainnet doesn't expose this metadata, so `dfx deps pull` errors out before any deployment begins.

## Fix

- Remove `dfx deps pull`
- Replace bare `dfx deploy` (deploys all canisters including II) with an explicit list of the 17 backend canisters
- `internet_identity` and `frontend` are excluded — no backend canister imports II, and the frontend asset canister isn't needed for backend tests

## Test plan

- [ ] CI passes the "Deploy canisters" step without the deps pull error
- [ ] All backend canister tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)