### PR TITLE
fix(ci): correct dfxvm PATH in ci.yml and deploy-testnet.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
         # test-backend.sh also calls `dfx ping`, so dfx must be the active replica.
         run: |
           DFX_VERSION=0.24.3 DFXVM_INIT_YES=1 sh -c "$(curl -fsSL https://internetcomputer.org/install.sh)"
-          echo "$HOME/.local/share/dfx/bin" >> "$GITHUB_PATH"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Cache mops packages
         uses: actions/cache@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,8 +96,8 @@ jobs:
         # cycles infrastructure so icp canister create fails on fresh networks.
         # test-backend.sh also calls `dfx ping`, so dfx must be the active replica.
         run: |
-          curl -fsSL "https://github.com/dfinity/sdk/releases/download/0.24.3/dfx-x86_64-unknown-linux-musl.tar.xz" \
-            | tar -xJ dfx
+          curl -fsSL "https://github.com/dfinity/sdk/releases/download/0.24.3/dfx-x86_64-unknown-linux-gnu.tar.gz" \
+            | tar -xz dfx
           sudo install -m 755 dfx /usr/local/bin/dfx
           dfx --version
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,9 @@ jobs:
         # test-backend.sh also calls `dfx ping`, so dfx must be the active replica.
         run: |
           DFX_VERSION=0.24.3 DFXVM_INIT_YES=1 sh -c "$(curl -fsSL https://internetcomputer.org/install.sh)"
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          . "$HOME/.local/share/dfx/env"
+          echo "PATH=$PATH" >> "$GITHUB_ENV"
+          dfx --version
 
       - name: Cache mops packages
         uses: actions/cache@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,9 +96,9 @@ jobs:
         # cycles infrastructure so icp canister create fails on fresh networks.
         # test-backend.sh also calls `dfx ping`, so dfx must be the active replica.
         run: |
-          DFX_VERSION=0.24.3 DFXVM_INIT_YES=1 sh -c "$(curl -fsSL https://internetcomputer.org/install.sh)"
-          . "$HOME/.local/share/dfx/env"
-          echo "PATH=$PATH" >> "$GITHUB_ENV"
+          curl -fsSL "https://github.com/dfinity/sdk/releases/download/0.24.3/dfx-x86_64-unknown-linux-musl.tar.xz" \
+            | tar -xJ dfx
+          sudo install -m 755 dfx /usr/local/bin/dfx
           dfx --version
 
       - name: Cache mops packages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,8 +97,9 @@ jobs:
         # test-backend.sh also calls `dfx ping`, so dfx must be the active replica.
         run: |
           curl -fsSL "https://github.com/dfinity/sdk/releases/download/0.24.3/dfx-x86_64-unknown-linux-gnu.tar.gz" \
-            | tar -xz dfx
-          sudo install -m 755 dfx /usr/local/bin/dfx
+            | tar -xz
+          DFX_BIN=$(find . -name "dfx*" -type f -perm /111 | head -1)
+          sudo install -m 755 "$DFX_BIN" /usr/local/bin/dfx
           dfx --version
 
       - name: Cache mops packages

--- a/.github/workflows/deploy-testnet.yml
+++ b/.github/workflows/deploy-testnet.yml
@@ -41,7 +41,9 @@ jobs:
       - name: Install dfx
         run: |
           DFX_VERSION=0.24.3 DFXVM_INIT_YES=1 sh -c "$(curl -fsSL https://internetcomputer.org/install.sh)"
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          . "$HOME/.local/share/dfx/env"
+          echo "PATH=$PATH" >> "$GITHUB_ENV"
+          dfx --version
 
       - name: Wallet cycles pre-flight
         run: bash scripts/check-wallet-balance.sh

--- a/.github/workflows/deploy-testnet.yml
+++ b/.github/workflows/deploy-testnet.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Install dfx
         run: |
           DFX_VERSION=0.24.3 DFXVM_INIT_YES=1 sh -c "$(curl -fsSL https://internetcomputer.org/install.sh)"
-          echo "$HOME/.local/share/dfx/bin" >> "$GITHUB_PATH"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Wallet cycles pre-flight
         run: bash scripts/check-wallet-balance.sh

--- a/.github/workflows/deploy-testnet.yml
+++ b/.github/workflows/deploy-testnet.yml
@@ -40,8 +40,8 @@ jobs:
 
       - name: Install dfx
         run: |
-          curl -fsSL "https://github.com/dfinity/sdk/releases/download/0.24.3/dfx-x86_64-unknown-linux-musl.tar.xz" \
-            | tar -xJ dfx
+          curl -fsSL "https://github.com/dfinity/sdk/releases/download/0.24.3/dfx-x86_64-unknown-linux-gnu.tar.gz" \
+            | tar -xz dfx
           sudo install -m 755 dfx /usr/local/bin/dfx
           dfx --version
 

--- a/.github/workflows/deploy-testnet.yml
+++ b/.github/workflows/deploy-testnet.yml
@@ -41,8 +41,9 @@ jobs:
       - name: Install dfx
         run: |
           curl -fsSL "https://github.com/dfinity/sdk/releases/download/0.24.3/dfx-x86_64-unknown-linux-gnu.tar.gz" \
-            | tar -xz dfx
-          sudo install -m 755 dfx /usr/local/bin/dfx
+            | tar -xz
+          DFX_BIN=$(find . -name "dfx*" -type f -perm /111 | head -1)
+          sudo install -m 755 "$DFX_BIN" /usr/local/bin/dfx
           dfx --version
 
       - name: Wallet cycles pre-flight

--- a/.github/workflows/deploy-testnet.yml
+++ b/.github/workflows/deploy-testnet.yml
@@ -40,9 +40,9 @@ jobs:
 
       - name: Install dfx
         run: |
-          DFX_VERSION=0.24.3 DFXVM_INIT_YES=1 sh -c "$(curl -fsSL https://internetcomputer.org/install.sh)"
-          . "$HOME/.local/share/dfx/env"
-          echo "PATH=$PATH" >> "$GITHUB_ENV"
+          curl -fsSL "https://github.com/dfinity/sdk/releases/download/0.24.3/dfx-x86_64-unknown-linux-musl.tar.xz" \
+            | tar -xJ dfx
+          sudo install -m 755 dfx /usr/local/bin/dfx
           dfx --version
 
       - name: Wallet cycles pre-flight


### PR DESCRIPTION
## Summary
- Changes `~/.local/share/dfx/bin` → `~/.local/bin` in the dfx install step in both `ci.yml` (test-backend) and `deploy-testnet.yml`

DFXVM places the `dfx` shim at `~/.local/bin/dfx`. The previous path (`~/.local/share/dfx/bin`) doesn't exist, so every step calling `dfx` after install got `command not found`.

## Test plan
- [ ] `test-backend` — "Start local replica" step passes without `dfx: command not found`
- [ ] `deploy-testnet` — "Wallet cycles pre-flight" step can call `dfx wallet balance`

🤖 Generated with [Claude Code](https://claude.com/claude-code)