### PR TITLE
fix(ci): load DFX_IDENTITY_PEM into dfx before wallet balance check

### DIFF
--- a/scripts/check-wallet-balance.sh
+++ b/scripts/check-wallet-balance.sh
@@ -9,6 +9,7 @@
 #   bash scripts/check-wallet-balance.sh
 #
 # Environment:
+#   DFX_IDENTITY_PEM  — PEM content for the deploy identity (required in CI)
 #   DFX_NETWORK       — target network (default: ic)
 #   MIN_WALLET_CYCLES — minimum required cycles (default: 5T)
 
@@ -16,6 +17,15 @@ set -uo pipefail
 
 DFX_NETWORK="${DFX_NETWORK:-ic}"
 MIN_WALLET_CYCLES="${MIN_WALLET_CYCLES:-5000000000000}"   # 5T
+
+# Load deploy identity from PEM env var when running in CI.
+if [ -n "${DFX_IDENTITY_PEM:-}" ]; then
+  PEM_FILE=$(mktemp /tmp/ci-identity-XXXXXX.pem)
+  trap 'rm -f "$PEM_FILE"' EXIT
+  printf '%s' "$DFX_IDENTITY_PEM" > "$PEM_FILE"
+  dfx identity import --storage-mode=plaintext ci-deploy "$PEM_FILE" 2>/dev/null || true
+  dfx identity use ci-deploy
+fi
 
 echo "============================================"
 echo "  HomeGentic — Wallet Pre-flight Check"


### PR DESCRIPTION
check-wallet-balance.sh was falling back to the 'default' identity which has no wallet configured on mainnet. Import the PEM from the env var into a 'ci-deploy' dfx identity (same as deploy.sh does via icp-cli) before querying the wallet.

## Summary
<!-- What does this PR do? -->

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [ ] Backend tests pass (`make test`)
- [ ] Frontend builds (`cd frontend && npm run build`)
- [ ] Tested locally with dfx

## Checklist
- [ ] Code follows project conventions
- [ ] Self-review completed
- [ ] No sensitive data committed
