### PR TITLE
fix(ci): call set-wallet after identity import; add DFX_WALLET_ID secret

### DIFF
--- a/.github/workflows/deploy-testnet.yml
+++ b/.github/workflows/deploy-testnet.yml
@@ -50,6 +50,7 @@ jobs:
         run: bash scripts/check-wallet-balance.sh
         env:
           DFX_IDENTITY_PEM: ${{ secrets.DFX_IDENTITY_PEM }}
+          DFX_WALLET_ID: ${{ secrets.DFX_WALLET_ID }}
           DFX_NETWORK: ic
           MIN_WALLET_CYCLES: '5000000000000'
 

--- a/scripts/check-wallet-balance.sh
+++ b/scripts/check-wallet-balance.sh
@@ -25,6 +25,9 @@ if [ -n "${DFX_IDENTITY_PEM:-}" ]; then
   printf '%s' "$DFX_IDENTITY_PEM" > "$PEM_FILE"
   dfx identity import --storage-mode=plaintext ci-deploy "$PEM_FILE" 2>/dev/null || true
   dfx identity use ci-deploy
+  if [ -n "${DFX_WALLET_ID:-}" ]; then
+    dfx identity set-wallet "$DFX_WALLET_ID" --network "$DFX_NETWORK"
+  fi
 fi
 
 echo "============================================"


### PR DESCRIPTION
dfx identity import loads the key but dfx still has no wallet configured for mainnet. Call 'dfx identity set-wallet <id> --network ic' using the new DFX_WALLET_ID secret (h4jao-bqaaa-aaaao-ba3lq-cai).

## Summary
<!-- What does this PR do? -->

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [ ] Backend tests pass (`make test`)
- [ ] Frontend builds (`cd frontend && npm run build`)
- [ ] Tested locally with dfx

## Checklist
- [ ] Code follows project conventions
- [ ] Self-review completed
- [ ] No sensitive data committed
