### PR TITLE
fix(deploy): pass --wallet explicitly to dfx canister call --with-cycles

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -229,6 +229,7 @@ if [ "$ENV" != "local" ] && [ -n "${DFX_WALLET_ID:-}" ] && [ -n "${DFX_IDENTITY_
   if dfx canister call um5iw-rqaaa-aaaaq-qaaba-cai deposit_cycles \
     "(record { to = record { owner = principal \"$DEPLOY_PRINCIPAL\"; subaccount = null } })" \
     --with-cycles "$_FUND" \
+    --wallet "$DFX_WALLET_ID" \
     --network ic; then
     echo "  ✓ Cycles ledger funded"
   else


### PR DESCRIPTION
dfx canister call requires --wallet <id> as an explicit arg even when the identity's wallet is already configured via set-wallet.

## Summary
<!-- What does this PR do? -->

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [ ] Backend tests pass (`make test`)
- [ ] Frontend builds (`cd frontend && npm run build`)
- [ ] Tested locally with dfx

## Checklist
- [ ] Code follows project conventions
- [ ] Self-review completed
- [ ] No sensitive data committed
