### PR TITLE
fix(deploy): use correct cycles ledger deposit method name

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-DEPLOY_SCRIPT_VERSION="1.4.8"
+DEPLOY_SCRIPT_VERSION="1.4.9"
 ENV=${1:-local}
 
 echo "============================================"
@@ -226,8 +226,8 @@ if [ "$ENV" != "local" ] && [ -n "${DFX_WALLET_ID:-}" ] && [ -n "${DFX_IDENTITY_
   # Wallet must hold ≥ 40T cycles — top up at https://nns.ic0.app if needed.
   _FUND=40000000000000
   echo "▶ Depositing ${_FUND} cycles from wallet to cycles ledger for $DEPLOY_PRINCIPAL..."
-  if dfx canister call um5iw-rqaaa-aaaaq-qaaba-cai deposit_cycles \
-    "(record { to = record { owner = principal \"$DEPLOY_PRINCIPAL\"; subaccount = null } })" \
+  if dfx canister call um5iw-rqaaa-aaaaq-qaaba-cai deposit \
+    "(record { to = record { owner = principal \"$DEPLOY_PRINCIPAL\"; subaccount = null }; memo = null; created_at_time = null })" \
     --with-cycles "$_FUND" \
     --wallet "$DFX_WALLET_ID" \
     --network ic; then


### PR DESCRIPTION
`deposit_cycles` does not exist on the IC cycles ledger canister (um5iw-rqaaa-aaaaq-qaaba-cai). The correct update method is `deposit`, which also requires `memo` and `created_at_time` optional fields.

## Summary
<!-- What does this PR do? -->

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [ ] Backend tests pass (`make test`)
- [ ] Frontend builds (`cd frontend && npm run build`)
- [ ] Tested locally with dfx

## Checklist
- [ ] Code follows project conventions
- [ ] Self-review completed
- [ ] No sensitive data committed
