### PR TITLE
fix(deploy): commit testnet canister IDs + fix cycles check pipefail

### DIFF
--- a/canister_ids.json
+++ b/canister_ids.json
@@ -1,0 +1,19 @@
+{
+  "auth": { "testnet": "bkyzt-paaaa-aaaaj-a6mlq-cai" },
+  "property": { "testnet": "ahw55-aiaaa-aaaaj-a6mma-cai" },
+  "job": { "testnet": "aax3j-nqaaa-aaaaj-a6mmq-cai" },
+  "contractor": { "testnet": "ajuqv-3yaaa-aaaaj-a6mna-cai" },
+  "quote": { "testnet": "aovwb-waaaa-aaaaj-a6mnq-cai" },
+  "payment": { "testnet": "a3shm-xiaaa-aaaaj-a6moa-cai" },
+  "photo": { "testnet": "a4tby-2qaaa-aaaaj-a6moq-cai" },
+  "report": { "testnet": "avqke-myaaa-aaaaj-a6mpa-cai" },
+  "maintenance": { "testnet": "asrmq-baaaa-aaaaj-a6mpq-cai" },
+  "market": { "testnet": "fokwv-kiaaa-aaaaj-a6mqa-cai" },
+  "sensor": { "testnet": "fjlqb-hqaaa-aaaaj-a6mqq-cai" },
+  "monitoring": { "testnet": "fai35-ryaaa-aaaaj-a6mra-cai" },
+  "listing": { "testnet": "fhj5j-4aaaa-aaaaj-a6mrq-cai" },
+  "agent": { "testnet": "fsome-5iaaa-aaaaj-a6msa-cai" },
+  "recurring": { "testnet": "fvpkq-qqaaa-aaaaj-a6msq-cai" },
+  "bills": { "testnet": "f4mbm-gyaaa-aaaaj-a6mta-cai" },
+  "ai_proxy": { "testnet": "f3nhy-laaaa-aaaaj-a6mtq-cai" }
+}

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-DEPLOY_SCRIPT_VERSION="1.4.9"
+DEPLOY_SCRIPT_VERSION="1.4.10"
 ENV=${1:-local}
 
 echo "============================================"
@@ -447,9 +447,9 @@ if [ "$ENV" != "local" ]; then
       continue
     }
 
-    BALANCE_RAW=$(echo "$STATUS_OUT" | grep "Balance:" | head -1 | sed 's/.*Balance: //;s/ Cycles.*//;s/_//g')
+    BALANCE_RAW=$(echo "$STATUS_OUT" | grep "Balance:" | head -1 | sed 's/.*Balance: //;s/ Cycles.*//;s/_//g') || BALANCE_RAW=""
 
-    if [ -z "$BALANCE_RAW" ]; then
+    if [ -z "$BALANCE_RAW" ] || ! [[ "$BALANCE_RAW" =~ ^[0-9]+$ ]]; then
       echo "  ⚠️  Could not parse cycles balance for $canister"
       continue
     fi


### PR DESCRIPTION
- canister_ids.json: record all 17 testnet canister IDs from the successful Phase 1-3 run so future deploys upgrade existing canisters instead of creating new orphans on a fresh CI runner
- deploy.sh: guard BALANCE_RAW pipeline with || BALANCE_RAW="" so a grep-no-match (exit 1) under set -o pipefail does not abort the deploy after a successful install; also add numeric regex guard before -lt

## Summary
<!-- What does this PR do? -->

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [ ] Backend tests pass (`make test`)
- [ ] Frontend builds (`cd frontend && npm run build`)
- [ ] Tested locally with dfx

## Checklist
- [ ] Code follows project conventions
- [ ] Self-review completed
- [ ] No sensitive data committed
