### PR TITLE
fix(deploy): seed icp-cli state from canister_ids.json before install

### DIFF
--- a/.github/workflows/deploy-testnet.yml
+++ b/.github/workflows/deploy-testnet.yml
@@ -66,10 +66,10 @@ jobs:
           STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
           VITE_STRIPE_PUBLISHABLE_KEY: ${{ secrets.VITE_STRIPE_PUBLISHABLE_KEY }}
 
-      - name: Commit canister_ids.json
+      - name: Commit canister IDs
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add canister_ids.json
-          git diff --staged --quiet && echo "canister_ids.json unchanged, nothing to commit" || \
-            git commit -m "ops: update canister_ids.json after testnet deploy [skip ci]" && git push
+          git add canister_ids.json .icp/data/mappings/
+          git diff --staged --quiet && echo "canister IDs unchanged, nothing to commit" || \
+            git commit -m "ops: update canister IDs after testnet deploy [skip ci]" && git push

--- a/.icp/data/mappings/testnet.ids.json
+++ b/.icp/data/mappings/testnet.ids.json
@@ -1,0 +1,19 @@
+{
+  "auth": "bkyzt-paaaa-aaaaj-a6mlq-cai",
+  "property": "ahw55-aiaaa-aaaaj-a6mma-cai",
+  "job": "aax3j-nqaaa-aaaaj-a6mmq-cai",
+  "contractor": "ajuqv-3yaaa-aaaaj-a6mna-cai",
+  "quote": "aovwb-waaaa-aaaaj-a6mnq-cai",
+  "payment": "a3shm-xiaaa-aaaaj-a6moa-cai",
+  "photo": "a4tby-2qaaa-aaaaj-a6moq-cai",
+  "report": "avqke-myaaa-aaaaj-a6mpa-cai",
+  "maintenance": "asrmq-baaaa-aaaaj-a6mpq-cai",
+  "market": "fokwv-kiaaa-aaaaj-a6mqa-cai",
+  "sensor": "fjlqb-hqaaa-aaaaj-a6mqq-cai",
+  "monitoring": "fai35-ryaaa-aaaaj-a6mra-cai",
+  "listing": "fhj5j-4aaaa-aaaaj-a6mrq-cai",
+  "agent": "fsome-5iaaa-aaaaj-a6msa-cai",
+  "recurring": "fvpkq-qqaaa-aaaaj-a6msq-cai",
+  "bills": "f4mbm-gyaaa-aaaaj-a6mta-cai",
+  "ai_proxy": "f3nhy-laaaa-aaaaj-a6mtq-cai"
+}

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-DEPLOY_SCRIPT_VERSION="1.4.11"
+DEPLOY_SCRIPT_VERSION="1.4.12"
 ENV=${1:-local}
 
 echo "============================================"
@@ -206,6 +206,23 @@ CANISTERS=(auth property job contractor quote payment photo report maintenance m
 LOG_DIR=$(mktemp -d /tmp/icp-deploy-XXXXXX)
 trap 'rm -rf "$LOG_DIR"' EXIT
 DEPLOY_PRINCIPAL=$(icp identity principal)
+
+# ── Seed icp-cli state from canister_ids.json ────────────────────────────────
+# icp canister install resolves names via .icp/data/mappings/<env>.ids.json.
+# On a fresh CI runner that file doesn't exist; generate it from the committed
+# canister_ids.json so installs work without re-creating canister slots.
+if [ "$ENV" != "local" ] && [ -f "canister_ids.json" ] && command -v python3 >/dev/null 2>&1; then
+  mkdir -p ".icp/data/mappings"
+  python3 - <<'PYEOF'
+import json, os, sys
+env = os.environ.get("ENV", "")
+src = json.load(open("canister_ids.json"))
+flat = {k: v[env] for k, v in src.items() if isinstance(v, dict) and v.get(env)}
+dest = f".icp/data/mappings/{env}.ids.json"
+json.dump(flat, open(dest, "w"), indent=2)
+print(f"  ✓ Seeded {len(flat)} canister IDs into {dest}")
+PYEOF
+fi
 
 # ── Determine which canisters need new slot creation ─────────────────────────
 # Read canister_ids.json to skip creation for canisters already deployed.


### PR DESCRIPTION
icp canister install resolves names via .icp/data/mappings/<env>.ids.json, not canister_ids.json. On a fresh CI runner this file is missing, causing Phase 3 to fail with "could not find ID for canister".

- .icp/data/mappings/testnet.ids.json: seed file with all 17 live IDs
- deploy.sh: generate .icp/data/mappings/<env>.ids.json from canister_ids.json at deploy start so fresh runners always have state
- deploy-testnet.yml: also commit .icp/data/mappings/ after fresh deploys

## Summary
<!-- What does this PR do? -->

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [ ] Backend tests pass (`make test`)
- [ ] Frontend builds (`cd frontend && npm run build`)
- [ ] Tested locally with dfx

## Checklist
- [ ] Code follows project conventions
- [ ] Self-review completed
- [ ] No sensitive data committed
