### PR TITLE
fix(deploy): record frontend canister ID + fix ENV seed + non-fatal push

### DIFF
--- a/.github/workflows/deploy-testnet.yml
+++ b/.github/workflows/deploy-testnet.yml
@@ -71,5 +71,9 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add canister_ids.json .icp/data/mappings/
-          git diff --staged --quiet && echo "canister IDs unchanged, nothing to commit" || \
-            git commit -m "ops: update canister IDs after testnet deploy [skip ci]" && git push
+          if git diff --staged --quiet; then
+            echo "canister IDs unchanged, nothing to commit"
+          else
+            git commit -m "ops: update canister IDs after testnet deploy [skip ci]"
+            git push || echo "⚠️  Push blocked by branch protection — commit canister_ids.json manually from the deploy log above"
+          fi

--- a/.icp/data/mappings/testnet.ids.json
+++ b/.icp/data/mappings/testnet.ids.json
@@ -15,5 +15,6 @@
   "agent": "fsome-5iaaa-aaaaj-a6msa-cai",
   "recurring": "fvpkq-qqaaa-aaaaj-a6msq-cai",
   "bills": "f4mbm-gyaaa-aaaaj-a6mta-cai",
-  "ai_proxy": "f3nhy-laaaa-aaaaj-a6mtq-cai"
+  "ai_proxy": "f3nhy-laaaa-aaaaj-a6mtq-cai",
+  "frontend": "eybo6-7yaaa-aaaaj-a6mva-cai"
 }

--- a/canister_ids.json
+++ b/canister_ids.json
@@ -15,5 +15,6 @@
   "agent": { "testnet": "fsome-5iaaa-aaaaj-a6msa-cai" },
   "recurring": { "testnet": "fvpkq-qqaaa-aaaaj-a6msq-cai" },
   "bills": { "testnet": "f4mbm-gyaaa-aaaaj-a6mta-cai" },
-  "ai_proxy": { "testnet": "f3nhy-laaaa-aaaaj-a6mtq-cai" }
+  "ai_proxy": { "testnet": "f3nhy-laaaa-aaaaj-a6mtq-cai" },
+  "frontend": { "testnet": "eybo6-7yaaa-aaaaj-a6mva-cai" }
 }

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-DEPLOY_SCRIPT_VERSION="1.4.13"
+DEPLOY_SCRIPT_VERSION="1.4.14"
 ENV=${1:-local}
 
 echo "============================================"
@@ -213,7 +213,7 @@ DEPLOY_PRINCIPAL=$(icp identity principal)
 # canister_ids.json so installs work without re-creating canister slots.
 if [ "$ENV" != "local" ] && [ -f "canister_ids.json" ] && command -v python3 >/dev/null 2>&1; then
   mkdir -p ".icp/data/mappings"
-  python3 - <<'PYEOF'
+  ENV="$ENV" python3 - <<'PYEOF'
 import json, os, sys
 env = os.environ.get("ENV", "")
 src = json.load(open("canister_ids.json"))


### PR DESCRIPTION
- canister_ids.json / testnet.ids.json: add frontend eybo6-7yaaa-aaaaj-a6mva-cai so all 18 IDs are known and future deploys skip slot creation entirely
- deploy.sh v1.4.14: prefix python3 call with ENV="$ENV" so os.environ sees the variable inside the single-quoted heredoc (was creating .icp/data/mappings/.ids.json with empty-string filename)
- deploy-testnet.yml: make post-deploy git push non-fatal; protected-branch rejection no longer fails an otherwise successful deploy

## Summary
<!-- What does this PR do? -->

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [ ] Backend tests pass (`make test`)
- [ ] Frontend builds (`cd frontend && npm run build`)
- [ ] Tested locally with dfx

## Checklist
- [ ] Code follows project conventions
- [ ] Self-review completed
- [ ] No sensitive data committed
