### PR TITLE
fix(voice): replace dfx shell-outs with @dfinity/agent canister calls…

### DIFF
--- a/agents/voice/.env.example
+++ b/agents/voice/.env.example
@@ -27,6 +27,14 @@ STRIPE_PRICE_CONTRACTOR_PRO_YEARLY=price_...
 STRIPE_PRICE_CREDITS_25=price_...
 STRIPE_PRICE_CREDITS_100=price_...
 
+# ── ICP canister calls (replaces dfx shell-outs) ─────────────────────────────
+# Same PEM used by the deploy identity — must be admin in the payment canister
+DFX_IDENTITY_PEM="-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----"
+
+# Payment canister principal — testnet default is already hardcoded as fallback
+# Set this if deploying against a different network or canister ID changes
+# CANISTER_ID_PAYMENT=a3shm-xiaaa-aaaaj-a6moa-cai
+
 # ── Optional ──────────────────────────────────────────────────────────────────
 # Railway/Render inject PORT automatically; VOICE_AGENT_PORT overrides if set
 # VOICE_AGENT_PORT=3001

--- a/agents/voice/package-lock.json
+++ b/agents/voice/package-lock.json
@@ -9,6 +9,9 @@
       "version": "0.1.0",
       "dependencies": {
         "@anthropic-ai/sdk": ">=0.91.1",
+        "@dfinity/agent": "^2.1.3",
+        "@dfinity/identity": "^2.1.3",
+        "@dfinity/principal": "^2.1.3",
         "cors": "^2.8.5",
         "dotenv": "^17.3.1",
         "express": "^5.2.1",
@@ -1869,6 +1872,62 @@
         "node": ">=12"
       }
     },
+    "node_modules/@dfinity/agent": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-2.4.1.tgz",
+      "integrity": "sha512-IczFFOUDGfMTdQ83yiCvGtvHr1IIB80lWBP0ZYRLogs6NVt8t6HYcMlu1sgT+9VivhT7iwX4pktPFxxOkO3COw==",
+      "deprecated": "This package has been deprecated. Use @icp-sdk/core/agent instead. Migration guide: https://js.icp.build/core/latest/upgrading/v5",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@noble/curves": "^1.4.0",
+        "@noble/hashes": "^1.3.1",
+        "base64-arraybuffer": "^0.2.0",
+        "borc": "^2.1.1",
+        "buffer": "^6.0.3",
+        "simple-cbor": "^0.4.1"
+      },
+      "peerDependencies": {
+        "@dfinity/candid": "^2.4.1",
+        "@dfinity/principal": "^2.4.1"
+      }
+    },
+    "node_modules/@dfinity/candid": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-2.4.1.tgz",
+      "integrity": "sha512-kOaIKfhR2PYN8vD4M0Pc4s/7wb1nKjlTJUw+5E9jh26T03fITIZmaafIuwlX+wmdxwIT9Xoy7PlsxOEpzv203A==",
+      "deprecated": "This package has been deprecated. Use @icp-sdk/core/candid instead. Migration guide: https://js.icp.build/core/latest/upgrading/v5",
+      "license": "Apache-2.0",
+      "peer": true,
+      "peerDependencies": {
+        "@dfinity/principal": "^2.4.1"
+      }
+    },
+    "node_modules/@dfinity/identity": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/identity/-/identity-2.4.1.tgz",
+      "integrity": "sha512-CXhTmdtqkA0vE6ue2GaF9ZwD0OQ5OinrGj77Eg0dX0zPZpxJQ+NCjyYNWkaIvsKxmnCaW+5yrCcchN8Sqk8uIA==",
+      "deprecated": "This package has been deprecated. Use @icp-sdk/core/identity instead. Migration guide: https://js.icp.build/core/latest/upgrading/v5",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@noble/curves": "^1.2.0",
+        "@noble/hashes": "^1.3.1",
+        "borc": "^2.1.1"
+      },
+      "peerDependencies": {
+        "@dfinity/agent": "^2.4.1",
+        "@dfinity/principal": "^2.4.1"
+      }
+    },
+    "node_modules/@dfinity/principal": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-2.4.1.tgz",
+      "integrity": "sha512-Cz6XQVOwq0TXDBClPbcidDd4SqK1lfr1/Kn34ruDD13xVQ4iaP1iCntzS9O97+vGpY/6jwDtKd32Gn5YJ9BQNw==",
+      "deprecated": "This package has been deprecated. Use @icp-sdk/core/principal instead. Migration guide: https://js.icp.build/core/latest/upgrading/v5",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@noble/hashes": "^1.3.1"
+      }
+    },
     "node_modules/@emnapi/core": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
@@ -2539,11 +2598,25 @@
         "@tybys/wasm-util": "^0.10.0"
       }
     },
+    "node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@noble/hashes": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
       "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^14.21.3 || >=16"
@@ -3474,6 +3547,34 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.2.0.tgz",
+      "integrity": "sha512-7emyCsu1/xiBXgQZrscw/8KPRT44I4Yq9Pe6EGs3aPRTsWuggML1/1DTuZUuIaJPIm1FTDUVXl4x/yW8s0kQDQ==",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.14",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.14.tgz",
@@ -3485,6 +3586,15 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/body-parser": {
@@ -3509,6 +3619,48 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/borc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/borc/-/borc-2.1.2.tgz",
+      "integrity": "sha512-Sy9eoUi4OiKzq7VovMn246iTo17kzuyHJKomCfpWMlI6RpfN1gk95w7d7gH264nApVLg0HZfcpz62/g4VH1Y4w==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0",
+        "buffer": "^5.5.0",
+        "commander": "^2.15.0",
+        "ieee754": "^1.1.13",
+        "iso-url": "~0.4.7",
+        "json-text-sequence": "~0.1.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/borc/node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/brace-expansion": {
@@ -3564,6 +3716,30 @@
       "license": "Apache-2.0",
       "dependencies": {
         "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/buffer-from": {
@@ -3768,6 +3944,12 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT"
+    },
     "node_modules/component-emitter": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
@@ -3943,6 +4125,12 @@
       "engines": {
         "node": ">=0.4.0"
       }
+    },
+    "node_modules/delimit-stream": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/delimit-stream/-/delimit-stream-0.1.0.tgz",
+      "integrity": "sha512-a02fiQ7poS5CnjiJBAsjGLPp5EwVoGHNeu9sziBd9huppRfsAFIpv5zNLv0V1gbop53ilngAf5Kf331AwcoRBQ==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/depd": {
       "version": "2.0.0",
@@ -4713,6 +4901,26 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/import-local": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
@@ -4847,6 +5055,15 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/iso-url": {
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/iso-url/-/iso-url-0.4.7.tgz",
+      "integrity": "sha512-27fFRDnPAMnHGLq36bWTpKET+eiXct3ENlCcdcMdk+mjXrb2kw3mhBUg1B7ewAC0kVzlOPhADzQgz1SE6Tglog==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -5701,6 +5918,15 @@
         "node": ">=16"
       }
     },
+    "node_modules/json-text-sequence": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/json-text-sequence/-/json-text-sequence-0.1.1.tgz",
+      "integrity": "sha512-L3mEegEWHRekSHjc7+sc8eJhba9Clq1PZ8kMkzf8OxElhXc8O4TS5MwcVlj9aEbm5dr81N90WHC5nAz3UO971w==",
+      "license": "MIT",
+      "dependencies": {
+        "delimit-stream": "0.1.0"
+      }
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -6372,6 +6598,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/regenerate": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
@@ -6520,6 +6760,26 @@
       "engines": {
         "node": ">= 18"
       }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -6690,6 +6950,12 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/simple-cbor": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/simple-cbor/-/simple-cbor-0.4.1.tgz",
+      "integrity": "sha512-rijcxtwx2b4Bje3sqeIqw5EeW7UlOIC4YfOdwqIKacpvRQ/D78bWg/4/0m5e0U91oKvlGh7LlJuZCu07ISCC7w==",
+      "license": "ISC"
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -6758,6 +7024,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-length": {
@@ -7235,6 +7510,12 @@
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/uuid": {
       "version": "14.0.0",

--- a/agents/voice/package.json
+++ b/agents/voice/package.json
@@ -19,6 +19,9 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": ">=0.91.1",
+    "@dfinity/agent": "^2.1.3",
+    "@dfinity/identity": "^2.1.3",
+    "@dfinity/principal": "^2.1.3",
     "cors": "^2.8.5",
     "dotenv": "^17.3.1",
     "express": "^5.2.1",

--- a/agents/voice/paymentCanister.ts
+++ b/agents/voice/paymentCanister.ts
@@ -1,0 +1,142 @@
+import { HttpAgent, Actor } from "@dfinity/agent";
+import { Ed25519KeyIdentity } from "@dfinity/identity";
+import { Principal } from "@dfinity/principal";
+import crypto from "node:crypto";
+
+// Testnet ID is the fallback; override with CANISTER_ID_PAYMENT in Railway env vars.
+const PAYMENT_CANISTER_ID =
+  process.env.CANISTER_ID_PAYMENT ?? "a3shm-xiaaa-aaaaj-a6moa-cai";
+
+const PRINCIPAL_RE = /^[a-z0-9]([a-z0-9-]{0,60}[a-z0-9])?$/;
+
+export const VALID_TIERS = new Set([
+  "Free", "Basic", "Pro", "Premium",
+  "ContractorFree", "ContractorPro", "RealtorFree", "RealtorPro",
+]);
+
+// ── Identity ──────────────────────────────────────────────────────────────────
+// Parse DFX_IDENTITY_PEM (Ed25519 SEC1 or PKCS8) into an @dfinity/identity.
+// The principal of this identity must be registered as admin in the payment
+// canister (done during deploy bootstrap in scripts/deploy.sh).
+function identityFromPem(pem: string): Ed25519KeyIdentity {
+  const keyObj = crypto.createPrivateKey({ key: pem, format: "pem" });
+  const jwk = keyObj.export({ format: "jwk" }) as crypto.JsonWebKey;
+  if (jwk.crv !== "Ed25519" || !jwk.d) {
+    throw new Error(
+      `DFX_IDENTITY_PEM must be an Ed25519 key (got crv=${jwk.crv ?? "unknown"})`,
+    );
+  }
+  const seed = Buffer.from(jwk.d, "base64url");
+  return Ed25519KeyIdentity.fromSecretKey(seed.buffer as ArrayBuffer);
+}
+
+// ── Agent (lazy singleton) ────────────────────────────────────────────────────
+let _agent: HttpAgent | undefined;
+
+function getAgent(): HttpAgent {
+  if (_agent) return _agent;
+  const pem = process.env.DFX_IDENTITY_PEM;
+  if (!pem) {
+    throw new Error(
+      "DFX_IDENTITY_PEM is not set — cannot make authenticated canister calls",
+    );
+  }
+  _agent = new HttpAgent({ host: "https://ic0.app", identity: identityFromPem(pem) });
+  // Do NOT call fetchRootKey() — IC mainnet uses the hardcoded root key.
+  return _agent;
+}
+
+// ── Minimal IDL for the three admin methods ───────────────────────────────────
+const idlFactory = ({ IDL }: { IDL: any }) => {
+  const Tier = IDL.Variant({
+    Free: IDL.Null, Basic: IDL.Null, Pro: IDL.Null, Premium: IDL.Null,
+    ContractorFree: IDL.Null, ContractorPro: IDL.Null,
+    RealtorFree: IDL.Null, RealtorPro: IDL.Null,
+  });
+  const Err = IDL.Variant({
+    NotFound: IDL.Null, NotAuthorized: IDL.Null,
+    PaymentFailed: IDL.Text, RateLimited: IDL.Null, InvalidInput: IDL.Text,
+  });
+  const Sub = IDL.Record({
+    owner: IDL.Principal, tier: Tier,
+    expiresAt: IDL.Int, createdAt: IDL.Int, cancelledAt: IDL.Opt(IDL.Int),
+  });
+  return IDL.Service({
+    adminActivateStripeSubscription: IDL.Func(
+      [IDL.Principal, Tier, IDL.Nat],
+      [IDL.Variant({ ok: Sub, err: Err })],
+      [],
+    ),
+    consumeAgentCredit: IDL.Func(
+      [IDL.Principal],
+      [IDL.Variant({ ok: IDL.Nat, err: Err })],
+      [],
+    ),
+    adminGrantAgentCredits: IDL.Func(
+      [IDL.Principal, IDL.Nat],
+      [IDL.Variant({ ok: IDL.Nat, err: Err })],
+      [],
+    ),
+  });
+};
+
+type PaymentActor = {
+  adminActivateStripeSubscription(
+    user: Principal,
+    tier: Record<string, null>,
+    months: bigint,
+  ): Promise<{ ok: unknown } | { err: unknown }>;
+  consumeAgentCredit(
+    user: Principal,
+  ): Promise<{ ok: bigint } | { err: unknown }>;
+  adminGrantAgentCredits(
+    user: Principal,
+    amount: bigint,
+  ): Promise<{ ok: bigint } | { err: unknown }>;
+};
+
+function getActor(): PaymentActor {
+  return Actor.createActor(idlFactory, {
+    agent:     getAgent(),
+    canisterId: PAYMENT_CANISTER_ID,
+  }) as unknown as PaymentActor;
+}
+
+// ── Public helpers (replace dfx shell-outs in server.ts) ─────────────────────
+
+export async function activateInCanister(
+  principal: string,
+  tier: string,
+  months: number,
+): Promise<void> {
+  if (!VALID_TIERS.has(tier)) throw new Error(`Invalid tier: ${tier}`);
+  if (!PRINCIPAL_RE.test(principal)) throw new Error("Invalid principal format");
+  const result = await getActor().adminActivateStripeSubscription(
+    Principal.fromText(principal),
+    { [tier]: null },
+    BigInt(months),
+  );
+  if ("err" in result)
+    throw new Error(`Canister activation failed: ${JSON.stringify(result.err)}`);
+}
+
+export async function consumeAgentCredit(principal: string): Promise<void> {
+  if (!PRINCIPAL_RE.test(principal)) throw new Error("Invalid principal format");
+  const result = await getActor().consumeAgentCredit(Principal.fromText(principal));
+  if ("err" in result) throw new Error("No agent credits available");
+}
+
+export async function grantAgentCredits(
+  principal: string,
+  amount: number,
+): Promise<void> {
+  if (!PRINCIPAL_RE.test(principal)) throw new Error("Invalid principal format");
+  if (!Number.isInteger(amount) || amount <= 0)
+    throw new Error("Invalid credit amount");
+  const result = await getActor().adminGrantAgentCredits(
+    Principal.fromText(principal),
+    BigInt(amount),
+  );
+  if ("err" in result)
+    throw new Error(`Credit grant failed: ${JSON.stringify(result.err)}`);
+}

--- a/agents/voice/server.ts
+++ b/agents/voice/server.ts
@@ -1,5 +1,6 @@
 import "dotenv/config";
 import express, { Request, Response } from "express";
+import { activateInCanister, consumeAgentCredit, grantAgentCredits } from "./paymentCanister";
 import cors from "cors";
 import rateLimit from "express-rate-limit";
 import { buildSystemPrompt } from "./prompts";
@@ -1096,33 +1097,6 @@ app.post("/api/stripe/create-subscription-intent", async (req: Request, res: Res
 // by calling adminActivateStripeSubscription via dfx CLI (local dev only).
 // Returns { type, tier?, billing? } so the frontend can refresh the subscription state.
 
-const VALID_TIERS = new Set(["Free", "Pro", "Premium", "ContractorFree", "ContractorPro"]);
-
-async function activateInCanister(principal: string, tier: string, months: number): Promise<void> {
-  // Validate inputs before passing to shell
-  if (!VALID_TIERS.has(tier)) throw new Error(`Invalid tier: ${tier}`);
-  // ICP principals: base32 segments separated by hyphens, or short text form
-  if (!/^[a-z0-9]([a-z0-9-]{0,60}[a-z0-9])?$/.test(principal)) {
-    throw new Error(`Invalid principal format`);
-  }
-  const { exec }     = await import("child_process");
-  const { promisify } = await import("util");
-  const execAsync = promisify(exec);
-  const cmd = `dfx canister call payment adminActivateStripeSubscription '(principal "${principal}", variant { ${tier} }, ${months})'`;
-  const { stderr } = await execAsync(cmd);
-  if (stderr && /error/i.test(stderr)) {
-    throw new Error(`Canister activation failed: ${stderr.trim()}`);
-  }
-}
-
-/**
- * Revert a user's subscription tier to Free in the payment canister.
- * Called by the webhook handler on subscription cancellation or payment failure.
- */
-async function revertPrincipalToFree(principal: string): Promise<void> {
-  await activateInCanister(principal, "Free", 0);
-}
-
 // ── Credit top-up helpers (#89) ───────────────────────────────────────────────
 
 /** Valid top-up pack sizes and their Stripe price-ID env vars. */
@@ -1131,38 +1105,8 @@ export const CREDIT_PACKS: Record<number, { envVar: string; label: string }> = {
   100: { envVar: "STRIPE_PRICE_CREDITS_100", label: "100 credits" },
 };
 
-/**
- * Atomically decrement 1 agent credit for `principal` in the payment canister.
- * Throws if the canister returns an error (no credits, expired, or unavailable).
- */
-async function consumeAgentCredit(principal: string): Promise<void> {
-  if (!/^[a-z0-9]([a-z0-9-]{0,60}[a-z0-9])?$/.test(principal)) {
-    throw new Error("Invalid principal format");
-  }
-  const { exec }      = await import("child_process");
-  const { promisify } = await import("util");
-  const execAsync = promisify(exec);
-  const cmd = `dfx canister call payment consumeAgentCredit '(principal "${principal}")'`;
-  const { stdout, stderr } = await execAsync(cmd);
-  if (stderr && /error/i.test(stderr)) throw new Error(`Credit consume failed: ${stderr.trim()}`);
-  if (/\berr\b/i.test(stdout))         throw new Error("No agent credits available");
-}
-
-/**
- * Grant agent credits to `principal` in the payment canister.
- * Called by the voice server after Stripe confirms a one-time credit pack purchase.
- */
-async function grantAgentCredits(principal: string, amount: number): Promise<void> {
-  if (!/^[a-z0-9]([a-z0-9-]{0,60}[a-z0-9])?$/.test(principal)) {
-    throw new Error("Invalid principal format");
-  }
-  if (!Number.isInteger(amount) || amount <= 0) throw new Error("Invalid credit amount");
-  const { exec }      = await import("child_process");
-  const { promisify } = await import("util");
-  const execAsync = promisify(exec);
-  const cmd = `dfx canister call payment adminGrantAgentCredits '(principal "${principal}", ${amount} : nat)'`;
-  const { stderr } = await execAsync(cmd);
-  if (stderr && /error/i.test(stderr)) throw new Error(`Credit grant failed: ${stderr.trim()}`);
+async function revertPrincipalToFree(principal: string): Promise<void> {
+  await activateInCanister(principal, "Free", 0);
 }
 
 app.post("/api/stripe/verify-session", async (req: Request, res: Response) => {


### PR DESCRIPTION
… (#213)

Closes #213

activateInCanister, consumeAgentCredit, and grantAgentCredits previously shelled out to `dfx canister call`, which is not installed in the Railway production container. All three Stripe lifecycle paths (subscription activate/revert, agent credit grant/consume) silently skipped in prod.

Fix:
- New paymentCanister.ts builds an HttpAgent + Actor from DFX_IDENTITY_PEM using @dfinity/agent + @dfinity/identity (Ed25519 key, IC mainnet host)
- Minimal IDL covers the three admin methods; input validation preserved
- server.ts imports the three helpers; dfx child_process shell-outs removed
- .env.example documents DFX_IDENTITY_PEM and CANISTER_ID_PAYMENT

Add DFX_IDENTITY_PEM and optionally CANISTER_ID_PAYMENT to Railway env vars to activate. The testnet payment canister ID is hardcoded as the fallback.

## Summary
<!-- What does this PR do? -->

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [ ] Backend tests pass (`make test`)
- [ ] Frontend builds (`cd frontend && npm run build`)
- [ ] Tested locally with dfx

## Checklist
- [ ] Code follows project conventions
- [ ] Self-review completed
- [ ] No sensitive data committed
