### PR TITLE
fix(test): load agents/voice/.env in stripe.elements integration test

### DIFF
--- a/agents/voice/__tests__/stripe.elements.integration.test.ts
+++ b/agents/voice/__tests__/stripe.elements.integration.test.ts
@@ -18,8 +18,8 @@
 
 import dotenv from "dotenv";
 import path from "path";
-// Load root-level .env (two directories up from __tests__/)
-dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
+// Load agents/voice/.env (one directory up from __tests__/)
+dotenv.config({ path: path.resolve(__dirname, "../.env") });
 
 import Stripe from "stripe";
 


### PR DESCRIPTION
The path pointed to the repo root .env (../../../), which doesn't contain Stripe test keys. Corrected to ../.env so all three integration test files consistently load from agents/voice/.env.

## Summary
<!-- What does this PR do? -->

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [ ] Backend tests pass (`make test`)
- [ ] Frontend builds (`cd frontend && npm run build`)
- [ ] Tested locally with dfx

## Checklist
- [ ] Code follows project conventions
- [ ] Self-review completed
- [ ] No sensitive data committed
