### PR TITLE
fix(#217): route paymentCanister to local dfx replica when DFX_NETWOR…

### DIFF
--- a/agents/voice/.env.example
+++ b/agents/voice/.env.example
@@ -31,6 +31,11 @@ STRIPE_PRICE_CREDITS_100=price_...
 # Same PEM used by the deploy identity — must be admin in the payment canister
 DFX_IDENTITY_PEM="-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----"
 
+# Network routing for paymentCanister.ts:
+#   local  → http://localhost:4943  (dfx replica, fetchRootKey called automatically)
+#   <unset> or anything else → https://ic0.app  (IC mainnet)
+# DFX_NETWORK=local
+
 # Payment canister principal — testnet default is already hardcoded as fallback
 # Set this if deploying against a different network or canister ID changes
 # CANISTER_ID_PAYMENT=a3shm-xiaaa-aaaaj-a6moa-cai

--- a/agents/voice/__tests__/paymentCanister.integration.test.ts
+++ b/agents/voice/__tests__/paymentCanister.integration.test.ts
@@ -1,0 +1,74 @@
+/**
+ * paymentCanister.ts — local replica integration tests (#217)
+ *
+ * Exercises all three canister call paths against a running dfx local replica.
+ * Skipped automatically unless DFX_NETWORK=local and DFX_IDENTITY_PEM are set,
+ * so CI and local dev without a replica stay green.
+ *
+ * Prerequisites (run once before this suite):
+ *   dfx start --clean --background
+ *   bash scripts/deploy.sh          # deploys payment canister, wires admin
+ *   # The deploy identity is automatically admin — no extra seeding needed.
+ *
+ * Run:
+ *   DFX_NETWORK=local DFX_IDENTITY_PEM="$(dfx identity export default)" \
+ *     CANISTER_ID_PAYMENT="$(dfx canister id payment)" \
+ *     cd agents/voice && npm test -- paymentCanister.integration
+ *
+ * INTEG.1  activateInCanister — activates a Basic subscription for a test principal
+ * INTEG.2  grantAgentCredits  — grants credits to a test principal
+ * INTEG.3  consumeAgentCredit — consumes a credit granted in INTEG.2
+ */
+
+import "dotenv/config";
+import { describe, it, expect, beforeAll } from "@jest/globals";
+
+const configured =
+  process.env.DFX_NETWORK === "local" &&
+  !!process.env.DFX_IDENTITY_PEM &&
+  !!process.env.CANISTER_ID_PAYMENT;
+
+const describeIfConfigured = configured ? describe : describe.skip;
+
+// Use a stable test principal derived from the default dfx identity's textual form.
+// Any valid lowercase principal works — it doesn't need a wallet or cycles.
+const TEST_PRINCIPAL = process.env.TEST_PRINCIPAL ?? "aaaaa-aa";
+
+// Re-import after env is set so the module picks up the correct IC_HOST.
+let activateInCanister: (p: string, t: string, m: number) => Promise<void>;
+let grantAgentCredits:  (p: string, a: number)            => Promise<void>;
+let consumeAgentCredit: (p: string)                        => Promise<void>;
+
+beforeAll(async () => {
+  if (!configured) return;
+  const mod = await import("../paymentCanister");
+  activateInCanister = mod.activateInCanister;
+  grantAgentCredits  = mod.grantAgentCredits;
+  consumeAgentCredit = mod.consumeAgentCredit;
+});
+
+describeIfConfigured("INTEG.1 — activateInCanister against local replica", () => {
+  it("activates a Basic subscription without throwing", async () => {
+    await expect(
+      activateInCanister(TEST_PRINCIPAL, "Basic", 1),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describeIfConfigured("INTEG.2 — grantAgentCredits against local replica", () => {
+  it("grants 5 credits without throwing", async () => {
+    await expect(
+      grantAgentCredits(TEST_PRINCIPAL, 5),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describeIfConfigured("INTEG.3 — consumeAgentCredit against local replica", () => {
+  it("consumes a credit after grant without throwing", async () => {
+    // Grant first so there is a credit to consume.
+    await grantAgentCredits(TEST_PRINCIPAL, 1);
+    await expect(
+      consumeAgentCredit(TEST_PRINCIPAL),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/agents/voice/paymentCanister.ts
+++ b/agents/voice/paymentCanister.ts
@@ -34,19 +34,30 @@ export function identityFromPem(pem: string): Ed25519KeyIdentity {
 }
 
 // ── Agent (lazy singleton) ────────────────────────────────────────────────────
-let _agent: HttpAgent | undefined;
+// Route to local dfx replica when DFX_NETWORK=local; otherwise IC mainnet.
+const IC_HOST = process.env.DFX_NETWORK === "local"
+  ? "http://localhost:4943"
+  : "https://ic0.app";
 
-function getAgent(): HttpAgent {
-  if (_agent) return _agent;
+let _agentPromise: Promise<HttpAgent> | undefined;
+
+async function getAgent(): Promise<HttpAgent> {
+  if (_agentPromise) return _agentPromise;
   const pem = process.env.DFX_IDENTITY_PEM;
   if (!pem) {
     throw new Error(
       "DFX_IDENTITY_PEM is not set — cannot make authenticated canister calls",
     );
   }
-  _agent = new HttpAgent({ host: "https://ic0.app", identity: identityFromPem(pem) });
-  // Do NOT call fetchRootKey() — IC mainnet uses the hardcoded root key.
-  return _agent;
+  _agentPromise = (async () => {
+    const agent = new HttpAgent({ host: IC_HOST, identity: identityFromPem(pem) });
+    // Local replica uses a self-signed root key; mainnet has a hardcoded one.
+    if (process.env.DFX_NETWORK === "local") {
+      await agent.fetchRootKey();
+    }
+    return agent;
+  })();
+  return _agentPromise;
 }
 
 // ── Minimal IDL for the three admin methods ───────────────────────────────────
@@ -98,9 +109,9 @@ type PaymentActor = {
   ): Promise<{ ok: bigint } | { err: unknown }>;
 };
 
-function getActor(): PaymentActor {
+async function getActor(): Promise<PaymentActor> {
   return Actor.createActor(idlFactory, {
-    agent:     getAgent(),
+    agent:      await getAgent(),
     canisterId: PAYMENT_CANISTER_ID,
   }) as unknown as PaymentActor;
 }
@@ -114,7 +125,7 @@ export async function activateInCanister(
 ): Promise<void> {
   if (!VALID_TIERS.has(tier)) throw new Error(`Invalid tier: ${tier}`);
   if (!PRINCIPAL_RE.test(principal)) throw new Error("Invalid principal format");
-  const result = await getActor().adminActivateStripeSubscription(
+  const result = await (await getActor()).adminActivateStripeSubscription(
     Principal.fromText(principal),
     { [tier]: null },
     BigInt(months),
@@ -125,7 +136,7 @@ export async function activateInCanister(
 
 export async function consumeAgentCredit(principal: string): Promise<void> {
   if (!PRINCIPAL_RE.test(principal)) throw new Error("Invalid principal format");
-  const result = await getActor().consumeAgentCredit(Principal.fromText(principal));
+  const result = await (await getActor()).consumeAgentCredit(Principal.fromText(principal));
   if ("err" in result) throw new Error("No agent credits available");
 }
 
@@ -136,7 +147,7 @@ export async function grantAgentCredits(
   if (!PRINCIPAL_RE.test(principal)) throw new Error("Invalid principal format");
   if (!Number.isInteger(amount) || amount <= 0)
     throw new Error("Invalid credit amount");
-  const result = await getActor().adminGrantAgentCredits(
+  const result = await (await getActor()).adminGrantAgentCredits(
     Principal.fromText(principal),
     BigInt(amount),
   );


### PR DESCRIPTION
…K=local

- IC_HOST derived from DFX_NETWORK: local → http://localhost:4943, anything else → https://ic0.app
- getAgent() is async; calls fetchRootKey() only for local replicas
- getActor() and all three public helpers updated to await the async agent
- .env.example documents DFX_NETWORK=local with setup instructions
- paymentCanister.integration.test.ts smoke-tests all three call paths; self-skips when DFX_NETWORK != local so CI stays green

## Summary
<!-- What does this PR do? -->

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [ ] Backend tests pass (`make test`)
- [ ] Frontend builds (`cd frontend && npm run build`)
- [ ] Tested locally with dfx

## Checklist
- [ ] Code follows project conventions
- [ ] Self-review completed
- [ ] No sensitive data committed
