### PR TITLE
test(backend): add assertions for tier propagation and sensor→job aut…

### DIFF
--- a/backend/payment/test.sh
+++ b/backend/payment/test.sh
@@ -322,29 +322,51 @@ if [ -n "$PROPERTY_ID" ] && [ -n "$QUOTE_ID" ] && [ -n "$PHOTO_ID" ]; then
     dfx canister call photo    addAdmin "(principal \"$PAYMENT_ID\")" 2>/dev/null || true
   fi
 
-  # Grant Pro subscription — should propagate to property, quote, photo
+  # Grant Pro subscription — triggers propagateTier → property/quote/photo.setTier
   dfx canister call payment grantSubscription \
     "(principal \"$PROP_TEST_PRINCIPAL\", variant { Pro })" 2>/dev/null
 
-  # Verify tier was propagated to property
-  PROP_TIER=$(dfx canister call property setTier \
-    "(principal \"$PROP_TEST_PRINCIPAL\", variant { Pro })" 2>/dev/null || echo "")
-  # Simpler check: read it back via a query if available, otherwise call setTier directly
-  # Since property doesn't expose getTierForPrincipal, we verify indirectly:
-  # calling registerProperty should no longer be blocked by Free-tier limit (0 properties)
-  echo "  ↳ grantSubscription + propagateTier completed without error — ✓"
+  # [P3a] payment records the tier correctly
+  TIER=$(dfx canister call payment getTierForPrincipal "(principal \"$PROP_TEST_PRINCIPAL\")")
+  echo "$TIER" | grep -q "Pro" \
+    && echo "  ↳ [P3a] getTierForPrincipal = Pro — ✓" \
+    || (echo "  ↳ ❌ [P3a] Expected Pro in payment: $TIER"; exit 1)
 
-  # Downgrade to Free via grantSubscription (cancellation path)
+  # [P3b] property enforces Pro limit (5 properties allowed): registration succeeds
+  REG=$(dfx canister call property registerProperty '(record {
+    address = "100 Tier Test St"; city = "Austin"; state = "TX";
+    zipCode = "78701"; propertyType = variant { SingleFamily };
+    yearBuilt = 2000; squareFeet = 1500; tier = variant { Free };
+  })' --identity tier-prop-test 2>&1)
+  echo "$REG" | grep -q "LimitReached" \
+    && echo "  ↳ ❌ [P3b] registerProperty blocked under Pro tier — unexpected" \
+    || echo "  ↳ [P3b] registerProperty succeeded under Pro tier — ✓"
+
+  # Downgrade to Free — property should now block further registrations
   dfx canister call payment grantSubscription \
     "(principal \"$PROP_TEST_PRINCIPAL\", variant { Free })" 2>/dev/null
-  echo "  ↳ Downgrade to Free propagated without error — ✓"
+
+  TIER_AFTER=$(dfx canister call payment getTierForPrincipal "(principal \"$PROP_TEST_PRINCIPAL\")")
+  echo "$TIER_AFTER" | grep -q "Free" \
+    && echo "  ↳ [P3c] getTierForPrincipal = Free after downgrade — ✓" \
+    || echo "  ↳ ❌ [P3c] Expected Free after downgrade: $TIER_AFTER"
+
+  # [P3d] property enforces Free limit (0 properties): second registration fails
+  REG2=$(dfx canister call property registerProperty '(record {
+    address = "200 Tier Test Ave"; city = "Austin"; state = "TX";
+    zipCode = "78702"; propertyType = variant { SingleFamily };
+    yearBuilt = 2001; squareFeet = 1200; tier = variant { Free };
+  })' --identity tier-prop-test 2>&1)
+  echo "$REG2" | grep -q "LimitReached\|NotAuthorized" \
+    && echo "  ↳ [P3d] registerProperty blocked after Free downgrade — ✓" \
+    || echo "  ↳ ❌ [P3d] Expected LimitReached after downgrade: $REG2"
 else
   echo "  ↳ SKIP — property/quote/photo not deployed (will run in full integration suite)"
 fi
 
 echo ""
 echo "── [P4] cancelSubscription → Free tier propagated ───────────────────────"
-# Grant the tier-prop-test user Pro, then cancel, verify payment record shows cancelledAt
+# Grant the tier-prop-test user Pro, then cancel, verify payment record shows cancelledAt.
 RESULT=$(dfx canister call payment grantSubscription \
   "(principal \"$PROP_TEST_PRINCIPAL\", variant { Pro })" 2>&1)
 echo "$RESULT" | grep -q "ok" \
@@ -357,6 +379,13 @@ CANCEL_RESULT=$(dfx canister call payment cancelSubscription \
 echo "$CANCEL_RESULT" | grep -q "cancelledAt" \
   && echo "  ↳ cancelSubscription set cancelledAt — ✓" \
   || echo "  ↳ ❌ Expected cancelledAt in cancellation result: $CANCEL_RESULT"
+
+# [P4a] payment reflects the cancellation: tier query should still show Pro (access until expiry)
+TIER_AFTER_CANCEL=$(dfx canister call payment getTierForPrincipal \
+  "(principal \"$PROP_TEST_PRINCIPAL\")" 2>&1)
+echo "$TIER_AFTER_CANCEL" | grep -q "Pro" \
+  && echo "  ↳ [P4a] tier still Pro after cancellation (access until expiry) — ✓" \
+  || echo "  ↳ ❌ [P4a] Expected Pro to persist until expiry: $TIER_AFTER_CANCEL"
 
 echo ""
 echo "✅ Tier propagation tests complete!"

--- a/backend/sensor/test.sh
+++ b/backend/sensor/test.sh
@@ -83,13 +83,21 @@ dfx canister call sensor recordEvent '(
 # ─── Critical events — auto job creation ──────────────────────────────────────
 echo ""
 echo "── [7] recordEvent — water leak CRITICAL (should auto-create pending job) "
-dfx canister call sensor recordEvent '(
+LEAK_EVENT=$(dfx canister call sensor recordEvent '(
   "moen-flo-xyz789",
   variant { WaterLeak },
   8.3,
   "L/min",
   "{\"flowRate\":8.3,\"shutoff\":true}"
-)'
+)')
+echo "$LEAK_EVENT"
+if [ -n "$JOB_ID" ]; then
+  echo "$LEAK_EVENT" | grep -q "jobId = opt" \
+    && echo "  ↳ jobId auto-created for WaterLeak — ✓" \
+    || (echo "  ↳ ❌ Expected jobId to be set for WaterLeak; got: $LEAK_EVENT"; exit 1)
+else
+  echo "  ↳ SKIP jobId assertion — job canister not deployed"
+fi
 
 echo ""
 echo "── [8] recordEvent — low temperature CRITICAL (pipe freeze risk) ────────"
@@ -113,13 +121,21 @@ dfx canister call sensor getPendingAlerts '("PROP_1")'
 # ─── Boundary values ──────────────────────────────────────────────────────────
 echo ""
 echo "── [11] recordEvent — HVAC alert (Critical) ─────────────────────────────"
-dfx canister call sensor recordEvent '(
+HVAC_EVENT=$(dfx canister call sensor recordEvent '(
   "nest-abc123",
   variant { HvacAlert },
   0.0,
   "",
   "{\"code\":\"E4\",\"description\":\"Compressor fault\"}"
-)'
+)')
+echo "$HVAC_EVENT"
+if [ -n "$JOB_ID" ]; then
+  echo "$HVAC_EVENT" | grep -q "jobId = opt" \
+    && echo "  ↳ jobId auto-created for HvacAlert — ✓" \
+    || (echo "  ↳ ❌ Expected jobId to be set for HvacAlert; got: $HVAC_EVENT"; exit 1)
+else
+  echo "  ↳ SKIP jobId assertion — job canister not deployed"
+fi
 
 echo ""
 echo "── [12] getEventsForProperty — limit 5 (pagination) ────────────────────"
@@ -137,7 +153,15 @@ dfx canister call sensor getDevicesForProperty '("PROP_1")'
 # ─── Final metrics ────────────────────────────────────────────────────────────
 echo ""
 echo "── [15] Get metrics (after tests) ──────────────────────────────────────"
-dfx canister call sensor getMetrics
+METRICS=$(dfx canister call sensor getMetrics)
+echo "$METRICS"
+if [ -n "$JOB_ID" ]; then
+  echo "$METRICS" | grep -qE "jobsCreated = [1-9]" \
+    && echo "  ↳ jobsCreated > 0 — ✓" \
+    || (echo "  ↳ ❌ Expected jobsCreated > 0 after Critical events"; exit 1)
+else
+  echo "  ↳ SKIP jobsCreated assertion — job canister not deployed"
+fi
 
 echo ""
 echo "============================================"


### PR DESCRIPTION
…o-create

payment/test.sh:
- [P3a] assert getTierForPrincipal = Pro after grantSubscription
- [P3b] assert registerProperty succeeds under Pro tier (limit 5)
- [P3c] assert getTierForPrincipal = Free after downgrade
- [P3d] assert registerProperty blocked after Free downgrade (limit 0)
- [P4a] assert tier stays Pro after cancelSubscription (access until expiry)

sensor/test.sh:
- [7]  assert jobId is set in WaterLeak event (Critical → auto-create job)
- [11] assert jobId is set in HvacAlert event (Critical → auto-create job)
- [15] assert jobsCreated > 0 in final metrics

All new assertions are gated on JOB_ID / PROPERTY_ID being set so the tests stay green in single-canister standalone runs.

## Summary
<!-- What does this PR do? -->

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [ ] Backend tests pass (`make test`)
- [ ] Frontend builds (`cd frontend && npm run build`)
- [ ] Tested locally with dfx

## Checklist
- [ ] Code follows project conventions
- [ ] Self-review completed
- [ ] No sensitive data committed
