### PR TITLE
feat(#242,#243): getMyBids + service ZIP input for contractors

### DIFF
--- a/backend/quote/main.mo
+++ b/backend/quote/main.mo
@@ -455,6 +455,15 @@ persistent actor Quote {
     )
   };
 
+  /// Fetch all quotes submitted by the caller (contractor bid history).
+  public query(msg) func getMyQuotes() : async [Quote] {
+    Iter.toArray(
+      Iter.filter(Map.values(quotes), func(q: Quote) : Bool {
+        q.contractor == msg.caller
+      })
+    )
+  };
+
   /// Submit a quote for an open request.
   /// Subject to 20-submissions-per-day limit per contractor.
   public shared(msg) func submitQuote(

--- a/frontend/src/__tests__/contracts/__snapshots__/candid.contract.test.ts.snap
+++ b/frontend/src/__tests__/contracts/__snapshots__/candid.contract.test.ts.snap
@@ -1331,6 +1331,15 @@ exports[`quote IDL factory > full signature snapshot 1`] = `
       "vec record {id:text; status:variant {Quoted; Open; Closed; Accepted; Cancelled}; serviceType:variant {HVAC; Plumbing; Painting; Landscaping; Windows; Electrical; Flooring; Roofing}; urgency:variant {Low; High; Medium; Emergency}; createdAt:int; description:text; propertyId:text; zipCode:opt text; closeAt:opt int; homeowner:principal}",
     ],
   },
+  "getMyQuotes": {
+    "args": [],
+    "mode": [
+      "query",
+    ],
+    "rets": [
+      "vec record {id:text; status:variant {Rejected; Accepted; Expired; Pending}; requestId:text; createdAt:int; amount:nat; contractor:principal; validUntil:int; timeline:nat}",
+    ],
+  },
   "getOpenRequests": {
     "args": [],
     "mode": [

--- a/frontend/src/__tests__/contracts/candid.contract.test.ts
+++ b/frontend/src/__tests__/contracts/candid.contract.test.ts
@@ -362,6 +362,7 @@ describe("quote IDL factory", () => {
       "closeQuoteRequest",
       "createQuoteRequest",
       "getMyQuoteRequests",
+      "getMyQuotes",
       "getOpenRequests",
       "getOpenRequestsForMe",
       "getQuoteRequest",
@@ -379,6 +380,7 @@ describe("quote IDL factory", () => {
       .sort();
     expect(queries).toEqual([
       "getMyQuoteRequests",
+      "getMyQuotes",
       "getOpenRequests",
       "getQuoteRequest",
       "getQuotesForRequest",

--- a/frontend/src/__tests__/services/__snapshots__/candidContracts.test.ts.snap
+++ b/frontend/src/__tests__/services/__snapshots__/candidContracts.test.ts.snap
@@ -194,6 +194,7 @@ cancelQuoteRequest(1) -> (1)
 closeQuoteRequest(1) -> (1)
 createQuoteRequest(5) -> (1)
 getMyQuoteRequests(0) -> (1) [query]
+getMyQuotes(0) -> (1) [query]
 getOpenRequests(0) -> (1) [query]
 getOpenRequestsForMe(0) -> (1)
 getQuoteRequest(1) -> (1) [query]

--- a/frontend/src/pages/ContractorProfilePage.tsx
+++ b/frontend/src/pages/ContractorProfilePage.tsx
@@ -54,11 +54,12 @@ interface FormState {
   bio:           string;
   licenseNumber: string;
   serviceArea:   string;
+  serviceZips:   string[];
 }
 
 const EMPTY: FormState = {
   name: "", specialties: [], email: "", phone: "",
-  bio: "", licenseNumber: "", serviceArea: "",
+  bio: "", licenseNumber: "", serviceArea: "", serviceZips: [],
 };
 
 function fromProfile(p: ContractorProfile): FormState {
@@ -70,6 +71,7 @@ function fromProfile(p: ContractorProfile): FormState {
     bio:           p.bio           ?? "",
     licenseNumber: p.licenseNumber ?? "",
     serviceArea:   p.serviceArea   ?? "",
+    serviceZips:   p.serviceZips   ?? [],
   };
 }
 
@@ -82,10 +84,11 @@ function toggleTrade(specialties: string[], trade: string): string[] {
 export default function ContractorProfilePage() {
   const navigate = useNavigate();
   const { isMobile } = useBreakpoint();
-  const [existing, setExisting] = useState<ContractorProfile | null>(null);
-  const [form,     setForm]     = useState<FormState>(EMPTY);
-  const [loading,  setLoading]  = useState(true);
-  const [saving,   setSaving]   = useState(false);
+  const [existing,  setExisting]  = useState<ContractorProfile | null>(null);
+  const [form,      setForm]      = useState<FormState>(EMPTY);
+  const [loading,   setLoading]   = useState(true);
+  const [saving,    setSaving]    = useState(false);
+  const [zipInput,  setZipInput]  = useState("");
 
   useEffect(() => {
     contractorService.getMyProfile()
@@ -98,6 +101,14 @@ export default function ContractorProfilePage() {
 
   const update = (key: keyof FormState, value: string) =>
     setForm((f) => ({ ...f, [key]: value }));
+
+  const commitZip = (raw: string) => {
+    const zip = raw.trim();
+    if (/^\d{5}$/.test(zip) && form.serviceZips.length < 50 && !form.serviceZips.includes(zip)) {
+      setForm((f) => ({ ...f, serviceZips: [...f.serviceZips, zip] }));
+    }
+    setZipInput("");
+  };
 
   const isEditing = existing !== null;
 
@@ -121,7 +132,7 @@ export default function ContractorProfilePage() {
           bio:           form.bio.trim()           || null,
           licenseNumber: form.licenseNumber.trim() || null,
           serviceArea:   form.serviceArea.trim()   || null,
-          serviceZips:   existing?.serviceZips     ?? [],
+          serviceZips:   form.serviceZips,
         });
         toast.success("Profile updated.");
       } else {
@@ -346,6 +357,42 @@ export default function ContractorProfilePage() {
                     onChange={(e) => update("serviceArea", e.target.value)}
                   />
                 </div>
+              </div>
+
+              <div>
+                <label className="form-label">Service ZIP Codes</label>
+                {form.serviceZips.length > 0 && (
+                  <div style={{ display: "flex", flexWrap: "wrap", gap: "0.375rem", marginBottom: "0.5rem" }}>
+                    {form.serviceZips.map((zip) => (
+                      <span
+                        key={zip}
+                        style={{ display: "inline-flex", alignItems: "center", gap: "0.3rem", padding: "0.15rem 0.5rem", border: `1px solid ${UI.sage}`, background: COLORS.sageLight, fontFamily: UI.mono, fontSize: "0.6rem", color: UI.sage }}
+                      >
+                        {zip}
+                        <button
+                          type="button"
+                          onClick={() => setForm((f) => ({ ...f, serviceZips: f.serviceZips.filter((z) => z !== zip) }))}
+                          style={{ background: "none", border: "none", cursor: "pointer", padding: 0, lineHeight: 1, color: UI.sage }}
+                          aria-label={`Remove ${zip}`}
+                        >
+                          ×
+                        </button>
+                      </span>
+                    ))}
+                  </div>
+                )}
+                <input
+                  className="form-input"
+                  placeholder="e.g. 78701 — press Enter to add"
+                  value={zipInput}
+                  onChange={(e) => setZipInput(e.target.value.replace(/\D/g, "").slice(0, 5))}
+                  onKeyDown={(e) => { if (e.key === "Enter" || e.key === " " || e.key === ",") { e.preventDefault(); commitZip(zipInput); } }}
+                  onBlur={() => commitZip(zipInput)}
+                  maxLength={5}
+                />
+                <p style={{ fontFamily: UI.mono, fontSize: "0.6rem", color: UI.inkLight, marginTop: "0.375rem" }}>
+                  Leave blank to receive requests from all areas
+                </p>
               </div>
             </div>
           </div>

--- a/frontend/src/services/quote.ts
+++ b/frontend/src/services/quote.ts
@@ -58,6 +58,7 @@ export const idlFactory = ({ IDL }: any) => {
       ["query"]
     ),
     getMyQuoteRequests: IDL.Func([], [IDL.Vec(QuoteRequest)], ["query"]),
+    getMyQuotes: IDL.Func([], [IDL.Vec(Quote)], ["query"]),
     getOpenRequests: IDL.Func([], [IDL.Vec(QuoteRequest)], ["query"]),
     getOpenRequestsForMe: IDL.Func([], [IDL.Vec(QuoteRequest)], []),
     submitQuote: IDL.Func(
@@ -294,8 +295,14 @@ function createQuoteService() {
   },
 
   async getMyBids(): Promise<Quote[]> {
-    // TODO(#xxx): canister does not expose getMyQuotes yet; implement when added.
-    throw new Error("getMyBids: not implemented — canister endpoint pending");
+    if (typeof window !== "undefined" && (window as any).__e2e_quotes) {
+      return (window as any).__e2e_quotes as Quote[];
+    }
+    if (typeof window !== "undefined" && (window as any).__e2e_properties) {
+      return [];
+    }
+    const a = await getActor();
+    return (await a.getMyQuotes() as any[]).map(fromQuote);
   },
 
   async getQuotesForRequest(requestId: string): Promise<Quote[]> {

--- a/tests/e2e/contractor-flow.spec.ts
+++ b/tests/e2e/contractor-flow.spec.ts
@@ -17,7 +17,7 @@
 
 import { test, expect } from "@playwright/test";
 import { injectTestAuth } from "./helpers/auth";
-import { injectContractors } from "./helpers/testData";
+import { injectContractors, injectQuotes } from "./helpers/testData";
 
 // ─── shared fixtures ──────────────────────────────────────────────────────────
 
@@ -143,5 +143,37 @@ test.describe("CD — /contractor-dashboard", () => {
     await injectContractors(page, [CONTRACTORS[0]]);
     await page.goto("/contractor-dashboard");
     await expect(page.getByText("Cool Air Services")).toBeVisible();
+  });
+
+  // CD.4 — bid history section appears and shows injected bid amount
+  test("shows bid history with amount when bids are injected", async ({ page }) => {
+    await injectQuotes(page, [
+      {
+        id:         "bid-1",
+        requestId:  "req-1",
+        contractor: "test-principal",
+        amount:     15000,
+        timeline:   5,
+        validUntil: Date.now() + 7 * 24 * 60 * 60 * 1000,
+        status:     "pending",
+        createdAt:  Date.now(),
+      },
+    ]);
+    await injectContractors(page, [CONTRACTORS[0]]);
+    await page.goto("/contractor-dashboard");
+    const historyBtn = page.getByRole("button", { name: /bid history/i });
+    await expect(historyBtn).toBeVisible();
+    await historyBtn.click();
+    await expect(page.getByText("$150")).toBeVisible();
+  });
+
+  // CD.5 — service ZIP input on contractor profile form
+  test("ZIP codes can be added to the profile form", async ({ page }) => {
+    await injectContractors(page, [CONTRACTORS[0]]);
+    await page.goto("/contractor-profile");
+    const zipInput = page.getByPlaceholder(/78701/i);
+    await zipInput.fill("90210");
+    await zipInput.press("Enter");
+    await expect(page.getByText("90210")).toBeVisible();
   });
 });

--- a/tests/e2e/contractor-flow.spec.ts
+++ b/tests/e2e/contractor-flow.spec.ts
@@ -170,7 +170,7 @@ test.describe("CD — /contractor-dashboard", () => {
   // CD.5 — service ZIP input on contractor profile form
   test("ZIP codes can be added to the profile form", async ({ page }) => {
     await injectContractors(page, [CONTRACTORS[0]]);
-    await page.goto("/contractor-profile");
+    await page.goto("/contractor/profile");
     const zipInput = page.getByPlaceholder(/78701/i);
     await zipInput.fill("90210");
     await zipInput.press("Enter");


### PR DESCRIPTION
#242 — getMyBids (contractor bid history)
- backend/quote/main.mo: add getMyQuotes() query — filters quotes by caller
- quote.ts IDL: add getMyQuotes Func (query)
- quoteService.getMyBids(): replace throw with real canister call + E2E mock
- E2E CD.4: assert bid history section and amount visible when injected
- Candid contract tests + snapshots updated for new method

#243 — service ZIP input on contractor profile
- ContractorProfilePage: add serviceZips[] to FormState, fromProfile(), EMPTY; commitZip() handler with /^\d{5}$/ validation, max 50, dedup
- ZIP tag-input UI in Credentials section with removable chips
- updateProfile() now sends form.serviceZips instead of silently preserving the existing value
- E2E CD.5: fill ZIP input → press Enter → tag appears on page

## Summary
<!-- What does this PR do? -->

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [ ] Backend tests pass (`make test`)
- [ ] Frontend builds (`cd frontend && npm run build`)
- [ ] Tested locally with dfx

## Checklist
- [ ] Code follows project conventions
- [ ] Self-review completed
- [ ] No sensitive data committed
