### PR TITLE
feat(admin): add contractor and realtor pro-verification tabs (#247, …

### DIFF
--- a/frontend/src/__tests__/contracts/__snapshots__/candid.contract.test.ts.snap
+++ b/frontend/src/__tests__/contracts/__snapshots__/candid.contract.test.ts.snap
@@ -319,6 +319,15 @@ exports[`contractor IDL factory > full signature snapshot 1`] = `
       "variant {ok:record {id:principal; bio:opt text; serviceArea:opt text; jobsCompleted:nat; serviceZips:vec text; name:text; createdAt:int; trustScore:nat; email:text; isVerified:bool; licenseNumber:opt text; specialties:vec variant {Solar; HVAC; Pest; Pool; Plumbing; Painting; Concrete; Fencing; Gutters; Insulation; Landscaping; Windows; Electrical; Flooring; Roofing; GeneralHandyman}; phone:text}; err:variant {Paused; InvalidInput:text; NotFound; Unauthorized; AlreadyExists; RateLimitExceeded}}",
     ],
   },
+  "verifyContractor": {
+    "args": [
+      "principal",
+    ],
+    "mode": [],
+    "rets": [
+      "variant {ok:record {id:principal; bio:opt text; serviceArea:opt text; jobsCompleted:nat; serviceZips:vec text; name:text; createdAt:int; trustScore:nat; email:text; isVerified:bool; licenseNumber:opt text; specialties:vec variant {Solar; HVAC; Pest; Pool; Plumbing; Painting; Concrete; Fencing; Gutters; Insulation; Landscaping; Windows; Electrical; Flooring; Roofing; GeneralHandyman}; phone:text}; err:variant {Paused; InvalidInput:text; NotFound; Unauthorized; AlreadyExists; RateLimitExceeded}}",
+    ],
+  },
 }
 `;
 

--- a/frontend/src/__tests__/contracts/candid.contract.test.ts
+++ b/frontend/src/__tests__/contracts/candid.contract.test.ts
@@ -424,6 +424,7 @@ describe("contractor IDL factory", () => {
       "setJobCanisterId",
       "submitReview",
       "updateProfile",
+      "verifyContractor",
     ]);
   });
 

--- a/frontend/src/__tests__/services/__snapshots__/candidContracts.test.ts.snap
+++ b/frontend/src/__tests__/services/__snapshots__/candidContracts.test.ts.snap
@@ -66,7 +66,8 @@ recordJobVerified(4) -> (1)
 register(1) -> (1)
 setJobCanisterId(1) -> (1)
 submitReview(4) -> (1)
-updateProfile(1) -> (1)"
+updateProfile(1) -> (1)
+verifyContractor(1) -> (1)"
 `;
 
 exports[`Candid contract snapshots — method arity > job 1`] = `

--- a/frontend/src/pages/AdminDashboardPage.tsx
+++ b/frontend/src/pages/AdminDashboardPage.tsx
@@ -5,6 +5,8 @@ import { propertyService, Property, VerificationLevel, SubscriptionTier } from "
 import { monitoringService, CanisterMetrics, CycleLevelResult, runwayDays, cyclesToUsd } from "@/services/monitoringService";
 import { jobService, Job } from "@/services/job";
 import { referralService } from "@/services/referralService";
+import { contractorService, ContractorProfile } from "@/services/contractor";
+import { agentService, AgentOnChainProfile } from "@/services/agent";
 import { useAuthStore } from "@/store/authStore";
 import { Shield, CheckCircle, XCircle, RefreshCw, AlertTriangle, DollarSign } from "lucide-react";
 import toast from "react-hot-toast";
@@ -21,7 +23,7 @@ const UI = {
   mono:     FONTS.sans,
 };
 
-type Tab = "verifications" | "tiers" | "cycles" | "referrals";
+type Tab = "verifications" | "contractors" | "realtors" | "tiers" | "cycles" | "referrals";
 const TIERS: SubscriptionTier[] = ["Basic", "Pro", "Premium", "ContractorFree", "ContractorPro"];
 
 // ─── 13.6.3: Cycles burn rate dashboard ──────────────────────────────────────
@@ -542,6 +544,206 @@ function ReferralPipeline() {
   );
 }
 
+function ContractorVerificationTab() {
+  const [contractors, setContractors] = useState<ContractorProfile[]>([]);
+  const [loading, setLoading]         = useState(false);
+  const [verifying, setVerifying]     = useState<string | null>(null);
+
+  const load = async () => {
+    setLoading(true);
+    try {
+      const all = await contractorService.search();
+      setContractors(all);
+    } catch {
+      toast.error("Failed to load contractors");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => { load(); }, []);
+
+  const handleVerify = async (principalText: string) => {
+    setVerifying(principalText);
+    try {
+      await contractorService.verifyContractor(principalText);
+      toast.success("Contractor verified");
+      setContractors((prev) =>
+        prev.map((c) => c.id === principalText ? { ...c, isVerified: true } : c)
+      );
+    } catch (err: any) {
+      toast.error(err.message ?? "Verification failed");
+    } finally {
+      setVerifying(null);
+    }
+  };
+
+  const unverified = contractors.filter((c) => !c.isVerified);
+  const verified   = contractors.filter((c) =>  c.isVerified);
+
+  if (loading) {
+    return (
+      <div style={{ display: "flex", justifyContent: "center", padding: "3rem" }}>
+        <div className="spinner-lg" />
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "1.25rem" }}>
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+        <p style={{ fontFamily: UI.mono, fontSize: "0.65rem", letterSpacing: "0.06em", color: UI.inkLight }}>
+          {unverified.length} unverified · {verified.length} verified
+        </p>
+        <button
+          onClick={load}
+          style={{ display: "inline-flex", alignItems: "center", gap: "0.375rem", padding: "0.375rem 0.875rem", border: `1px solid ${UI.rule}`, background: COLORS.white, fontFamily: UI.mono, fontSize: "0.6rem", letterSpacing: "0.1em", textTransform: "uppercase", cursor: "pointer", color: UI.inkLight }}
+        >
+          <RefreshCw size={11} /> Refresh
+        </button>
+      </div>
+
+      {unverified.length === 0 ? (
+        <div style={{ border: `1px dashed ${UI.rule}`, padding: "3rem", textAlign: "center" }}>
+          <CheckCircle size={32} color={UI.rule} style={{ margin: "0 auto 0.75rem" }} />
+          <p style={{ fontFamily: UI.mono, fontSize: "0.65rem", color: UI.inkLight }}>All contractors are verified.</p>
+        </div>
+      ) : (
+        <div style={{ border: `1px solid ${UI.rule}`, background: COLORS.white }}>
+          <table style={{ width: "100%", borderCollapse: "collapse", fontFamily: UI.mono, fontSize: "0.7rem" }}>
+            <thead>
+              <tr style={{ borderBottom: `1px solid ${UI.rule}` }}>
+                {["Name", "Specialties", "License", "Trust Score", "Action"].map((h) => (
+                  <th key={h} style={{ padding: "0.625rem 1rem", textAlign: "left", fontWeight: 400, fontSize: "0.55rem", letterSpacing: "0.1em", textTransform: "uppercase", color: UI.inkLight }}>{h}</th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {unverified.map((c) => (
+                <tr key={c.id} style={{ borderBottom: `1px solid ${UI.rule}` }}>
+                  <td style={{ padding: "0.625rem 1rem", color: UI.ink, fontWeight: 600 }}>{c.name}</td>
+                  <td style={{ padding: "0.625rem 1rem", color: UI.inkLight }}>{c.specialties.join(", ")}</td>
+                  <td style={{ padding: "0.625rem 1rem", color: UI.inkLight }}>{c.licenseNumber ?? "—"}</td>
+                  <td style={{ padding: "0.625rem 1rem", color: UI.inkLight }}>{c.trustScore}</td>
+                  <td style={{ padding: "0.625rem 1rem" }}>
+                    <button
+                      onClick={() => handleVerify(c.id)}
+                      disabled={verifying === c.id}
+                      style={{ display: "inline-flex", alignItems: "center", gap: "0.3rem", padding: "0.375rem 0.875rem", border: `1px solid ${UI.sage}`, background: COLORS.white, color: UI.sage, fontFamily: UI.mono, fontSize: "0.6rem", letterSpacing: "0.08em", textTransform: "uppercase", cursor: verifying === c.id ? "not-allowed" : "pointer", opacity: verifying === c.id ? 0.6 : 1 }}
+                    >
+                      <Shield size={11} /> {verifying === c.id ? "Verifying…" : "Verify"}
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function AgentVerificationTab() {
+  const [agents, setAgents]       = useState<AgentOnChainProfile[]>([]);
+  const [loading, setLoading]     = useState(false);
+  const [verifying, setVerifying] = useState<string | null>(null);
+
+  const load = async () => {
+    setLoading(true);
+    try {
+      const all = await agentService.getAllProfiles();
+      setAgents(all);
+    } catch {
+      toast.error("Failed to load agents");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => { load(); }, []);
+
+  const handleVerify = async (agentId: string) => {
+    setVerifying(agentId);
+    try {
+      await agentService.verifyAgent(agentId);
+      toast.success("Agent verified");
+      setAgents((prev) =>
+        prev.map((a) => a.id === agentId ? { ...a, isVerified: true } : a)
+      );
+    } catch (err: any) {
+      toast.error(err.message ?? "Verification failed");
+    } finally {
+      setVerifying(null);
+    }
+  };
+
+  const unverified = agents.filter((a) => !a.isVerified);
+  const verified   = agents.filter((a) =>  a.isVerified);
+
+  if (loading) {
+    return (
+      <div style={{ display: "flex", justifyContent: "center", padding: "3rem" }}>
+        <div className="spinner-lg" />
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "1.25rem" }}>
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+        <p style={{ fontFamily: UI.mono, fontSize: "0.65rem", letterSpacing: "0.06em", color: UI.inkLight }}>
+          {unverified.length} unverified · {verified.length} verified
+        </p>
+        <button
+          onClick={load}
+          style={{ display: "inline-flex", alignItems: "center", gap: "0.375rem", padding: "0.375rem 0.875rem", border: `1px solid ${UI.rule}`, background: COLORS.white, fontFamily: UI.mono, fontSize: "0.6rem", letterSpacing: "0.1em", textTransform: "uppercase", cursor: "pointer", color: UI.inkLight }}
+        >
+          <RefreshCw size={11} /> Refresh
+        </button>
+      </div>
+
+      {unverified.length === 0 ? (
+        <div style={{ border: `1px dashed ${UI.rule}`, padding: "3rem", textAlign: "center" }}>
+          <CheckCircle size={32} color={UI.rule} style={{ margin: "0 auto 0.75rem" }} />
+          <p style={{ fontFamily: UI.mono, fontSize: "0.65rem", color: UI.inkLight }}>All agents are verified.</p>
+        </div>
+      ) : (
+        <div style={{ border: `1px solid ${UI.rule}`, background: COLORS.white }}>
+          <table style={{ width: "100%", borderCollapse: "collapse", fontFamily: UI.mono, fontSize: "0.7rem" }}>
+            <thead>
+              <tr style={{ borderBottom: `1px solid ${UI.rule}` }}>
+                {["Name", "Brokerage", "License", "States", "Action"].map((h) => (
+                  <th key={h} style={{ padding: "0.625rem 1rem", textAlign: "left", fontWeight: 400, fontSize: "0.55rem", letterSpacing: "0.1em", textTransform: "uppercase", color: UI.inkLight }}>{h}</th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {unverified.map((a) => (
+                <tr key={a.id} style={{ borderBottom: `1px solid ${UI.rule}` }}>
+                  <td style={{ padding: "0.625rem 1rem", color: UI.ink, fontWeight: 600 }}>{a.name}</td>
+                  <td style={{ padding: "0.625rem 1rem", color: UI.inkLight }}>{a.brokerage}</td>
+                  <td style={{ padding: "0.625rem 1rem", color: UI.inkLight }}>{a.licenseNumber}</td>
+                  <td style={{ padding: "0.625rem 1rem", color: UI.inkLight }}>{a.statesLicensed.join(", ")}</td>
+                  <td style={{ padding: "0.625rem 1rem" }}>
+                    <button
+                      onClick={() => handleVerify(a.id)}
+                      disabled={verifying === a.id}
+                      style={{ display: "inline-flex", alignItems: "center", gap: "0.3rem", padding: "0.375rem 0.875rem", border: `1px solid ${UI.sage}`, background: COLORS.white, color: UI.sage, fontFamily: UI.mono, fontSize: "0.6rem", letterSpacing: "0.08em", textTransform: "uppercase", cursor: verifying === a.id ? "not-allowed" : "pointer", opacity: verifying === a.id ? 0.6 : 1 }}
+                    >
+                      <Shield size={11} /> {verifying === a.id ? "Verifying…" : "Verify"}
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
 export default function AdminDashboardPage() {
   const { isAuthenticated, principal } = useAuthStore();
   const [isAdmin, setIsAdmin] = useState<boolean | null>(null);
@@ -652,6 +854,8 @@ export default function AdminDashboardPage() {
         <div style={{ display: "flex", borderBottom: `1px solid ${UI.rule}`, marginBottom: "1.5rem" }}>
           {([
             { id: "verifications", label: `Verifications${pending.length > 0 ? ` (${pending.length})` : ""}` },
+            { id: "contractors",   label: "Contractors" },
+            { id: "realtors",      label: "Realtors" },
             { id: "tiers",         label: "Subscription Tiers" },
             { id: "cycles",        label: "Cycles & Health" },
             { id: "referrals",     label: "Referral Fees" },
@@ -707,6 +911,10 @@ export default function AdminDashboardPage() {
             )}
           </div>
         )}
+
+        {tab === "contractors" && <ContractorVerificationTab />}
+
+        {tab === "realtors" && <AgentVerificationTab />}
 
         {tab === "tiers" && <TierManager />}
 

--- a/frontend/src/services/agent.ts
+++ b/frontend/src/services/agent.ts
@@ -247,6 +247,13 @@ function createAgentService() {
       const raw = await actor.getReviews(Principal.fromText(agentId));
       return raw.map(fromRawReview);
     },
+
+    async verifyAgent(agentId: string): Promise<void> {
+      const { Principal } = await import("@icp-sdk/core/principal");
+      const actor = await getActor();
+      const result = await actor.verifyAgent(Principal.fromText(agentId));
+      if ("err" in result) throw new Error(JSON.stringify(result.err));
+    },
   };
 }
 

--- a/frontend/src/services/contractor.ts
+++ b/frontend/src/services/contractor.ts
@@ -115,6 +115,11 @@ export const idlFactory = ({ IDL }: any) => {
       [IDL.Variant({ ok: IDL.Null, err: Error })],
       []
     ),
+    verifyContractor: IDL.Func(
+      [IDL.Principal],
+      [IDL.Variant({ ok: ContractorProfile, err: Error })],
+      []
+    ),
   });
 };
 
@@ -311,6 +316,12 @@ function createContractorService() {
     const a = await getActor();
     const result = await a.getBySpecialty({ [specialty]: null }) as any[];
     return result.map(fromProfile);
+  },
+
+  async verifyContractor(principalText: string): Promise<ContractorProfile> {
+    const { Principal: P } = await import("@icp-sdk/core/principal");
+    const a = await getActor();
+    return unwrap(await a.verifyContractor(P.fromText(principalText)));
   },
 
   reset() {


### PR DESCRIPTION
…#248)

Admins can now verify contractors and realtors from the Admin Dashboard.
- `contractorService.verifyContractor()` and `agentService.verifyAgent()` wired to new Contractors / Realtors tabs
- Unverified profiles listed in a table with per-row Verify button; optimistic update on success
- Candid contract test + snapshot updated for `verifyContractor` addition

## Summary
<!-- What does this PR do? -->

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [ ] Backend tests pass (`make test`)
- [ ] Frontend builds (`cd frontend && npm run build`)
- [ ] Tested locally with dfx

## Checklist
- [ ] Code follows project conventions
- [ ] Self-review completed
- [ ] No sensitive data committed
