### PR TITLE
feat(iot-gateway): Ecobee REST poller with token auto-refresh (#261)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -57,3 +57,27 @@ STRIPE_PRICE_CREDITS_100=
 # Stripe webhook endpoint secret — from the Stripe Dashboard → Webhooks → your endpoint
 # Required in production; if unset the /api/stripe/webhook route returns 500 (fail-closed).
 STRIPE_WEBHOOK_SECRET=
+
+# ── IoT Gateway (agents/iot-gateway) ─────────────────────────────────────────
+
+# Gateway service identity — 32-byte hex seed for the Ed25519 key that the sensor
+# canister must whitelist via addAuthorizedGateway(principal).
+# Generate: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+GATEWAY_IDENTITY_SEED=
+IOT_GATEWAY_PORT=3002
+
+# Webhook secrets — set on the respective cloud dashboards to authenticate inbound events.
+NEST_WEBHOOK_SECRET=
+ECOBEE_WEBHOOK_SECRET=
+MOEN_FLO_WEBHOOK_SECRET=
+
+# Ecobee polling (consumer apps must poll — no push webhooks available)
+# Obtain tokens via the PIN flow described in agents/iot-gateway/README.md.
+ECOBEE_CLIENT_ID=
+ECOBEE_ACCESS_TOKEN=
+ECOBEE_REFRESH_TOKEN=
+# Optional — restrict polling to a single thermostat identifier (12-digit number).
+# If unset, all registered thermostats are polled.
+ECOBEE_THERMOSTAT_ID=
+# Optional — path to the token persistence file (default: .ecobee-tokens.json in cwd).
+ECOBEE_TOKENS_FILE=

--- a/agents/iot-gateway/README.md
+++ b/agents/iot-gateway/README.md
@@ -86,7 +86,7 @@ After completing the PIN flow, run:
 
 ```bash
 curl "https://api.ecobee.com/1/thermostat?json=%7B%22selection%22%3A%7B%22selectionType%22%3A%22registered%22%2C%22selectionMatch%22%3A%22%22%7D%7D" \
-  -H "Authorization: Bearer YOUR_ACCESS_TOKEN"
+  -H "Authorization: Bearer $ECOBEE_ACCESS_TOKEN"
 ```
 
 Look at `thermostatList[0].identifier` — a 12-digit number like `411848373746`.

--- a/agents/iot-gateway/README.md
+++ b/agents/iot-gateway/README.md
@@ -1,0 +1,131 @@
+# HomeGentic IoT Gateway
+
+Node.js/Express bridge that receives webhooks from smart-home platforms and forwards
+normalized sensor readings to the HomeGentic Sensor canister on ICP.
+
+## Supported platforms
+
+| Platform | Protocol | Env var required |
+|---|---|---|
+| Nest (Google SDM) | Push webhook (Pub/Sub) | `NEST_WEBHOOK_SECRET` |
+| Ecobee | REST polling (3 min) | `ECOBEE_CLIENT_ID` + tokens |
+| Moen Flo | Push webhook | `MOEN_FLO_WEBHOOK_SECRET` |
+
+## Running
+
+```bash
+cd agents/iot-gateway
+npm install
+npm run dev        # ts-node server.ts, port 3002
+```
+
+Copy `.env.example` to `.env` and fill in the relevant vars before starting.
+
+---
+
+## Ecobee — PIN authorization walkthrough
+
+Ecobee uses an OAuth 2.0 PIN flow for consumer apps. Run these two steps once to
+obtain your initial `access_token` and `refresh_token`. The gateway refreshes tokens
+automatically on every restart and whenever the token is close to expiring.
+
+### Prerequisites
+
+1. Create a free account at [developer.ecobee.com](https://developer.ecobee.com)
+2. Create an application → note the **API Key** — this is your `ECOBEE_CLIENT_ID`
+
+### Step 1 — request a PIN
+
+```bash
+curl "https://api.ecobee.com/authorize?response_type=ecobeePin&client_id=YOUR_CLIENT_ID&scope=smartRead"
+```
+
+Response:
+
+```json
+{
+  "ecobeePin": "ABCD-1234",
+  "code": "AUTHORIZATION_CODE",
+  "scope": "smartRead",
+  "expires_in": 900
+}
+```
+
+Go to your Ecobee app → **Menu → My Apps → Add Application** and enter the PIN
+(`ABCD-1234`). You have 15 minutes.
+
+### Step 2 — exchange code for tokens
+
+```bash
+curl -X POST "https://api.ecobee.com/token?grant_type=ecobeePin&code=AUTHORIZATION_CODE&client_id=YOUR_CLIENT_ID"
+```
+
+Response:
+
+```json
+{
+  "access_token": "...",
+  "token_type": "Bearer",
+  "expires_in": 3600,
+  "refresh_token": "...",
+  "scope": "smartRead"
+}
+```
+
+Add to your `.env`:
+
+```
+ECOBEE_CLIENT_ID=YOUR_CLIENT_ID
+ECOBEE_ACCESS_TOKEN=<access_token from above>
+ECOBEE_REFRESH_TOKEN=<refresh_token from above>
+```
+
+### Finding your thermostat ID
+
+After completing the PIN flow, run:
+
+```bash
+curl "https://api.ecobee.com/1/thermostat?json=%7B%22selection%22%3A%7B%22selectionType%22%3A%22registered%22%2C%22selectionMatch%22%3A%22%22%7D%7D" \
+  -H "Authorization: Bearer YOUR_ACCESS_TOKEN"
+```
+
+Look at `thermostatList[0].identifier` — a 12-digit number like `411848373746`.
+Set `ECOBEE_THERMOSTAT_ID` to restrict polling to a single unit, or leave it unset
+to poll all registered thermostats.
+
+### Register the device in HomeGentic
+
+Once you have the thermostat identifier, register it once so the gateway can match
+incoming readings to the correct sensor record:
+
+```ts
+sensorService.registerDevice(propertyId, "411848373746", "Ecobee", "Living Room Ecobee")
+```
+
+The `externalDeviceId` passed here must match the identifier returned by the Ecobee API.
+
+---
+
+## Gateway identity setup
+
+The sensor canister only accepts `recordEvent` calls from authorized gateway principals.
+Generate a stable identity seed and whitelist it once:
+
+```bash
+# Generate a 32-byte hex seed
+node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+# → add as GATEWAY_IDENTITY_SEED in .env
+
+# Print the derived principal
+cd agents/iot-gateway && node -e "
+const { Ed25519KeyIdentity } = require('@icp-sdk/core/identity');
+const seed = Buffer.from(process.env.GATEWAY_IDENTITY_SEED, 'hex');
+const id = Ed25519KeyIdentity.generate(new Uint8Array(seed));
+console.log(id.getPrincipal().toText());
+"
+
+# Whitelist it on the sensor canister
+dfx canister call sensor addAuthorizedGateway '(principal "YOUR_GATEWAY_PRINCIPAL")'
+```
+
+The gateway also prints its principal on startup via `GET /health`.

--- a/agents/iot-gateway/handlers.ts
+++ b/agents/iot-gateway/handlers.ts
@@ -77,14 +77,18 @@ function fahrenheitToCelsius(f: number): number {
   return parseFloat(((f - 32) * (5 / 9)).toFixed(1));
 }
 
+const HIGH_TEMP_THRESHOLD_C = 35;
+const HIGH_HUMIDITY_THRESHOLD = 70;
+
 export function handleEcobeeEvent(
   body: EcobeeWebhookEvent,
   raw: string
 ): SensorReading | null {
-  const { thermostatId, alerts } = body;
-  if (!thermostatId || !alerts?.length) return null;
+  const { thermostatId, alerts, runtime } = body;
+  if (!thermostatId) return null;
 
-  for (const alert of alerts) {
+  // Alert-driven events take priority — return on first actionable match.
+  for (const alert of alerts ?? []) {
     switch (alert.alertType) {
       case "lowTemp": {
         const celsius =
@@ -128,7 +132,7 @@ export function handleEcobeeEvent(
           rawPayload: raw,
         };
       case "humidity":
-        if (alert.value !== undefined && alert.value > 70) {
+        if (alert.value !== undefined && alert.value > HIGH_HUMIDITY_THRESHOLD) {
           return {
             externalDeviceId: thermostatId,
             eventType: { HighHumidity: null } as SensorEventType,
@@ -138,6 +142,39 @@ export function handleEcobeeEvent(
           };
         }
         break;
+    }
+  }
+
+  // Runtime threshold checks — belt-and-suspenders for polls without active alerts.
+  // Ecobee reports temperature in 10ths of °F (e.g. 680 = 68.0 °F).
+  if (runtime) {
+    const celsius = fahrenheitToCelsius(runtime.actualTemperature / 10);
+    if (celsius <= PIPE_FREEZE_THRESHOLD_C) {
+      return {
+        externalDeviceId: thermostatId,
+        eventType: { LowTemperature: null } as SensorEventType,
+        value: celsius,
+        unit: "°C",
+        rawPayload: raw,
+      };
+    }
+    if (celsius > HIGH_TEMP_THRESHOLD_C) {
+      return {
+        externalDeviceId: thermostatId,
+        eventType: { HighTemperature: null } as SensorEventType,
+        value: celsius,
+        unit: "°C",
+        rawPayload: raw,
+      };
+    }
+    if (runtime.actualHumidity > HIGH_HUMIDITY_THRESHOLD) {
+      return {
+        externalDeviceId: thermostatId,
+        eventType: { HighHumidity: null } as SensorEventType,
+        value: runtime.actualHumidity,
+        unit: "%RH",
+        rawPayload: raw,
+      };
     }
   }
 

--- a/agents/iot-gateway/pollers/ecobee.ts
+++ b/agents/iot-gateway/pollers/ecobee.ts
@@ -1,0 +1,221 @@
+/**
+ * Ecobee REST polling script.
+ *
+ * Ecobee has no push webhook capability for consumer apps — data must be pulled.
+ * Recommended interval: 3 minutes (Ecobee rate-limits at ~12 req/min).
+ *
+ * Token lifecycle:
+ *   - access_token expires in 1 hour
+ *   - Refresh is triggered when < 2 minutes remain
+ *   - Refreshed tokens are persisted to ECOBEE_TOKENS_FILE so they survive
+ *     process restarts (default: .ecobee-tokens.json in the working directory)
+ *
+ * Required env vars (see .env.example):
+ *   ECOBEE_CLIENT_ID        — from developer.ecobee.com
+ *   ECOBEE_ACCESS_TOKEN     — obtained via PIN flow (see README)
+ *   ECOBEE_REFRESH_TOKEN    — obtained via PIN flow
+ *   ECOBEE_THERMOSTAT_ID    — optional; if set, only this thermostat is polled
+ */
+
+import fs from "fs";
+import path from "path";
+import { handleEcobeeEvent } from "../handlers";
+import { recordSensorEvent } from "../icp";
+import type { EcobeeWebhookEvent, EcobeeAlert } from "../types";
+
+const ECOBEE_API        = "https://api.ecobee.com";
+const REFRESH_BUFFER_MS = 2 * 60 * 1000; // refresh 2 min before expiry
+
+const TOKENS_FILE = process.env.ECOBEE_TOKENS_FILE
+  ?? path.resolve(process.cwd(), ".ecobee-tokens.json");
+
+// ── Token state ───────────────────────────────────────────────────────────────
+
+interface TokenState {
+  accessToken:  string;
+  refreshToken: string;
+  expiresAt:    number; // ms epoch
+}
+
+function loadTokenState(): TokenState | null {
+  // Persisted file takes precedence — survives restarts with refreshed tokens.
+  if (fs.existsSync(TOKENS_FILE)) {
+    try {
+      const parsed = JSON.parse(fs.readFileSync(TOKENS_FILE, "utf8")) as TokenState;
+      if (parsed.accessToken && parsed.refreshToken && parsed.expiresAt) {
+        return parsed;
+      }
+    } catch {
+      console.warn("[ecobee-poller] corrupted token file — falling back to env vars");
+    }
+  }
+
+  const accessToken  = process.env.ECOBEE_ACCESS_TOKEN;
+  const refreshToken = process.env.ECOBEE_REFRESH_TOKEN;
+  if (!accessToken || !refreshToken) return null;
+
+  return {
+    accessToken,
+    refreshToken,
+    expiresAt: Date.now() + 60 * 60 * 1000, // assume 1 h if unknown
+  };
+}
+
+function persistTokenState(state: TokenState): void {
+  try {
+    fs.writeFileSync(TOKENS_FILE, JSON.stringify(state, null, 2), "utf8");
+  } catch (err) {
+    console.warn("[ecobee-poller] failed to persist tokens:", err);
+  }
+  // Keep process.env in sync so other callers (e.g. tests) see current values.
+  process.env.ECOBEE_ACCESS_TOKEN  = state.accessToken;
+  process.env.ECOBEE_REFRESH_TOKEN = state.refreshToken;
+}
+
+async function refreshTokens(state: TokenState): Promise<TokenState> {
+  const clientId = process.env.ECOBEE_CLIENT_ID;
+  if (!clientId) throw new Error("[ecobee-poller] ECOBEE_CLIENT_ID is required for token refresh");
+
+  const url = `${ECOBEE_API}/token`
+    + `?grant_type=refresh_token`
+    + `&refresh_token=${encodeURIComponent(state.refreshToken)}`
+    + `&client_id=${encodeURIComponent(clientId)}`;
+
+  const resp = await fetch(url, { method: "POST" });
+  if (!resp.ok) {
+    const body = await resp.text();
+    throw new Error(`[ecobee-poller] token refresh failed (${resp.status}): ${body}`);
+  }
+
+  const data = await resp.json() as {
+    access_token:  string;
+    refresh_token: string;
+    expires_in:    number; // seconds
+  };
+
+  const newState: TokenState = {
+    accessToken:  data.access_token,
+    refreshToken: data.refresh_token,
+    expiresAt:    Date.now() + data.expires_in * 1000,
+  };
+
+  persistTokenState(newState);
+  console.log(`[ecobee-poller] tokens refreshed — next expiry in ${Math.round(data.expires_in / 60)} min`);
+  return newState;
+}
+
+async function ensureFreshToken(state: TokenState): Promise<TokenState> {
+  if (Date.now() < state.expiresAt - REFRESH_BUFFER_MS) return state;
+  return refreshTokens(state);
+}
+
+// ── Ecobee REST API response shape (fields we use) ───────────────────────────
+
+interface EcobeeApiResponse {
+  thermostatList: Array<{
+    identifier: string;
+    name:       string;
+    alerts:     EcobeeAlert[];
+    runtime: {
+      actualTemperature: number; // 10ths of °F
+      actualHumidity:    number; // %
+    };
+  }>;
+}
+
+// ── Poll ──────────────────────────────────────────────────────────────────────
+
+async function pollOnce(state: TokenState): Promise<void> {
+  const selectionMatch = process.env.ECOBEE_THERMOSTAT_ID ?? "";
+  const selectionType  = selectionMatch ? "thermostats" : "registered";
+
+  const selection = encodeURIComponent(JSON.stringify({
+    selection: {
+      selectionType,
+      selectionMatch,
+      includeAlerts:  true,
+      includeRuntime: true,
+    },
+  }));
+
+  const resp = await fetch(`${ECOBEE_API}/1/thermostat?json=${selection}`, {
+    headers: { Authorization: `Bearer ${state.accessToken}` },
+  });
+
+  if (!resp.ok) {
+    console.error(`[ecobee-poller] poll failed (${resp.status}): ${await resp.text()}`);
+    return;
+  }
+
+  const data = await resp.json() as EcobeeApiResponse;
+
+  for (const therm of data.thermostatList ?? []) {
+    const raw = JSON.stringify(therm);
+    const event: EcobeeWebhookEvent = {
+      thermostatId: therm.identifier,
+      alerts:       therm.alerts ?? [],
+      runtime:      therm.runtime,
+    };
+
+    const reading = handleEcobeeEvent(event, raw);
+    if (!reading) continue;
+
+    const eventName = Object.keys(reading.eventType)[0];
+    console.log(`[ecobee-poller] ${eventName} device=${therm.identifier} (${therm.name})`);
+
+    const result = await recordSensorEvent(reading);
+    if (result.success) {
+      console.log(
+        `[ecobee-poller] recorded eventId=${result.eventId}` +
+        (result.jobId ? ` jobId=${result.jobId}` : "")
+      );
+    } else {
+      console.error(`[ecobee-poller] canister error: ${result.error}`);
+    }
+  }
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/**
+ * Starts the Ecobee polling loop. Returns a stop function.
+ *
+ * No-ops (returns immediately) when ECOBEE_ACCESS_TOKEN / ECOBEE_REFRESH_TOKEN
+ * are not set — safe to call unconditionally at gateway startup.
+ */
+export function startEcobeePoller(intervalMs = 3 * 60 * 1000): () => void {
+  const initial = loadTokenState();
+  if (!initial) {
+    console.warn(
+      "[ecobee-poller] ECOBEE_ACCESS_TOKEN or ECOBEE_REFRESH_TOKEN not set — poller disabled"
+    );
+    return () => {};
+  }
+
+  let currentState = initial;
+  let stopped      = false;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+
+  async function tick(): Promise<void> {
+    if (stopped) return;
+    try {
+      currentState = await ensureFreshToken(currentState);
+      await pollOnce(currentState);
+    } catch (err) {
+      console.error("[ecobee-poller] tick error:", err);
+    } finally {
+      if (!stopped) {
+        timer = setTimeout(tick, intervalMs);
+      }
+    }
+  }
+
+  console.log(`[ecobee-poller] starting — interval=${intervalMs / 1000}s`);
+  tick(); // run immediately, then on each interval
+
+  return () => {
+    stopped = true;
+    if (timer) clearTimeout(timer);
+    console.log("[ecobee-poller] stopped");
+  };
+}

--- a/agents/iot-gateway/server.ts
+++ b/agents/iot-gateway/server.ts
@@ -24,6 +24,7 @@ import cors from "cors";
 import rateLimit from "express-rate-limit";
 import { handleNestEvent, handleEcobeeEvent, handleMoenFloEvent } from "./handlers";
 import { recordSensorEvent, getGatewayPrincipal } from "./icp";
+import { startEcobeePoller } from "./pollers/ecobee";
 import type {
   NestWebhookEvent,
   EcobeeWebhookEvent,
@@ -204,6 +205,9 @@ app.get("/health", (_req: Request, res: Response) => {
     gatewayPrincipal: getGatewayPrincipal(),
     sensorCanisterId: process.env.SENSOR_CANISTER_ID ?? "(not set)",
     platforms: ["nest", "ecobee", "moen-flo"],
+    pollers: {
+      ecobee: !!process.env.ECOBEE_CLIENT_ID,
+    },
   });
 });
 
@@ -212,4 +216,9 @@ app.listen(port, () => {
   console.log(`HomeGentic IoT Gateway → http://localhost:${port}`);
   console.log(`Gateway principal: ${getGatewayPrincipal()}`);
   console.log(`Sensor canister:   ${process.env.SENSOR_CANISTER_ID ?? "(set SENSOR_CANISTER_ID)"}`);
+
+  // Start polling integrations — each is a no-op when env vars are absent.
+  if (process.env.ECOBEE_CLIENT_ID) {
+    startEcobeePoller();
+  }
 });

--- a/agents/iot-gateway/types.ts
+++ b/agents/iot-gateway/types.ts
@@ -68,9 +68,18 @@ export interface EcobeeAlert {
   value?: number; // temperature °F or humidity %
 }
 
+export interface EcobeeRuntime {
+  /** 10ths of °F — e.g. 680 = 68.0 °F */
+  actualTemperature: number;
+  /** Relative humidity % */
+  actualHumidity: number;
+}
+
 export interface EcobeeWebhookEvent {
   thermostatId: string;
   alerts?: EcobeeAlert[];
+  /** Populated by the poller from the REST API runtime object. */
+  runtime?: EcobeeRuntime;
   runtimeSensorData?: {
     columns: string[];
     data: string[][];


### PR DESCRIPTION
## Summary

Closes #261.

Ecobee has no push webhook capability for consumer apps — data must be polled. This PR adds the polling script that drives the existing `handleEcobeeEvent` handler, plus token auto-refresh, runtime threshold fallback, env var documentation, and a first-time setup README.

- **`pollers/ecobee.ts`** — polls `GET /1/thermostat` every 3 minutes; refreshes `access_token` 2 min before expiry; persists refreshed tokens to `.ecobee-tokens.json` so restarts don't require re-auth; no-ops silently when env vars are absent
- **`handlers.ts`** — adds a runtime threshold fallback to `handleEcobeeEvent`: when no alert fires, checks live `actualTemperature` (10ths °F → °C) and `actualHumidity` against the same thresholds as alert-driven events
- **`types.ts`** — adds `EcobeeRuntime` interface and `runtime?: EcobeeRuntime` field to `EcobeeWebhookEvent`
- **`server.ts`** — calls `startEcobeePoller()` at startup when `ECOBEE_CLIENT_ID` is set; exposes poller on/off status in `GET /health`
- **`.env.example`** — documents all IoT gateway env vars in one block (`GATEWAY_IDENTITY_SEED`, webhook secrets, all Ecobee vars)
- **`README.md`** — Ecobee PIN auth walkthrough (two `curl` commands), thermostat ID lookup, device registration, gateway identity setup

## Test plan

- [ ] Set `ECOBEE_CLIENT_ID`, `ECOBEE_ACCESS_TOKEN`, `ECOBEE_REFRESH_TOKEN` in `.env` via the PIN flow in `README.md`
- [ ] `npm run dev` in `agents/iot-gateway/` — confirm `[ecobee-poller] starting` log appears
- [ ] Verify `GET /health` returns `"pollers": { "ecobee": true }`
- [ ] Confirm `.ecobee-tokens.json` is written after first poll
- [ ] Restart the gateway — confirm it reads tokens from the file, not env vars
- [ ] Set `ECOBEE_ACCESS_TOKEN` to an expired token — confirm `[ecobee-poller] tokens refreshed` log fires before the first poll
- [ ] Unset `ECOBEE_CLIENT_ID` — confirm gateway starts without error and poller is silent

🤖 Generated with [Claude Code](https://claude.com/claude-code)