### PR TITLE
feat(iot-gateway): Honeywell Home / Resideo REST polling (#263)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -81,3 +81,14 @@ ECOBEE_REFRESH_TOKEN=
 ECOBEE_THERMOSTAT_ID=
 # Optional — path to the token persistence file (default: .ecobee-tokens.json in cwd).
 ECOBEE_TOKENS_FILE=
+
+# Honeywell Home / Resideo polling (OAuth 2.0 Authorization Code flow)
+# Register at developer.honeywellhome.com → see agents/iot-gateway/README.md for setup.
+HONEYWELL_CLIENT_ID=
+HONEYWELL_CLIENT_SECRET=
+HONEYWELL_ACCESS_TOKEN=
+HONEYWELL_REFRESH_TOKEN=
+# Optional — restrict polling to one location ID. If unset, all locations are polled.
+HONEYWELL_LOCATION_ID=
+# Optional — path to the token persistence file (default: .honeywell-tokens.json in cwd).
+HONEYWELL_TOKENS_FILE=

--- a/agents/iot-gateway/README.md
+++ b/agents/iot-gateway/README.md
@@ -10,6 +10,7 @@ normalized sensor readings to the HomeGentic Sensor canister on ICP.
 | Nest (Google SDM) | Push webhook (Pub/Sub) | `NEST_WEBHOOK_SECRET` |
 | Ecobee | REST polling (3 min) | `ECOBEE_CLIENT_ID` + tokens |
 | Moen Flo | Push webhook | `MOEN_FLO_WEBHOOK_SECRET` |
+| Honeywell Home / Resideo | REST polling (3 min) | `HONEYWELL_CLIENT_ID` + tokens |
 
 ## Running
 
@@ -103,6 +104,84 @@ sensorService.registerDevice(propertyId, "411848373746", "Ecobee", "Living Room 
 ```
 
 The `externalDeviceId` passed here must match the identifier returned by the Ecobee API.
+
+---
+
+---
+
+## Honeywell Home / Resideo — OAuth 2.0 authorization walkthrough
+
+Honeywell uses the standard OAuth 2.0 Authorization Code flow. Run through
+steps 1–3 once to obtain your initial tokens. The gateway refreshes tokens
+automatically (access tokens expire in 10 minutes).
+
+### Prerequisites
+
+1. Sign up at [developer.honeywellhome.com](https://developer.honeywellhome.com)
+2. Create an app → note the **Consumer Key** (`HONEYWELL_CLIENT_ID`) and
+   **Consumer Secret** (`HONEYWELL_CLIENT_SECRET`)
+3. Set the callback URL to `http://localhost:3002/oauth/callback/honeywell`
+
+### Step 1 — start the gateway with credentials
+
+```
+HONEYWELL_CLIENT_ID=YOUR_KEY
+HONEYWELL_CLIENT_SECRET=YOUR_SECRET
+```
+
+Restart the gateway (`npm run dev`). The `/oauth/callback/honeywell` route is now active.
+
+### Step 2 — authorize in a browser
+
+Open this URL (replace `YOUR_KEY`):
+
+```
+https://api.honeywell.com/oauth2/authorize?response_type=code&client_id=YOUR_KEY&redirect_uri=http://localhost:3002/oauth/callback/honeywell
+```
+
+Log in with your Honeywell Home account and approve access. The browser redirects to the gateway callback, which exchanges the code for tokens and saves them to `.honeywell-tokens.json`.
+
+You should see: **"Honeywell Home connected!"**
+
+### Step 3 — restart to begin polling
+
+```bash
+npm run dev
+```
+
+The gateway loads the persisted tokens and starts polling every 3 minutes.
+
+### Finding your location and device IDs
+
+After completing the OAuth flow, inspect your locations and devices:
+
+```bash
+# List location IDs
+curl "https://api.honeywell.com/v2/locations?apikey=$HONEYWELL_CLIENT_ID" \
+  -H "Authorization: Bearer $HONEYWELL_ACCESS_TOKEN" | jq '.[].locationID'
+
+# List thermostats for a location (replace LOC_ID)
+curl "https://api.honeywell.com/v2/devices/thermostats?apikey=$HONEYWELL_CLIENT_ID&locationId=LOC_ID" \
+  -H "Authorization: Bearer $HONEYWELL_ACCESS_TOKEN" | jq '.[] | {deviceID, userDefinedDeviceName}'
+```
+
+Set `HONEYWELL_LOCATION_ID` to restrict polling to a single location, or leave it
+unset to poll all locations. The `deviceID` (e.g. `"LCC-00D02D123456"`) is used
+as `externalDeviceId` when registering in HomeGentic:
+
+```ts
+sensorService.registerDevice(propertyId, "LCC-00D02D123456", "HoneywellHome", "Living Room Thermostat")
+```
+
+### Events ingested
+
+| Condition | Canister event | Severity |
+|---|---|---|
+| `indoorTemperature` converts to ≤ 4 °C | `LowTemperature` | Critical |
+| `indoorTemperature` converts to > 35 °C | `HighTemperature` | Warning |
+| HVAC `equipmentStatus === "Fault"` or `"Off"` | `HvacAlert` | Warning |
+| `indoorHumidity > 70 %` | `HighHumidity` | Warning |
+| Water Leak Detector `isWaterPresent` | `WaterLeak` | Critical |
 
 ---
 

--- a/agents/iot-gateway/__tests__/handlers.test.ts
+++ b/agents/iot-gateway/__tests__/handlers.test.ts
@@ -1,8 +1,9 @@
-import { handleNestEvent, handleEcobeeEvent, handleMoenFloEvent } from "../handlers";
+import { handleNestEvent, handleEcobeeEvent, handleMoenFloEvent, handleHoneywellHomeEvent } from "../handlers";
 import type {
   NestWebhookEvent,
   EcobeeWebhookEvent,
   MoenFloWebhookEvent,
+  HoneywellDevice,
 } from "../types";
 
 const RAW = "{}";
@@ -338,5 +339,147 @@ describe("handleMoenFloEvent", () => {
 
   it("returns null when alertType is absent", () => {
     expect(handleMoenFloEvent(moenEvent({ alertType: "" }), RAW)).toBeNull();
+  });
+});
+
+// ── handleHoneywellHomeEvent ──────────────────────────────────────────────────
+
+describe("handleHoneywellHomeEvent", () => {
+  function honeywellDevice(overrides: Partial<HoneywellDevice>): HoneywellDevice {
+    return {
+      deviceID:              "LCC-00D02D123456",
+      userDefinedDeviceName: "Living Room",
+      deviceType:            "Thermostat",
+      ...overrides,
+    };
+  }
+
+  describe("guard conditions", () => {
+    it("returns null when deviceID is absent", () => {
+      expect(handleHoneywellHomeEvent(honeywellDevice({ deviceID: "" }), RAW)).toBeNull();
+    });
+
+    it("returns null when no relevant fields are present", () => {
+      expect(handleHoneywellHomeEvent(honeywellDevice({}), RAW)).toBeNull();
+    });
+  });
+
+  describe("WLD — water leak detector", () => {
+    it("returns WaterLeak when waterPresent is true", () => {
+      const reading = handleHoneywellHomeEvent(
+        honeywellDevice({ deviceType: "Water Leak Detector", waterPresent: true }), RAW
+      );
+      expect(reading!.eventType).toEqual({ WaterLeak: null });
+      expect(reading!.externalDeviceId).toBe("LCC-00D02D123456");
+      expect(reading!.value).toBe(0);
+    });
+
+    it("returns null when waterPresent is false", () => {
+      expect(handleHoneywellHomeEvent(
+        honeywellDevice({ deviceType: "Water Leak Detector", waterPresent: false }), RAW
+      )).toBeNull();
+    });
+
+    it("WaterLeak takes priority over cold temperature on the same device", () => {
+      // waterPresent should be checked before temperature
+      const reading = handleHoneywellHomeEvent(
+        honeywellDevice({ waterPresent: true, indoorTemperature: 33 }), RAW
+      );
+      expect(reading!.eventType).toEqual({ WaterLeak: null });
+    });
+  });
+
+  describe("temperature", () => {
+    // 33 °F → (33-32)*5/9 = 0.6 °C ≤ 4 °C
+    it("returns LowTemperature when temperature converts to below the freeze threshold", () => {
+      const reading = handleHoneywellHomeEvent(honeywellDevice({ indoorTemperature: 33 }), RAW);
+      expect(reading!.eventType).toEqual({ LowTemperature: null });
+      expect(reading!.unit).toBe("°C");
+      expect(reading!.value).toBe(0.6);
+    });
+
+    // 39.2 °F → (39.2-32)*5/9 = 4.0 °C — exactly at boundary
+    it("returns LowTemperature at exactly 4 °C (inclusive boundary)", () => {
+      const reading = handleHoneywellHomeEvent(honeywellDevice({ indoorTemperature: 39.2 }), RAW);
+      expect(reading!.eventType).toEqual({ LowTemperature: null });
+    });
+
+    // 40 °F → (40-32)*5/9 = 4.4 °C — just above threshold
+    it("returns null when temperature converts to just above 4 °C", () => {
+      expect(handleHoneywellHomeEvent(honeywellDevice({ indoorTemperature: 40 }), RAW)).toBeNull();
+    });
+
+    // 96 °F → (96-32)*5/9 = 35.6 °C > 35 °C
+    it("returns HighTemperature when temperature converts to above 35 °C", () => {
+      const reading = handleHoneywellHomeEvent(honeywellDevice({ indoorTemperature: 96 }), RAW);
+      expect(reading!.eventType).toEqual({ HighTemperature: null });
+      expect(reading!.unit).toBe("°C");
+    });
+
+    // 95 °F → (95-32)*5/9 = 35.0 °C — exactly 35 is NOT triggered (exclusive upper boundary)
+    it("returns null when temperature converts to exactly 35 °C (exclusive upper boundary)", () => {
+      expect(handleHoneywellHomeEvent(honeywellDevice({ indoorTemperature: 95 }), RAW)).toBeNull();
+    });
+
+    // 72 °F → 22.2 °C — normal range
+    it("returns null when temperature is in the normal range", () => {
+      expect(handleHoneywellHomeEvent(honeywellDevice({ indoorTemperature: 72 }), RAW)).toBeNull();
+    });
+  });
+
+  describe("HVAC status", () => {
+    it("returns HvacAlert when equipmentStatus is Fault", () => {
+      const reading = handleHoneywellHomeEvent(
+        honeywellDevice({ indoorTemperature: 72, operationStatus: { equipmentStatus: "Fault" } }), RAW
+      );
+      expect(reading!.eventType).toEqual({ HvacAlert: null });
+      expect(reading!.value).toBe(0);
+    });
+
+    it("returns HvacAlert when equipmentStatus is Off", () => {
+      const reading = handleHoneywellHomeEvent(
+        honeywellDevice({ indoorTemperature: 72, operationStatus: { equipmentStatus: "Off" } }), RAW
+      );
+      expect(reading!.eventType).toEqual({ HvacAlert: null });
+    });
+
+    it("returns null when equipmentStatus is Heating (normal operation)", () => {
+      expect(handleHoneywellHomeEvent(
+        honeywellDevice({ indoorTemperature: 72, operationStatus: { equipmentStatus: "Heating" } }), RAW
+      )).toBeNull();
+    });
+
+    it("temperature check takes priority over HVAC status", () => {
+      // Low temperature should be returned before HVAC Fault is evaluated
+      const reading = handleHoneywellHomeEvent(
+        honeywellDevice({ indoorTemperature: 33, operationStatus: { equipmentStatus: "Fault" } }), RAW
+      );
+      expect(reading!.eventType).toEqual({ LowTemperature: null });
+    });
+  });
+
+  describe("humidity", () => {
+    it("returns HighHumidity when humidity exceeds 70 % with normal temperature", () => {
+      const reading = handleHoneywellHomeEvent(
+        honeywellDevice({ indoorTemperature: 72, indoorHumidity: 75 }), RAW
+      );
+      expect(reading!.eventType).toEqual({ HighHumidity: null });
+      expect(reading!.value).toBe(75);
+      expect(reading!.unit).toBe("%RH");
+    });
+
+    it("returns null when humidity is exactly 70 % (exclusive boundary)", () => {
+      expect(handleHoneywellHomeEvent(
+        honeywellDevice({ indoorTemperature: 72, indoorHumidity: 70 }), RAW
+      )).toBeNull();
+    });
+
+    it("temperature alert takes priority over high humidity", () => {
+      // High temperature should win even when humidity is also high
+      const reading = handleHoneywellHomeEvent(
+        honeywellDevice({ indoorTemperature: 96, indoorHumidity: 80 }), RAW
+      );
+      expect(reading!.eventType).toEqual({ HighTemperature: null });
+    });
   });
 });

--- a/agents/iot-gateway/__tests__/pollers/honeywellHome.test.ts
+++ b/agents/iot-gateway/__tests__/pollers/honeywellHome.test.ts
@@ -1,0 +1,498 @@
+import fs from "fs";
+import {
+  loadTokenState,
+  persistTokenState,
+  refreshTokens,
+  ensureFreshToken,
+  pollOnce,
+  startHoneywellPoller,
+} from "../../pollers/honeywellHome";
+import type { TokenState } from "../../pollers/honeywellHome";
+
+// ── Module mocks ──────────────────────────────────────────────────────────────
+
+jest.mock("fs");
+jest.mock("../../icp", () => ({
+  recordSensorEvent: jest.fn(),
+}));
+
+import { recordSensorEvent } from "../../icp";
+
+const mockFs                = jest.mocked(fs);
+const mockRecordSensorEvent = recordSensorEvent as jest.Mock;
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeTokenState(overrides: Partial<TokenState> = {}): TokenState {
+  return {
+    accessToken:  "hw-access-abc",
+    refreshToken: "hw-refresh-xyz",
+    expiresAt:    Date.now() + 10 * 60 * 1000, // 10 min from now
+    ...overrides,
+  };
+}
+
+function mockFetchOk(body: unknown): void {
+  global.fetch = jest.fn().mockResolvedValue({
+    ok:   true,
+    json: jest.fn().mockResolvedValue(body),
+    text: jest.fn().mockResolvedValue(""),
+  } as unknown as Response);
+}
+
+function mockFetchFail(status: number, body = "error"): void {
+  global.fetch = jest.fn().mockResolvedValue({
+    ok:     false,
+    status,
+    text:   jest.fn().mockResolvedValue(body),
+    json:   jest.fn().mockResolvedValue({}),
+  } as unknown as Response);
+}
+
+// Sequences multiple fetch responses (locations + thermostats + WLD).
+function mockFetchSequence(responses: Array<{ ok: boolean; status?: number; body: unknown }>): void {
+  let call = 0;
+  global.fetch = jest.fn().mockImplementation(() => {
+    const r = responses[call] ?? responses[responses.length - 1];
+    call++;
+    return Promise.resolve({
+      ok:     r.ok,
+      status: r.status ?? 200,
+      json:   jest.fn().mockResolvedValue(r.body),
+      text:   jest.fn().mockResolvedValue(typeof r.body === "string" ? r.body : "error"),
+    } as unknown as Response);
+  });
+}
+
+const COLD_THERMOSTAT = {
+  deviceID:              "LCC-COLD",
+  userDefinedDeviceName: "Basement",
+  // 33 °F → 0.6 °C ≤ 4 °C threshold
+  indoorTemperature:     33,
+  indoorHumidity:        45,
+  operationStatus:       { equipmentStatus: "Heating" },
+};
+
+const NORMAL_THERMOSTAT = {
+  deviceID:              "LCC-NORMAL",
+  userDefinedDeviceName: "Living Room",
+  // 72 °F → 22.2 °C — normal range
+  indoorTemperature:     72,
+  indoorHumidity:        50,
+  operationStatus:       { equipmentStatus: "Heating" },
+};
+
+const LEAKING_WLD = {
+  deviceID:              "WLD-001",
+  userDefinedDeviceName: "Basement Sensor",
+  isWaterPresent:        true,
+};
+
+// ── loadTokenState ────────────────────────────────────────────────────────────
+
+describe("loadTokenState", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    delete process.env.HONEYWELL_ACCESS_TOKEN;
+    delete process.env.HONEYWELL_REFRESH_TOKEN;
+  });
+
+  it("returns parsed state from the token file when it exists and is valid", () => {
+    const stored: TokenState = {
+      accessToken:  "file-access",
+      refreshToken: "file-refresh",
+      expiresAt:    Date.now() + 600_000,
+    };
+    mockFs.existsSync.mockReturnValue(true);
+    mockFs.readFileSync.mockReturnValue(JSON.stringify(stored));
+
+    const state = loadTokenState();
+    expect(state).toEqual(stored);
+  });
+
+  it("falls back to env vars when the token file does not exist", () => {
+    mockFs.existsSync.mockReturnValue(false);
+    process.env.HONEYWELL_ACCESS_TOKEN  = "env-access";
+    process.env.HONEYWELL_REFRESH_TOKEN = "env-refresh";
+
+    const state = loadTokenState();
+    expect(state!.accessToken).toBe("env-access");
+    expect(state!.refreshToken).toBe("env-refresh");
+    expect(state!.expiresAt).toBeGreaterThan(Date.now());
+  });
+
+  it("falls back to env vars when the token file contains corrupted JSON", () => {
+    mockFs.existsSync.mockReturnValue(true);
+    mockFs.readFileSync.mockReturnValue("not-valid-json{{{");
+    process.env.HONEYWELL_ACCESS_TOKEN  = "env-access";
+    process.env.HONEYWELL_REFRESH_TOKEN = "env-refresh";
+
+    const state = loadTokenState();
+    expect(state!.accessToken).toBe("env-access");
+  });
+
+  it("falls back to env vars when the token file has missing fields", () => {
+    mockFs.existsSync.mockReturnValue(true);
+    mockFs.readFileSync.mockReturnValue(JSON.stringify({ accessToken: "only-one-field" }));
+    process.env.HONEYWELL_ACCESS_TOKEN  = "env-access";
+    process.env.HONEYWELL_REFRESH_TOKEN = "env-refresh";
+
+    const state = loadTokenState();
+    expect(state!.accessToken).toBe("env-access");
+  });
+
+  it("returns null when the file is absent and env vars are not set", () => {
+    mockFs.existsSync.mockReturnValue(false);
+    expect(loadTokenState()).toBeNull();
+  });
+});
+
+// ── persistTokenState ─────────────────────────────────────────────────────────
+
+describe("persistTokenState", () => {
+  beforeEach(() => jest.resetAllMocks());
+
+  it("writes the state as formatted JSON to the token file", () => {
+    const state = makeTokenState();
+    mockFs.writeFileSync.mockImplementation(() => {});
+
+    persistTokenState(state);
+
+    expect(mockFs.writeFileSync).toHaveBeenCalledWith(
+      expect.any(String),
+      JSON.stringify(state, null, 2),
+      "utf8"
+    );
+  });
+
+  it("updates process.env with the new tokens", () => {
+    const state = makeTokenState({ accessToken: "new-access", refreshToken: "new-refresh" });
+    mockFs.writeFileSync.mockImplementation(() => {});
+
+    persistTokenState(state);
+
+    expect(process.env.HONEYWELL_ACCESS_TOKEN).toBe("new-access");
+    expect(process.env.HONEYWELL_REFRESH_TOKEN).toBe("new-refresh");
+  });
+
+  it("does not throw when writeFileSync fails — logs a warning instead", () => {
+    mockFs.writeFileSync.mockImplementation(() => { throw new Error("disk full"); });
+    expect(() => persistTokenState(makeTokenState())).not.toThrow();
+  });
+});
+
+// ── refreshTokens ─────────────────────────────────────────────────────────────
+
+describe("refreshTokens", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    process.env.HONEYWELL_CLIENT_ID     = "test-client-id";
+    process.env.HONEYWELL_CLIENT_SECRET = "test-client-secret";
+    mockFs.writeFileSync.mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    delete process.env.HONEYWELL_CLIENT_ID;
+    delete process.env.HONEYWELL_CLIENT_SECRET;
+  });
+
+  it("throws when HONEYWELL_CLIENT_ID is not set", async () => {
+    delete process.env.HONEYWELL_CLIENT_ID;
+    await expect(refreshTokens(makeTokenState())).rejects.toThrow("HONEYWELL_CLIENT_ID");
+  });
+
+  it("throws when HONEYWELL_CLIENT_SECRET is not set", async () => {
+    delete process.env.HONEYWELL_CLIENT_SECRET;
+    await expect(refreshTokens(makeTokenState())).rejects.toThrow("HONEYWELL_CLIENT_SECRET");
+  });
+
+  it("POSTs to the Honeywell token endpoint with Basic auth and form body", async () => {
+    mockFetchOk({
+      access_token:  "new-access",
+      refresh_token: "new-refresh",
+      expires_in:    600,
+    });
+
+    await refreshTokens(makeTokenState({ refreshToken: "old-refresh" }));
+
+    const [url, init] = (global.fetch as jest.Mock).mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://api.honeywell.com/oauth2/token");
+    expect(init.method).toBe("POST");
+
+    const authHeader = (init.headers as Record<string, string>)["Authorization"];
+    expect(authHeader).toMatch(/^Basic /);
+
+    const decoded = Buffer.from(authHeader.slice(6), "base64").toString();
+    expect(decoded).toBe("test-client-id:test-client-secret");
+
+    expect(init.body).toContain("grant_type=refresh_token");
+    expect(init.body).toContain("refresh_token=old-refresh");
+  });
+
+  it("returns a new TokenState with updated tokens and a future expiresAt", async () => {
+    mockFetchOk({
+      access_token:  "refreshed-access",
+      refresh_token: "refreshed-refresh",
+      expires_in:    600,
+    });
+
+    const before    = Date.now();
+    const newState  = await refreshTokens(makeTokenState());
+    expect(newState.accessToken).toBe("refreshed-access");
+    expect(newState.refreshToken).toBe("refreshed-refresh");
+    expect(newState.expiresAt).toBeGreaterThan(before + 500_000);
+  });
+
+  it("persists the new tokens (writes to file and updates process.env)", async () => {
+    mockFetchOk({
+      access_token:  "refreshed-access",
+      refresh_token: "refreshed-refresh",
+      expires_in:    600,
+    });
+
+    await refreshTokens(makeTokenState());
+
+    expect(mockFs.writeFileSync).toHaveBeenCalledTimes(1);
+    expect(process.env.HONEYWELL_ACCESS_TOKEN).toBe("refreshed-access");
+  });
+
+  it("throws with a descriptive message when the Honeywell API returns an error", async () => {
+    mockFetchFail(401, "Unauthorized");
+    await expect(refreshTokens(makeTokenState())).rejects.toThrow("401");
+  });
+});
+
+// ── ensureFreshToken ──────────────────────────────────────────────────────────
+
+describe("ensureFreshToken", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    process.env.HONEYWELL_CLIENT_ID     = "test-client-id";
+    process.env.HONEYWELL_CLIENT_SECRET = "test-client-secret";
+    mockFs.writeFileSync.mockImplementation(() => {});
+  });
+
+  it("returns the same state object when the token is not close to expiry", async () => {
+    const state = makeTokenState({ expiresAt: Date.now() + 10 * 60 * 1000 });
+    const result = await ensureFreshToken(state);
+    expect(result).toBe(state); // same reference — no refresh occurred
+  });
+
+  it("calls refreshTokens when the token expires within the 1-minute buffer", async () => {
+    mockFetchOk({
+      access_token:  "refreshed",
+      refresh_token: "refreshed-rt",
+      expires_in:    600,
+    });
+
+    const expiringSoon = makeTokenState({ expiresAt: Date.now() + 30 * 1000 }); // 30 s away
+    const result = await ensureFreshToken(expiringSoon);
+
+    expect(result.accessToken).toBe("refreshed");
+    expect(global.fetch).toHaveBeenCalled();
+  });
+
+  it("calls refreshTokens when the token is already expired", async () => {
+    mockFetchOk({
+      access_token:  "refreshed",
+      refresh_token: "refreshed-rt",
+      expires_in:    600,
+    });
+
+    const expired = makeTokenState({ expiresAt: Date.now() - 1000 });
+    const result  = await ensureFreshToken(expired);
+    expect(result.accessToken).toBe("refreshed");
+  });
+});
+
+// ── pollOnce ──────────────────────────────────────────────────────────────────
+
+describe("pollOnce", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    process.env.HONEYWELL_CLIENT_ID  = "test-client-id";
+    process.env.HONEYWELL_LOCATION_ID = "loc-123"; // skip locations call
+    mockRecordSensorEvent.mockResolvedValue({ success: true, eventId: "evt-1" });
+  });
+
+  afterEach(() => {
+    delete process.env.HONEYWELL_CLIENT_ID;
+    delete process.env.HONEYWELL_LOCATION_ID;
+  });
+
+  it("skips poll and logs an error when HONEYWELL_CLIENT_ID is not set", async () => {
+    delete process.env.HONEYWELL_CLIENT_ID;
+    global.fetch = jest.fn();
+    await pollOnce(makeTokenState());
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("uses HONEYWELL_LOCATION_ID to skip the locations discovery call", async () => {
+    // With HONEYWELL_LOCATION_ID set, only 2 calls: thermostats + WLD
+    mockFetchSequence([
+      { ok: true,  body: [NORMAL_THERMOSTAT] }, // thermostats
+      { ok: false, status: 404, body: [] },     // WLD — 404 = no WLD devices
+    ]);
+
+    await pollOnce(makeTokenState({ accessToken: "my-token" }));
+
+    expect((global.fetch as jest.Mock).mock.calls).toHaveLength(2);
+    const [thermoUrl] = (global.fetch as jest.Mock).mock.calls[0] as [string];
+    expect(thermoUrl).toContain("/v2/devices/thermostats");
+    expect(thermoUrl).toContain("loc-123");
+  });
+
+  it("calls GET /v2/locations when HONEYWELL_LOCATION_ID is not set", async () => {
+    delete process.env.HONEYWELL_LOCATION_ID;
+    mockFetchSequence([
+      { ok: true, body: [{ locationID: "loc-abc", name: "Home" }] }, // locations
+      { ok: true, body: [NORMAL_THERMOSTAT] },                        // thermostats
+      { ok: false, status: 404, body: [] },                           // WLD
+    ]);
+
+    await pollOnce(makeTokenState());
+
+    const calls = (global.fetch as jest.Mock).mock.calls as [string][];
+    expect(calls[0][0]).toContain("/v2/locations");
+    expect(calls[1][0]).toContain("/v2/devices/thermostats");
+    expect(calls[1][0]).toContain("loc-abc");
+  });
+
+  it("sends the Bearer access token in the Authorization header", async () => {
+    mockFetchSequence([
+      { ok: true, body: [NORMAL_THERMOSTAT] },
+      { ok: false, status: 404, body: [] },
+    ]);
+
+    await pollOnce(makeTokenState({ accessToken: "my-hw-token" }));
+
+    const [, init] = (global.fetch as jest.Mock).mock.calls[0] as [string, RequestInit];
+    expect((init.headers as Record<string, string>)["Authorization"]).toBe("Bearer my-hw-token");
+  });
+
+  it("calls recordSensorEvent when a thermostat is below the freeze threshold", async () => {
+    mockFetchSequence([
+      { ok: true,  body: [COLD_THERMOSTAT] },
+      { ok: false, status: 404, body: [] },
+    ]);
+
+    await pollOnce(makeTokenState());
+
+    expect(mockRecordSensorEvent).toHaveBeenCalledTimes(1);
+    const reading = mockRecordSensorEvent.mock.calls[0][0];
+    expect(reading.eventType).toEqual({ LowTemperature: null });
+    expect(reading.externalDeviceId).toBe("LCC-COLD");
+  });
+
+  it("does not call recordSensorEvent when thermostat reading is not actionable", async () => {
+    mockFetchSequence([
+      { ok: true,  body: [NORMAL_THERMOSTAT] },
+      { ok: false, status: 404, body: [] },
+    ]);
+
+    await pollOnce(makeTokenState());
+    expect(mockRecordSensorEvent).not.toHaveBeenCalled();
+  });
+
+  it("calls recordSensorEvent for a leaking WLD", async () => {
+    mockFetchSequence([
+      { ok: true, body: [] },           // thermostats — empty
+      { ok: true, body: [LEAKING_WLD] }, // WLD
+    ]);
+
+    await pollOnce(makeTokenState());
+
+    expect(mockRecordSensorEvent).toHaveBeenCalledTimes(1);
+    const reading = mockRecordSensorEvent.mock.calls[0][0];
+    expect(reading.eventType).toEqual({ WaterLeak: null });
+    expect(reading.externalDeviceId).toBe("WLD-001");
+  });
+
+  it("suppresses WLD 404 silently (location has no WLD devices)", async () => {
+    mockFetchSequence([
+      { ok: true,  body: [NORMAL_THERMOSTAT] },
+      { ok: false, status: 404, body: "Not Found" },
+    ]);
+
+    await expect(pollOnce(makeTokenState())).resolves.toBeUndefined();
+    expect(mockRecordSensorEvent).not.toHaveBeenCalled();
+  });
+
+  it("logs error and continues when thermostats fetch fails", async () => {
+    mockFetchSequence([
+      { ok: false, status: 429, body: "rate limited" }, // thermostats fail
+      { ok: false, status: 404, body: [] },             // WLD
+    ]);
+
+    await expect(pollOnce(makeTokenState())).resolves.toBeUndefined();
+    expect(mockRecordSensorEvent).not.toHaveBeenCalled();
+  });
+
+  it("logs error and continues when locations fetch fails", async () => {
+    delete process.env.HONEYWELL_LOCATION_ID;
+    mockFetchFail(500, "server error");
+
+    await expect(pollOnce(makeTokenState())).resolves.toBeUndefined();
+    expect(mockRecordSensorEvent).not.toHaveBeenCalled();
+  });
+
+  it("logs canister error but does not throw when recordSensorEvent fails", async () => {
+    mockFetchSequence([
+      { ok: true,  body: [COLD_THERMOSTAT] },
+      { ok: false, status: 404, body: [] },
+    ]);
+    mockRecordSensorEvent.mockResolvedValue({ success: false, error: "Unauthorized" });
+
+    await expect(pollOnce(makeTokenState())).resolves.toBeUndefined();
+  });
+});
+
+// ── startHoneywellPoller ──────────────────────────────────────────────────────
+
+describe("startHoneywellPoller", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    delete process.env.HONEYWELL_ACCESS_TOKEN;
+    delete process.env.HONEYWELL_REFRESH_TOKEN;
+  });
+
+  it("returns a no-op stop function when tokens are absent", () => {
+    mockFs.existsSync.mockReturnValue(false);
+    const stop = startHoneywellPoller();
+    expect(typeof stop).toBe("function");
+    expect(() => stop()).not.toThrow();
+  });
+
+  it("the no-op stop function is idempotent — calling it twice does not throw", () => {
+    mockFs.existsSync.mockReturnValue(false);
+    const stop = startHoneywellPoller();
+    expect(() => { stop(); stop(); }).not.toThrow();
+  });
+
+  it("starts polling when valid tokens are available and returns a stop function", async () => {
+    mockFs.existsSync.mockReturnValue(false);
+    process.env.HONEYWELL_ACCESS_TOKEN  = "valid-access";
+    process.env.HONEYWELL_REFRESH_TOKEN = "valid-refresh";
+    process.env.HONEYWELL_CLIENT_ID     = "test-client-id";
+    process.env.HONEYWELL_LOCATION_ID   = "loc-123";
+
+    mockFetchSequence([
+      { ok: true,  body: [] },           // thermostats
+      { ok: false, status: 404, body: [] }, // WLD
+    ]);
+
+    jest.useFakeTimers();
+
+    const stop = startHoneywellPoller(60_000);
+    expect(typeof stop).toBe("function");
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    stop();
+    jest.useRealTimers();
+
+    delete process.env.HONEYWELL_CLIENT_ID;
+    delete process.env.HONEYWELL_LOCATION_ID;
+  });
+});

--- a/agents/iot-gateway/handlers.ts
+++ b/agents/iot-gateway/handlers.ts
@@ -11,6 +11,7 @@ import type {
   NestWebhookEvent,
   EcobeeWebhookEvent,
   MoenFloWebhookEvent,
+  HoneywellDevice,
 } from "./types";
 
 // ── Nest ─────────────────────────────────────────────────────────────────────
@@ -176,6 +177,76 @@ export function handleEcobeeEvent(
         rawPayload: raw,
       };
     }
+  }
+
+  return null;
+}
+
+// ── Honeywell Home / Resideo ─────────────────────────────────────────────────
+
+export function handleHoneywellHomeEvent(
+  device: HoneywellDevice,
+  raw: string
+): SensorReading | null {
+  if (!device.deviceID) return null;
+
+  const externalDeviceId = device.deviceID;
+
+  // WLD — highest priority; a water presence report is always actionable.
+  if (device.waterPresent === true) {
+    return {
+      externalDeviceId,
+      eventType: { WaterLeak: null } as SensorEventType,
+      value: 0,
+      unit: "",
+      rawPayload: raw,
+    };
+  }
+
+  // Temperature checks (Honeywell reports °F directly, not 10ths).
+  if (device.indoorTemperature !== undefined) {
+    const celsius = fahrenheitToCelsius(device.indoorTemperature);
+    if (celsius <= PIPE_FREEZE_THRESHOLD_C) {
+      return {
+        externalDeviceId,
+        eventType: { LowTemperature: null } as SensorEventType,
+        value: celsius,
+        unit: "°C",
+        rawPayload: raw,
+      };
+    }
+    if (celsius > HIGH_TEMP_THRESHOLD_C) {
+      return {
+        externalDeviceId,
+        eventType: { HighTemperature: null } as SensorEventType,
+        value: celsius,
+        unit: "°C",
+        rawPayload: raw,
+      };
+    }
+  }
+
+  // HVAC fault — "Fault" is a hard error; "Off" means the system is completely disabled.
+  const equipStatus = device.operationStatus?.equipmentStatus;
+  if (equipStatus === "Fault" || equipStatus === "Off") {
+    return {
+      externalDeviceId,
+      eventType: { HvacAlert: null } as SensorEventType,
+      value: 0,
+      unit: "",
+      rawPayload: raw,
+    };
+  }
+
+  // High humidity (only checked when temperature is in normal range).
+  if (device.indoorHumidity !== undefined && device.indoorHumidity > HIGH_HUMIDITY_THRESHOLD) {
+    return {
+      externalDeviceId,
+      eventType: { HighHumidity: null } as SensorEventType,
+      value: device.indoorHumidity,
+      unit: "%RH",
+      rawPayload: raw,
+    };
   }
 
   return null;

--- a/agents/iot-gateway/pollers/honeywellHome.ts
+++ b/agents/iot-gateway/pollers/honeywellHome.ts
@@ -1,0 +1,310 @@
+/**
+ * Honeywell Home / Resideo REST polling script.
+ *
+ * Honeywell uses OAuth 2.0 Authorization Code flow. Access tokens expire in
+ * 10 minutes — the poller proactively refreshes 1 minute before expiry.
+ * Refreshed tokens are persisted to HONEYWELL_TOKENS_FILE so they survive
+ * process restarts (default: .honeywell-tokens.json in the working directory).
+ *
+ * Poll interval: 3 minutes (well within Honeywell's rate limits).
+ * Each poll discovers all locations (unless HONEYWELL_LOCATION_ID is set),
+ * then fetches thermostats and water leak detectors for each location.
+ *
+ * Required env vars (see .env.example):
+ *   HONEYWELL_CLIENT_ID      — from developer.honeywellhome.com
+ *   HONEYWELL_CLIENT_SECRET  — from developer.honeywellhome.com
+ *   HONEYWELL_ACCESS_TOKEN   — obtained via OAuth flow (see README)
+ *   HONEYWELL_REFRESH_TOKEN  — obtained via OAuth flow
+ *   HONEYWELL_LOCATION_ID    — optional; restricts polling to a single location
+ */
+
+import fs from "fs";
+import path from "path";
+import { handleHoneywellHomeEvent } from "../handlers";
+import { recordSensorEvent } from "../icp";
+import type { HoneywellDevice } from "../types";
+
+const HONEYWELL_API     = "https://api.honeywell.com";
+const REFRESH_BUFFER_MS = 60 * 1000; // refresh 1 min before expiry (10-min token)
+
+const TOKENS_FILE = process.env.HONEYWELL_TOKENS_FILE
+  ?? path.resolve(process.cwd(), ".honeywell-tokens.json");
+
+// ── Token state ───────────────────────────────────────────────────────────────
+
+export interface TokenState {
+  accessToken:  string;
+  refreshToken: string;
+  expiresAt:    number; // ms epoch
+}
+
+export function loadTokenState(): TokenState | null {
+  if (fs.existsSync(TOKENS_FILE)) {
+    try {
+      const parsed = JSON.parse(fs.readFileSync(TOKENS_FILE, "utf8")) as TokenState;
+      if (parsed.accessToken && parsed.refreshToken && parsed.expiresAt) {
+        return parsed;
+      }
+    } catch {
+      console.warn("[honeywell-poller] corrupted token file — falling back to env vars");
+    }
+  }
+
+  const accessToken  = process.env.HONEYWELL_ACCESS_TOKEN;
+  const refreshToken = process.env.HONEYWELL_REFRESH_TOKEN;
+  if (!accessToken || !refreshToken) return null;
+
+  return {
+    accessToken,
+    refreshToken,
+    expiresAt: Date.now() + 10 * 60 * 1000, // assume 10 min if unknown
+  };
+}
+
+export function persistTokenState(state: TokenState): void {
+  try {
+    fs.writeFileSync(TOKENS_FILE, JSON.stringify(state, null, 2), "utf8");
+  } catch (err) {
+    console.warn("[honeywell-poller] failed to persist tokens:", err);
+  }
+  process.env.HONEYWELL_ACCESS_TOKEN  = state.accessToken;
+  process.env.HONEYWELL_REFRESH_TOKEN = state.refreshToken;
+}
+
+export async function refreshTokens(state: TokenState): Promise<TokenState> {
+  const clientId     = process.env.HONEYWELL_CLIENT_ID;
+  const clientSecret = process.env.HONEYWELL_CLIENT_SECRET;
+  if (!clientId)     throw new Error("[honeywell-poller] HONEYWELL_CLIENT_ID is required for token refresh");
+  if (!clientSecret) throw new Error("[honeywell-poller] HONEYWELL_CLIENT_SECRET is required for token refresh");
+
+  // Honeywell token endpoint uses HTTP Basic auth (client_id:client_secret).
+  const credentials = Buffer.from(`${clientId}:${clientSecret}`).toString("base64");
+  const body = new URLSearchParams({
+    grant_type:    "refresh_token",
+    refresh_token: state.refreshToken,
+  });
+
+  const resp = await fetch(`${HONEYWELL_API}/oauth2/token`, {
+    method: "POST",
+    headers: {
+      "Content-Type":  "application/x-www-form-urlencoded",
+      "Authorization": `Basic ${credentials}`,
+    },
+    body: body.toString(),
+  });
+
+  if (!resp.ok) {
+    const text = await resp.text();
+    throw new Error(`[honeywell-poller] token refresh failed (${resp.status}): ${text}`);
+  }
+
+  const data = await resp.json() as {
+    access_token:  string;
+    refresh_token: string;
+    expires_in:    number; // seconds
+  };
+
+  const newState: TokenState = {
+    accessToken:  data.access_token,
+    refreshToken: data.refresh_token,
+    expiresAt:    Date.now() + data.expires_in * 1000,
+  };
+
+  persistTokenState(newState);
+  console.log(`[honeywell-poller] tokens refreshed — next expiry in ${Math.round(data.expires_in / 60)} min`);
+  return newState;
+}
+
+export async function ensureFreshToken(state: TokenState): Promise<TokenState> {
+  if (Date.now() < state.expiresAt - REFRESH_BUFFER_MS) return state;
+  return refreshTokens(state);
+}
+
+// ── Raw Honeywell API response shapes (fields we use) ────────────────────────
+
+interface HoneywellLocation {
+  locationID: string;
+  name:       string;
+}
+
+interface HoneywellThermostatApiDevice {
+  deviceID:              string;
+  userDefinedDeviceName: string;
+  indoorTemperature?:    number; // °F
+  indoorHumidity?:       number; // %
+  operationStatus?:      { equipmentStatus: string };
+}
+
+interface HoneywellWldApiDevice {
+  deviceID:              string;
+  userDefinedDeviceName: string;
+  isWaterPresent:        boolean;
+}
+
+// ── Poll ──────────────────────────────────────────────────────────────────────
+
+export async function pollOnce(state: TokenState): Promise<void> {
+  const clientId = process.env.HONEYWELL_CLIENT_ID;
+  if (!clientId) {
+    console.error("[honeywell-poller] HONEYWELL_CLIENT_ID not set — skipping poll");
+    return;
+  }
+
+  const fixedLocationId = process.env.HONEYWELL_LOCATION_ID;
+  let locationIds: string[];
+
+  if (fixedLocationId) {
+    locationIds = [fixedLocationId];
+  } else {
+    const locResp = await fetch(
+      `${HONEYWELL_API}/v2/locations?apikey=${encodeURIComponent(clientId)}`,
+      { headers: { Authorization: `Bearer ${state.accessToken}` } }
+    );
+    if (!locResp.ok) {
+      console.error(
+        `[honeywell-poller] locations fetch failed (${locResp.status}): ${await locResp.text()}`
+      );
+      return;
+    }
+    const locs = await locResp.json() as HoneywellLocation[];
+    locationIds = (locs ?? []).map(l => l.locationID);
+  }
+
+  for (const locId of locationIds) {
+    await pollThermostats(state, clientId, locId);
+    await pollWaterLeakDetectors(state, clientId, locId);
+  }
+}
+
+async function pollThermostats(
+  state:      TokenState,
+  clientId:   string,
+  locationId: string
+): Promise<void> {
+  const resp = await fetch(
+    `${HONEYWELL_API}/v2/devices/thermostats` +
+    `?apikey=${encodeURIComponent(clientId)}&locationId=${encodeURIComponent(locationId)}`,
+    { headers: { Authorization: `Bearer ${state.accessToken}` } }
+  );
+
+  if (!resp.ok) {
+    console.error(
+      `[honeywell-poller] thermostats fetch failed (${resp.status}) ` +
+      `for location ${locationId}: ${await resp.text()}`
+    );
+    return;
+  }
+
+  const devices = await resp.json() as HoneywellThermostatApiDevice[];
+  for (const d of devices ?? []) {
+    const device: HoneywellDevice = {
+      deviceID:              d.deviceID,
+      userDefinedDeviceName: d.userDefinedDeviceName,
+      deviceType:            "Thermostat",
+      indoorTemperature:     d.indoorTemperature,
+      indoorHumidity:        d.indoorHumidity,
+      operationStatus:       d.operationStatus,
+    };
+    await processDevice(device);
+  }
+}
+
+async function pollWaterLeakDetectors(
+  state:      TokenState,
+  clientId:   string,
+  locationId: string
+): Promise<void> {
+  const resp = await fetch(
+    `${HONEYWELL_API}/v2/devices/waterLeakDetectors` +
+    `?apikey=${encodeURIComponent(clientId)}&locationId=${encodeURIComponent(locationId)}`,
+    { headers: { Authorization: `Bearer ${state.accessToken}` } }
+  );
+
+  if (!resp.ok) {
+    // 404 is expected when the location has no WLD devices — suppress to keep logs clean.
+    if (resp.status !== 404) {
+      console.error(
+        `[honeywell-poller] WLD fetch failed (${resp.status}) ` +
+        `for location ${locationId}: ${await resp.text()}`
+      );
+    }
+    return;
+  }
+
+  const devices = await resp.json() as HoneywellWldApiDevice[];
+  for (const d of devices ?? []) {
+    const device: HoneywellDevice = {
+      deviceID:              d.deviceID,
+      userDefinedDeviceName: d.userDefinedDeviceName,
+      deviceType:            "Water Leak Detector",
+      waterPresent:          d.isWaterPresent,
+    };
+    await processDevice(device);
+  }
+}
+
+async function processDevice(device: HoneywellDevice): Promise<void> {
+  const raw     = JSON.stringify(device);
+  const reading = handleHoneywellHomeEvent(device, raw);
+  if (!reading) return;
+
+  const eventName = Object.keys(reading.eventType)[0];
+  console.log(
+    `[honeywell-poller] ${eventName} device=${device.deviceID} (${device.userDefinedDeviceName})`
+  );
+
+  const result = await recordSensorEvent(reading);
+  if (result.success) {
+    console.log(
+      `[honeywell-poller] recorded eventId=${result.eventId}` +
+      (result.jobId ? ` jobId=${result.jobId}` : "")
+    );
+  } else {
+    console.error(`[honeywell-poller] canister error: ${result.error}`);
+  }
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/**
+ * Starts the Honeywell Home polling loop. Returns a stop function.
+ *
+ * No-ops (returns immediately) when tokens are absent — safe to call
+ * unconditionally at gateway startup.
+ */
+export function startHoneywellPoller(intervalMs = 3 * 60 * 1000): () => void {
+  const initial = loadTokenState();
+  if (!initial) {
+    console.warn(
+      "[honeywell-poller] HONEYWELL_ACCESS_TOKEN or HONEYWELL_REFRESH_TOKEN not set — poller disabled"
+    );
+    return () => {};
+  }
+
+  let currentState = initial;
+  let stopped      = false;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+
+  async function tick(): Promise<void> {
+    if (stopped) return;
+    try {
+      currentState = await ensureFreshToken(currentState);
+      await pollOnce(currentState);
+    } catch (err) {
+      console.error("[honeywell-poller] tick error:", err);
+    } finally {
+      if (!stopped) {
+        timer = setTimeout(tick, intervalMs);
+      }
+    }
+  }
+
+  console.log(`[honeywell-poller] starting — interval=${intervalMs / 1000}s`);
+  tick();
+
+  return () => {
+    stopped = true;
+    if (timer) clearTimeout(timer);
+    console.log("[honeywell-poller] stopped");
+  };
+}

--- a/agents/iot-gateway/server.ts
+++ b/agents/iot-gateway/server.ts
@@ -5,9 +5,10 @@
  * forwards normalized sensor readings to the HomeGentic Sensor canister on ICP.
  *
  * Supported platforms:
- *   POST /webhooks/nest      — Google Nest (SDM API Pub/Sub push)
- *   POST /webhooks/ecobee    — Ecobee thermostat alerts
- *   POST /webhooks/moen-flo  — Moen Flo water-leak detection
+ *   POST /webhooks/nest          — Google Nest (SDM API Pub/Sub push)
+ *   POST /webhooks/ecobee        — Ecobee thermostat alerts
+ *   POST /webhooks/moen-flo      — Moen Flo water-leak detection
+ *   GET  /oauth/callback/honeywell — Honeywell Home OAuth 2.0 callback (initial setup)
  *
  * Webhook authenticity:
  *   - Nest:     Validates the Google-Cloud-Token header against NEST_WEBHOOK_SECRET
@@ -22,13 +23,15 @@ import crypto from "crypto";
 import express, { Request, Response, NextFunction } from "express";
 import cors from "cors";
 import rateLimit from "express-rate-limit";
-import { handleNestEvent, handleEcobeeEvent, handleMoenFloEvent } from "./handlers";
+import { handleNestEvent, handleEcobeeEvent, handleMoenFloEvent, handleHoneywellHomeEvent } from "./handlers";
 import { recordSensorEvent, getGatewayPrincipal } from "./icp";
 import { startEcobeePoller } from "./pollers/ecobee";
+import { startHoneywellPoller, persistTokenState as persistHoneywellTokens } from "./pollers/honeywellHome";
 import type {
   NestWebhookEvent,
   EcobeeWebhookEvent,
   MoenFloWebhookEvent,
+  HoneywellDevice,
 } from "./types";
 
 const app = express();
@@ -198,15 +201,80 @@ app.post("/webhooks/moen-flo", moenFloLimiter, async (req: Request, res: Respons
   }
 });
 
+// ── GET /oauth/callback/honeywell ─────────────────────────────────────────────
+// One-time setup endpoint: exchanges the OAuth authorization code for tokens
+// and persists them so the polling loop can start on the next gateway restart.
+app.get("/oauth/callback/honeywell", async (req: Request, res: Response): Promise<void> => {
+  const code = req.query.code as string | undefined;
+  if (!code) {
+    res.status(400).send("Missing code parameter");
+    return;
+  }
+
+  const clientId     = process.env.HONEYWELL_CLIENT_ID;
+  const clientSecret = process.env.HONEYWELL_CLIENT_SECRET;
+  if (!clientId || !clientSecret) {
+    res.status(500).send("HONEYWELL_CLIENT_ID and HONEYWELL_CLIENT_SECRET must be set in .env");
+    return;
+  }
+
+  const redirectUri = `http://localhost:${port}/oauth/callback/honeywell`;
+  const credentials = Buffer.from(`${clientId}:${clientSecret}`).toString("base64");
+  const body = new URLSearchParams({
+    grant_type:   "authorization_code",
+    code,
+    redirect_uri: redirectUri,
+  });
+
+  try {
+    const tokenResp = await fetch("https://api.honeywell.com/oauth2/token", {
+      method:  "POST",
+      headers: {
+        "Content-Type":  "application/x-www-form-urlencoded",
+        "Authorization": `Basic ${credentials}`,
+      },
+      body: body.toString(),
+    });
+
+    if (!tokenResp.ok) {
+      const text = await tokenResp.text();
+      res.status(502).send(`Honeywell token exchange failed (${tokenResp.status}): ${text}`);
+      return;
+    }
+
+    const data = await tokenResp.json() as {
+      access_token:  string;
+      refresh_token: string;
+      expires_in:    number;
+    };
+
+    persistHoneywellTokens({
+      accessToken:  data.access_token,
+      refreshToken: data.refresh_token,
+      expiresAt:    Date.now() + data.expires_in * 1000,
+    });
+
+    console.log("[honeywell] OAuth callback — tokens saved. Restart gateway to start polling.");
+    res.send(
+      "<h2>Honeywell Home connected!</h2>" +
+      "<p>Tokens saved. Restart the IoT gateway to begin polling.</p>"
+    );
+  } catch (err) {
+    console.error("[honeywell] OAuth callback error:", err);
+    res.status(500).send("Internal error during token exchange");
+  }
+});
+
 // ── GET /health ───────────────────────────────────────────────────────────────
 app.get("/health", (_req: Request, res: Response) => {
   res.json({
     ok: true,
     gatewayPrincipal: getGatewayPrincipal(),
     sensorCanisterId: process.env.SENSOR_CANISTER_ID ?? "(not set)",
-    platforms: ["nest", "ecobee", "moen-flo"],
+    platforms: ["nest", "ecobee", "moen-flo", "honeywell-home"],
     pollers: {
-      ecobee: !!process.env.ECOBEE_CLIENT_ID,
+      ecobee:    !!process.env.ECOBEE_CLIENT_ID,
+      honeywell: !!process.env.HONEYWELL_CLIENT_ID,
     },
   });
 });
@@ -220,5 +288,8 @@ app.listen(port, () => {
   // Start polling integrations — each is a no-op when env vars are absent.
   if (process.env.ECOBEE_CLIENT_ID) {
     startEcobeePoller();
+  }
+  if (process.env.HONEYWELL_CLIENT_ID) {
+    startHoneywellPoller();
   }
 });

--- a/agents/iot-gateway/types.ts
+++ b/agents/iot-gateway/types.ts
@@ -86,6 +86,25 @@ export interface EcobeeWebhookEvent {
   };
 }
 
+// ── Honeywell Home / Resideo ─────────────────────────────────────────────────
+
+/** Normalized device shape shared between Honeywell thermostats and WLD units. */
+export interface HoneywellDevice {
+  deviceID: string;
+  userDefinedDeviceName: string;
+  deviceType: string; // "Thermostat" | "Water Leak Detector"
+  /** Indoor temperature in °F (thermostats only) */
+  indoorTemperature?: number;
+  /** Indoor relative humidity % (thermostats only) */
+  indoorHumidity?: number;
+  operationStatus?: {
+    /** "Heating" | "Cooling" | "Off" | "Fan Only" | "Fault" */
+    equipmentStatus: string;
+  };
+  /** True when a Water Leak Detector reports water presence */
+  waterPresent?: boolean;
+}
+
 // ── Moen Flo ─────────────────────────────────────────────────────────────────
 export type MoenFloAlertType =
   | "LEAK"


### PR DESCRIPTION
## Summary

- Adds `pollers/honeywellHome.ts` — OAuth 2.0 token management (10-min expiry, 1-min refresh buffer, Basic auth for token endpoint), location discovery, thermostat polling, and Water Leak Detector polling per location
- Adds `handleHoneywellHomeEvent` to `handlers.ts` — maps `LowTemperature`, `HighTemperature`, `HvacAlert` (Fault/Off), `HighHumidity`, and `WaterLeak` (WLD) from Honeywell device objects
- Adds `HoneywellDevice` type to `types.ts`
- Wires `startHoneywellPoller()` in `server.ts` when `HONEYWELL_CLIENT_ID` is set; adds `GET /oauth/callback/honeywell` for one-time initial auth setup
- Updates health endpoint to include `pollers.honeywell` status
- Adds Honeywell env vars to `.env.example` and OAuth walkthrough to `README.md`
- **49 new tests** across handler and poller — 117 total, 0 failing

## Test plan

- [x] `npm test` in `agents/iot-gateway` — 117 passed, 0 failed
- [ ] Manual: set `HONEYWELL_CLIENT_ID` + `HONEYWELL_CLIENT_SECRET`, visit OAuth authorize URL, confirm callback saves tokens and gateway picks them up on restart
- [ ] Manual: confirm WLD 404 is suppressed silently when location has no WLD devices

Closes #263

🤖 Generated with [Claude Code](https://claude.com/claude-code)