### PR TITLE
feat(iot-gateway): SmartThings webhook integration (#268)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -82,6 +82,13 @@ ECOBEE_THERMOSTAT_ID=
 # Optional — path to the token persistence file (default: .ecobee-tokens.json in cwd).
 ECOBEE_TOKENS_FILE=
 
+# SmartThings webhook (POST /webhooks/smartthings)
+# Personal Access Token: https://account.smartthings.com/tokens (scope: r:devices:*)
+# Webhook secret: set in your SmartThings Developer Workspace → Webhook → Signing Key.
+SMARTTHINGS_ACCESS_TOKEN=
+SMARTTHINGS_APP_ID=
+SMARTTHINGS_WEBHOOK_SECRET=
+
 # Honeywell Home / Resideo polling (OAuth 2.0 Authorization Code flow)
 # Register at developer.honeywellhome.com → see agents/iot-gateway/README.md for setup.
 HONEYWELL_CLIENT_ID=

--- a/agents/iot-gateway/README.md
+++ b/agents/iot-gateway/README.md
@@ -11,6 +11,7 @@ normalized sensor readings to the HomeGentic Sensor canister on ICP.
 | Ecobee | REST polling (3 min) | `ECOBEE_CLIENT_ID` + tokens |
 | Moen Flo | Push webhook | `MOEN_FLO_WEBHOOK_SECRET` |
 | Honeywell Home / Resideo | REST polling (3 min) | `HONEYWELL_CLIENT_ID` + tokens |
+| SmartThings | Push webhook | `SMARTTHINGS_WEBHOOK_SECRET` |
 
 ## Running
 
@@ -106,6 +107,60 @@ sensorService.registerDevice(propertyId, "411848373746", "Ecobee", "Living Room 
 The `externalDeviceId` passed here must match the identifier returned by the Ecobee API.
 
 ---
+
+---
+
+## SmartThings — Webhook SmartApp setup
+
+SmartThings is the highest-leverage integration: a single hub can represent
+dozens of Z-Wave, Zigbee, and Wi-Fi sensors. The gateway receives push events
+for every capability state change — no polling required.
+
+### Prerequisites
+
+1. Sign up at [developer.smartthings.com](https://developer.smartthings.com)
+2. Create a Project → **Automation for the SmartThings App** → **Webhook**
+3. Set the **Target URL** to `https://YOUR_GATEWAY_DOMAIN/webhooks/smartthings`
+4. Copy the **Signing Key** → set as `SMARTTHINGS_WEBHOOK_SECRET` in `.env`
+
+### Step 1 — confirm the webhook endpoint
+
+When you save the Target URL, SmartThings immediately POSTs a `CONFIRMATION` lifecycle
+event. The gateway automatically GETs the `confirmationUrl` in that payload to confirm
+ownership. You should see `[smartthings] webhook confirmed` in the gateway logs.
+
+### Step 2 — subscribe to device capabilities
+
+Install the SmartApp in the **SmartThings mobile app** (Automations → + → Your SmartApps).
+Select which devices to share. The app will subscribe to all supported capabilities
+(`temperatureMeasurement`, `relativeHumidityMeasurement`, `waterSensor`, `filterStatus`,
+`thermostatOperatingState`) on the selected devices.
+
+### Step 3 — find device IDs
+
+```bash
+# Personal Access Token (PAT): https://account.smartthings.com/tokens (scope: r:devices:*)
+curl https://api.smartthings.com/v1/devices \
+  -H "Authorization: Bearer $SMARTTHINGS_ACCESS_TOKEN" \
+  | jq '.items[] | {deviceId, label, type: .deviceTypeName}'
+```
+
+Use the `deviceId` UUID as `externalDeviceId` when registering in HomeGentic:
+
+```ts
+sensorService.registerDevice(propertyId, "abc12345-6789-abcd-ef01-234567890abc", "SmartThings", "Kitchen Leak Sensor")
+```
+
+### Events ingested
+
+| Capability | Condition | Canister event | Severity |
+|---|---|---|---|
+| `temperatureMeasurement` | ≤ 4 °C (converts from °F if `unit === "F"`) | `LowTemperature` | Critical |
+| `temperatureMeasurement` | > 35 °C | `HighTemperature` | Warning |
+| `relativeHumidityMeasurement` | > 70 % | `HighHumidity` | Warning |
+| `waterSensor` | `value === "wet"` | `WaterLeak` | Critical |
+| `filterStatus` | `value === "replace"` | `HvacFilterDue` | Info |
+| `thermostatOperatingState` | `value === "fan only"` | `HvacAlert` | Warning |
 
 ---
 

--- a/agents/iot-gateway/__tests__/handlers.test.ts
+++ b/agents/iot-gateway/__tests__/handlers.test.ts
@@ -1,9 +1,10 @@
-import { handleNestEvent, handleEcobeeEvent, handleMoenFloEvent, handleHoneywellHomeEvent } from "../handlers";
+import { handleNestEvent, handleEcobeeEvent, handleMoenFloEvent, handleHoneywellHomeEvent, handleSmartThingsEvent } from "../handlers";
 import type {
   NestWebhookEvent,
   EcobeeWebhookEvent,
   MoenFloWebhookEvent,
   HoneywellDevice,
+  SmartThingsDeviceEvent,
 } from "../types";
 
 const RAW = "{}";
@@ -480,6 +481,139 @@ describe("handleHoneywellHomeEvent", () => {
         honeywellDevice({ indoorTemperature: 96, indoorHumidity: 80 }), RAW
       );
       expect(reading!.eventType).toEqual({ HighTemperature: null });
+    });
+  });
+});
+
+// ── handleSmartThingsEvent ────────────────────────────────────────────────────
+
+describe("handleSmartThingsEvent", () => {
+  function stEvent(overrides: Partial<SmartThingsDeviceEvent>): SmartThingsDeviceEvent {
+    return {
+      deviceId:   "abc12345-6789-abcd-ef01-234567890abc",
+      capability: "temperatureMeasurement",
+      attribute:  "temperature",
+      value:      22,
+      unit:       "C",
+      ...overrides,
+    };
+  }
+
+  describe("guard conditions", () => {
+    it("returns null when deviceId is absent", () => {
+      expect(handleSmartThingsEvent(stEvent({ deviceId: "" }), RAW)).toBeNull();
+    });
+
+    it("returns null for an unknown capability", () => {
+      expect(handleSmartThingsEvent(stEvent({ capability: "motionSensor", attribute: "motion", value: "active" }), RAW)).toBeNull();
+    });
+  });
+
+  describe("temperatureMeasurement", () => {
+    it("returns LowTemperature when Celsius value is below the freeze threshold", () => {
+      const reading = handleSmartThingsEvent(stEvent({ value: 2, unit: "C" }), RAW);
+      expect(reading!.eventType).toEqual({ LowTemperature: null });
+      expect(reading!.value).toBe(2);
+      expect(reading!.unit).toBe("°C");
+    });
+
+    it("returns LowTemperature at exactly 4 °C (inclusive boundary)", () => {
+      expect(handleSmartThingsEvent(stEvent({ value: 4, unit: "C" }), RAW)!.eventType)
+        .toEqual({ LowTemperature: null });
+    });
+
+    it("returns null when Celsius temperature is just above 4 °C", () => {
+      expect(handleSmartThingsEvent(stEvent({ value: 5, unit: "C" }), RAW)).toBeNull();
+    });
+
+    it("returns HighTemperature when Celsius value exceeds 35", () => {
+      const reading = handleSmartThingsEvent(stEvent({ value: 36, unit: "C" }), RAW);
+      expect(reading!.eventType).toEqual({ HighTemperature: null });
+      expect(reading!.value).toBe(36);
+    });
+
+    it("returns null when Celsius temperature is exactly 35 (exclusive upper boundary)", () => {
+      expect(handleSmartThingsEvent(stEvent({ value: 35, unit: "C" }), RAW)).toBeNull();
+    });
+
+    it("returns null for a normal Celsius temperature", () => {
+      expect(handleSmartThingsEvent(stEvent({ value: 22, unit: "C" }), RAW)).toBeNull();
+    });
+
+    // 33 °F → 0.6 °C ≤ 4 °C
+    it("converts °F to °C and returns LowTemperature for a cold Fahrenheit reading", () => {
+      const reading = handleSmartThingsEvent(stEvent({ value: 33, unit: "F" }), RAW);
+      expect(reading!.eventType).toEqual({ LowTemperature: null });
+      expect(reading!.unit).toBe("°C");
+    });
+
+    // 96 °F → 35.6 °C > 35 °C
+    it("converts °F to °C and returns HighTemperature for a hot Fahrenheit reading", () => {
+      const reading = handleSmartThingsEvent(stEvent({ value: 96, unit: "F" }), RAW);
+      expect(reading!.eventType).toEqual({ HighTemperature: null });
+    });
+  });
+
+  describe("relativeHumidityMeasurement", () => {
+    it("returns HighHumidity when humidity exceeds 70 %", () => {
+      const reading = handleSmartThingsEvent(
+        stEvent({ capability: "relativeHumidityMeasurement", attribute: "humidity", value: 75, unit: "%" }), RAW
+      );
+      expect(reading!.eventType).toEqual({ HighHumidity: null });
+      expect(reading!.value).toBe(75);
+      expect(reading!.unit).toBe("%RH");
+    });
+
+    it("returns null when humidity is exactly 70 % (exclusive boundary)", () => {
+      expect(handleSmartThingsEvent(
+        stEvent({ capability: "relativeHumidityMeasurement", attribute: "humidity", value: 70, unit: "%" }), RAW
+      )).toBeNull();
+    });
+  });
+
+  describe("waterSensor", () => {
+    it("returns WaterLeak when water value is 'wet'", () => {
+      const reading = handleSmartThingsEvent(
+        stEvent({ capability: "waterSensor", attribute: "water", value: "wet", unit: undefined }), RAW
+      );
+      expect(reading!.eventType).toEqual({ WaterLeak: null });
+      expect(reading!.externalDeviceId).toBe("abc12345-6789-abcd-ef01-234567890abc");
+    });
+
+    it("returns null when water value is 'dry'", () => {
+      expect(handleSmartThingsEvent(
+        stEvent({ capability: "waterSensor", attribute: "water", value: "dry", unit: undefined }), RAW
+      )).toBeNull();
+    });
+  });
+
+  describe("filterStatus", () => {
+    it("returns HvacFilterDue when filterStatus is 'replace'", () => {
+      const reading = handleSmartThingsEvent(
+        stEvent({ capability: "filterStatus", attribute: "filterStatus", value: "replace", unit: undefined }), RAW
+      );
+      expect(reading!.eventType).toEqual({ HvacFilterDue: null });
+    });
+
+    it("returns null when filterStatus is 'normal'", () => {
+      expect(handleSmartThingsEvent(
+        stEvent({ capability: "filterStatus", attribute: "filterStatus", value: "normal", unit: undefined }), RAW
+      )).toBeNull();
+    });
+  });
+
+  describe("thermostatOperatingState", () => {
+    it("returns HvacAlert when thermostatOperatingState is 'fan only'", () => {
+      const reading = handleSmartThingsEvent(
+        stEvent({ capability: "thermostatOperatingState", attribute: "thermostatOperatingState", value: "fan only", unit: undefined }), RAW
+      );
+      expect(reading!.eventType).toEqual({ HvacAlert: null });
+    });
+
+    it("returns null when thermostatOperatingState is 'heating' (normal operation)", () => {
+      expect(handleSmartThingsEvent(
+        stEvent({ capability: "thermostatOperatingState", attribute: "thermostatOperatingState", value: "heating", unit: undefined }), RAW
+      )).toBeNull();
     });
   });
 });

--- a/agents/iot-gateway/handlers.ts
+++ b/agents/iot-gateway/handlers.ts
@@ -1,5 +1,5 @@
 /**
- * Webhook payload normalizers for Nest, Ecobee, and Moen Flo.
+ * Webhook payload normalizers for all supported IoT platforms.
  *
  * Each handler validates the incoming payload and returns a SensorReading
  * (or null if the event is not actionable for HomeGentic).
@@ -12,6 +12,7 @@ import type {
   EcobeeWebhookEvent,
   MoenFloWebhookEvent,
   HoneywellDevice,
+  SmartThingsDeviceEvent,
 } from "./types";
 
 // ── Nest ─────────────────────────────────────────────────────────────────────
@@ -250,6 +251,98 @@ export function handleHoneywellHomeEvent(
   }
 
   return null;
+}
+
+// ── SmartThings ───────────────────────────────────────────────────────────────
+
+export function handleSmartThingsEvent(
+  event: SmartThingsDeviceEvent,
+  raw: string
+): SensorReading | null {
+  if (!event.deviceId) return null;
+
+  const externalDeviceId = event.deviceId;
+
+  switch (event.capability) {
+    case "temperatureMeasurement": {
+      const raw_val = event.value as number;
+      // SmartThings reports the user's configured unit; convert °F → °C if needed.
+      const celsius = event.unit === "F" ? fahrenheitToCelsius(raw_val) : raw_val;
+      if (celsius <= PIPE_FREEZE_THRESHOLD_C) {
+        return {
+          externalDeviceId,
+          eventType: { LowTemperature: null } as SensorEventType,
+          value: celsius,
+          unit: "°C",
+          rawPayload: raw,
+        };
+      }
+      if (celsius > HIGH_TEMP_THRESHOLD_C) {
+        return {
+          externalDeviceId,
+          eventType: { HighTemperature: null } as SensorEventType,
+          value: celsius,
+          unit: "°C",
+          rawPayload: raw,
+        };
+      }
+      return null;
+    }
+
+    case "relativeHumidityMeasurement": {
+      const humidity = event.value as number;
+      if (humidity > HIGH_HUMIDITY_THRESHOLD) {
+        return {
+          externalDeviceId,
+          eventType: { HighHumidity: null } as SensorEventType,
+          value: humidity,
+          unit: "%RH",
+          rawPayload: raw,
+        };
+      }
+      return null;
+    }
+
+    case "waterSensor":
+      if (event.value === "wet") {
+        return {
+          externalDeviceId,
+          eventType: { WaterLeak: null } as SensorEventType,
+          value: 0,
+          unit: "",
+          rawPayload: raw,
+        };
+      }
+      return null;
+
+    case "filterStatus":
+      if (event.value === "replace") {
+        return {
+          externalDeviceId,
+          eventType: { HvacFilterDue: null } as SensorEventType,
+          value: 0,
+          unit: "",
+          rawPayload: raw,
+        };
+      }
+      return null;
+
+    case "thermostatOperatingState":
+      // "fan only" during heating/cooling season indicates the heat exchanger is bypassed.
+      if (event.value === "fan only") {
+        return {
+          externalDeviceId,
+          eventType: { HvacAlert: null } as SensorEventType,
+          value: 0,
+          unit: "",
+          rawPayload: raw,
+        };
+      }
+      return null;
+
+    default:
+      return null;
+  }
 }
 
 // ── Moen Flo ─────────────────────────────────────────────────────────────────

--- a/agents/iot-gateway/server.ts
+++ b/agents/iot-gateway/server.ts
@@ -5,9 +5,10 @@
  * forwards normalized sensor readings to the HomeGentic Sensor canister on ICP.
  *
  * Supported platforms:
- *   POST /webhooks/nest          — Google Nest (SDM API Pub/Sub push)
- *   POST /webhooks/ecobee        — Ecobee thermostat alerts
- *   POST /webhooks/moen-flo      — Moen Flo water-leak detection
+ *   POST /webhooks/nest            — Google Nest (SDM API Pub/Sub push)
+ *   POST /webhooks/ecobee          — Ecobee thermostat alerts
+ *   POST /webhooks/moen-flo        — Moen Flo water-leak detection
+ *   POST /webhooks/smartthings     — SmartThings capability events (+ CONFIRMATION lifecycle)
  *   GET  /oauth/callback/honeywell — Honeywell Home OAuth 2.0 callback (initial setup)
  *
  * Webhook authenticity:
@@ -23,7 +24,7 @@ import crypto from "crypto";
 import express, { Request, Response, NextFunction } from "express";
 import cors from "cors";
 import rateLimit from "express-rate-limit";
-import { handleNestEvent, handleEcobeeEvent, handleMoenFloEvent, handleHoneywellHomeEvent } from "./handlers";
+import { handleNestEvent, handleEcobeeEvent, handleMoenFloEvent, handleHoneywellHomeEvent, handleSmartThingsEvent } from "./handlers";
 import { recordSensorEvent, getGatewayPrincipal } from "./icp";
 import { startEcobeePoller } from "./pollers/ecobee";
 import { startHoneywellPoller, persistTokenState as persistHoneywellTokens } from "./pollers/honeywellHome";
@@ -32,6 +33,7 @@ import type {
   EcobeeWebhookEvent,
   MoenFloWebhookEvent,
   HoneywellDevice,
+  SmartThingsWebhookBody,
 } from "./types";
 
 const app = express();
@@ -55,6 +57,13 @@ const ecobeeLimiter = rateLimit({
 const nestLimiter = rateLimit({
   windowMs: 60 * 1000, // 1 minute
   max: 60,
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
+const smartThingsLimiter = rateLimit({
+  windowMs: 60 * 1000, // 1 minute
+  max: 120, // SmartThings hubs can send many device events in bursts
   standardHeaders: true,
   legacyHeaders: false,
 });
@@ -95,6 +104,18 @@ function verifyHmac(
   // Header may be "sha256=<hex>" or just "<hex>"
   const receivedHash = sig.startsWith("sha256=") ? sig.slice(7) : sig;
   return timingSafeEqual(expected, receivedHash);
+}
+
+// SmartThings signs requests with base64-encoded HMAC-SHA256 (not hex).
+function verifySmartThingsHmac(req: Request, secret: string | undefined): boolean {
+  if (!secret) return true;
+  const sig = req.headers["x-st-hmac-sha256"] as string | undefined;
+  if (!sig) return false;
+  const raw = (req as Request & { rawBody?: Buffer }).rawBody;
+  if (!raw) return false;
+  const expected = crypto.createHmac("sha256", secret).update(raw).digest("base64");
+  if (expected.length !== sig.length) return false;
+  return crypto.timingSafeEqual(Buffer.from(expected), Buffer.from(sig));
 }
 
 // ── Logging middleware ────────────────────────────────────────────────────────
@@ -201,6 +222,75 @@ app.post("/webhooks/moen-flo", moenFloLimiter, async (req: Request, res: Respons
   }
 });
 
+// ── POST /webhooks/smartthings ────────────────────────────────────────────────
+// Handles SmartThings Webhook SmartApp lifecycle events.
+// CONFIRMATION and PING are handled without signature verification; all other
+// lifecycles require X-ST-HMAC-SHA256 to match SMARTTHINGS_WEBHOOK_SECRET.
+app.post("/webhooks/smartthings", smartThingsLimiter, async (req: Request, res: Response): Promise<void> => {
+  const body = req.body as SmartThingsWebhookBody;
+
+  // CONFIRMATION — SmartThings verifies endpoint ownership on first registration.
+  // Must GET the confirmationUrl before responding.
+  if (body.lifecycle === "CONFIRMATION") {
+    const confirmationUrl = body.confirmationData?.confirmationUrl;
+    if (!confirmationUrl) {
+      res.status(400).json({ error: "missing confirmationUrl" });
+      return;
+    }
+    try {
+      await fetch(confirmationUrl);
+      console.log("[smartthings] webhook confirmed:", confirmationUrl);
+    } catch (err) {
+      console.error("[smartthings] confirmation fetch failed:", err);
+    }
+    res.json({});
+    return;
+  }
+
+  // PING — periodic liveness check from SmartThings.
+  if (body.lifecycle === "PING") {
+    res.json({});
+    return;
+  }
+
+  // All other lifecycles must have a valid signature.
+  if (!verifySmartThingsHmac(req, process.env.SMARTTHINGS_WEBHOOK_SECRET)) {
+    console.warn("[smartthings] rejected — invalid signature");
+    res.status(401).json({ error: "Unauthorized" });
+    return;
+  }
+
+  // INSTALL / UPDATE / UNINSTALL — acknowledge without processing device events.
+  if (body.lifecycle !== "EVENT") {
+    res.json({});
+    return;
+  }
+
+  // EVENT — process each capability state-change event.
+  const events = body.eventData?.events ?? [];
+  let processed = 0;
+
+  for (const e of events) {
+    if (!e.deviceEvent) continue;
+    const raw     = JSON.stringify(e.deviceEvent);
+    const reading = handleSmartThingsEvent(e.deviceEvent, raw);
+    if (!reading) continue;
+
+    const eventName = Object.keys(reading.eventType)[0];
+    console.log(`[smartthings] ${eventName} device=${reading.externalDeviceId}`);
+
+    const result = await recordSensorEvent(reading);
+    if (result.success) {
+      console.log(`[smartthings] recorded eventId=${result.eventId}${result.jobId ? ` jobId=${result.jobId}` : ""}`);
+      processed++;
+    } else {
+      console.error(`[smartthings] canister error: ${result.error}`);
+    }
+  }
+
+  res.json({ status: "processed", count: processed });
+});
+
 // ── GET /oauth/callback/honeywell ─────────────────────────────────────────────
 // One-time setup endpoint: exchanges the OAuth authorization code for tokens
 // and persists them so the polling loop can start on the next gateway restart.
@@ -271,7 +361,7 @@ app.get("/health", (_req: Request, res: Response) => {
     ok: true,
     gatewayPrincipal: getGatewayPrincipal(),
     sensorCanisterId: process.env.SENSOR_CANISTER_ID ?? "(not set)",
-    platforms: ["nest", "ecobee", "moen-flo", "honeywell-home"],
+    platforms: ["nest", "ecobee", "moen-flo", "smartthings", "honeywell-home"],
     pollers: {
       ecobee:    !!process.env.ECOBEE_CLIENT_ID,
       honeywell: !!process.env.HONEYWELL_CLIENT_ID,

--- a/agents/iot-gateway/types.ts
+++ b/agents/iot-gateway/types.ts
@@ -105,6 +105,32 @@ export interface HoneywellDevice {
   waterPresent?: boolean;
 }
 
+// ── SmartThings ──────────────────────────────────────────────────────────────
+
+/** A single capability state-change event from the SmartThings webhook payload. */
+export interface SmartThingsDeviceEvent {
+  deviceId:     string;
+  componentId?: string;
+  capability:   string; // e.g. "temperatureMeasurement", "waterSensor"
+  attribute:    string; // e.g. "temperature", "water"
+  value:        unknown; // number for temp/humidity, string for water/filter/hvac state
+  unit?:        string; // "C" | "F" | "%" — present on temperature events
+  stateChange?: boolean;
+}
+
+export interface SmartThingsWebhookBody {
+  lifecycle:        "CONFIRMATION" | "EVENT" | "INSTALL" | "UPDATE" | "UNINSTALL" | "PING";
+  executionId?:     string;
+  confirmationData?: {
+    appId:           string;
+    confirmationUrl: string;
+  };
+  eventData?: {
+    installedApp?: { installedAppId: string };
+    events: Array<{ deviceEvent?: SmartThingsDeviceEvent }>;
+  };
+}
+
 // ── Moen Flo ─────────────────────────────────────────────────────────────────
 export type MoenFloAlertType =
   | "LEAK"


### PR DESCRIPTION
## Summary

- Adds `POST /webhooks/smartthings` route to `server.ts`:
  - **CONFIRMATION** lifecycle: auto-GETs the `confirmationUrl` (required by SmartThings for endpoint ownership verification), no signature check
  - **PING**: responds `{}` (liveness check)
  - **EVENT**: verifies `X-ST-HMAC-SHA256` base64 HMAC signature, iterates `eventData.events`, calls `handleSmartThingsEvent` for each `deviceEvent`, records actionable readings to ICP
  - **INSTALL / UPDATE / UNINSTALL**: acknowledged with `{}`
- Adds `handleSmartThingsEvent` to `handlers.ts` — maps 5 capabilities: `temperatureMeasurement` (°C and °F with conversion), `relativeHumidityMeasurement`, `waterSensor`, `filterStatus`, `thermostatOperatingState`
- Adds `SmartThingsDeviceEvent` and `SmartThingsWebhookBody` types
- Adds `verifySmartThingsHmac()` — uses base64 HMAC-SHA256 (SmartThings format, distinct from hex used by other platforms)
- Adds SmartThings env vars to `.env.example` and full setup walkthrough to `README.md`
- **18 new handler tests** — 135 total, 0 failing

## Test plan

- [x] `npm test` in `agents/iot-gateway` — 135 passed, 0 failed
- [ ] Manual: register SmartApp webhook URL, confirm the CONFIRMATION lifecycle is handled and gateway logs `webhook confirmed`
- [ ] Manual: trigger a water sensor "wet" event in the SmartThings app, confirm `WaterLeak` is recorded in the sensor canister

Closes #268

🤖 Generated with [Claude Code](https://claude.com/claude-code)