### PR TITLE
feat(iot-gateway): LG ThinQ PCC webhook + GE SmartHQ OAuth polling (#273, #274)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -101,6 +101,23 @@ TESLA_ACCESS_TOKEN=
 # Optional: path to session file (default: .tesla-session.json in cwd)
 TESLA_SESSION_FILE=
 
+# LG ThinQ — PCC (Proactive Customer Care) webhook (POST /webhooks/lgthinq)
+# Register your callback URL in the LG ThinQ Developer Portal → My Apps → PCC.
+# LG POSTs fault/maintenance alerts with Authorization: Bearer <PAT>.
+LG_THINQ_PAT=
+# Optional — LG API base URL (default: us.api.lgthinq.com; EU: eu.api.lgthinq.com)
+LG_THINQ_API_BASE=https://us.api.lgthinq.com:46030
+
+# GE Appliances / SmartHQ — OAuth 2.0 REST polling (5 min)
+# Register at smarthqsolutions.com → SmartHQ Platform API to get credentials.
+# Complete the OAuth flow once via /oauth/callback/ge — see README.
+GE_CLIENT_ID=
+GE_CLIENT_SECRET=
+GE_ACCESS_TOKEN=
+GE_REFRESH_TOKEN=
+# Optional — path to token persistence file (default: .ge-tokens.json in cwd)
+GE_TOKENS_FILE=
+
 # SmartThings webhook (POST /webhooks/smartthings)
 # Personal Access Token: https://account.smartthings.com/tokens (scope: r:devices:*)
 # Webhook secret: set in your SmartThings Developer Workspace → Webhook → Signing Key.

--- a/agents/iot-gateway/README.md
+++ b/agents/iot-gateway/README.md
@@ -14,6 +14,8 @@ normalized sensor readings to the HomeGentic Sensor canister on ICP.
 | SmartThings | Push webhook | `SMARTTHINGS_WEBHOOK_SECRET` |
 | Enphase IQ Gateway | Local LAN polling (60 s) | `ENPHASE_ENVOY_IP` + `ENPHASE_ENVOY_TOKEN` |
 | Tesla Powerwall | Local LAN polling (60 s) | `TESLA_EMAIL` + `TESLA_PASSWORD` |
+| LG ThinQ | Push webhook (PCC API) | `LG_THINQ_PAT` |
+| GE Appliances / SmartHQ | REST polling (5 min) | `GE_CLIENT_ID` + tokens |
 
 ## Running
 
@@ -320,6 +322,104 @@ sensorService.registerDevice(propertyId, "LCC-00D02D123456", "HoneywellHome", "L
 | HVAC `equipmentStatus === "Fault"` or `"Off"` | `HvacAlert` | Warning |
 | `indoorHumidity > 70 %` | `HighHumidity` | Warning |
 | Water Leak Detector `isWaterPresent` | `WaterLeak` | Critical |
+
+---
+
+## Gateway identity setup
+
+## LG ThinQ — PCC webhook setup
+
+LG ThinQ Connect PCC (Proactive Customer Care) sends AI-driven fault and maintenance alerts to a registered callback URL.
+
+### Prerequisites
+
+1. Sign up at [thinq.developer.lge.com](https://thinq.developer.lge.com)
+2. Create an app → generate a **Personal Access Token (PAT)** — a UUID4 string
+3. Copy the PAT → set as `LG_THINQ_PAT` in `.env`
+
+### Step 1 — register your callback URL
+
+In the LG Developer Portal: **My Apps → PCC → Register Callback URL**
+
+Set the URL to `https://YOUR_GATEWAY_DOMAIN/webhooks/lgthinq`
+
+LG will POST fault/maintenance alerts with `Authorization: Bearer <your-PAT>`.
+
+### Step 2 — find your LG device ID
+
+```bash
+curl "https://us.api.lgthinq.com:46030/v1/devices" \
+  -H "x-client-id: YOUR_PAT" \
+  -H "x-message-id: " \
+  -H "x-country-code: US" \
+  -H "x-language-code: en-US" \
+  | jq '.result.item[] | {deviceId, alias, deviceType}'
+```
+
+Use `deviceId` as `externalDeviceId`:
+
+```ts
+sensorService.registerDevice(propertyId, "kr.KR.HRA-ADDDCCD0", "LGThinQ", "LG Refrigerator")
+```
+
+### Events ingested
+
+| Condition | Canister event | Severity |
+|---|---|---|
+| PCC `FAIL_CODE` or `FAULT` with severity HIGH or MEDIUM | `ApplianceFault` | Warning |
+| PCC `MAINTENANCE` (filter, descaling, cleaning) | `ApplianceMaintenance` | Info |
+
+---
+
+## GE Appliances / SmartHQ — OAuth 2.0 setup
+
+GE Appliances (GE, Café, Profile, Monogram, Hotpoint) exposes the SmartHQ Platform API. The integration uses OAuth 2.0 and polls every 5 minutes.
+
+### Prerequisites
+
+1. Apply at [smarthqsolutions.com](https://smarthqsolutions.com/smarthq-platform-api) for API access
+2. Once approved, create an app → note the **Client ID** (`GE_CLIENT_ID`) and **Client Secret** (`GE_CLIENT_SECRET`)
+3. Set the callback URL to `http://localhost:3002/oauth/callback/ge`
+
+### Step 1 — authorize in a browser
+
+Open this URL (replace `YOUR_CLIENT_ID`):
+
+```
+https://api.whrcloud.com/oauth/authorize?response_type=code&client_id=YOUR_CLIENT_ID&redirect_uri=http://localhost:3002/oauth/callback/ge
+```
+
+Log in with your GE account and approve access. The browser redirects to the gateway callback, which saves tokens to `.ge-tokens.json`.
+
+You should see: **"GE SmartHQ connected!"**
+
+### Step 2 — restart to begin polling
+
+```bash
+npm run dev
+```
+
+### Finding your GE appliance ID
+
+```bash
+curl "https://api.whrcloud.com/api/v1/appliance" \
+  -H "Authorization: Bearer $GE_ACCESS_TOKEN" \
+  -H "Content-Type: application/json" \
+  | jq '.[] | {applianceId, applianceType, nickName}'
+```
+
+Use `applianceId` as `externalDeviceId`:
+
+```ts
+sensorService.registerDevice(propertyId, "YOUR_APPLIANCE_ID", "GESmartHQ", "GE Dishwasher")
+```
+
+### Events ingested
+
+| Condition | Canister event | Severity |
+|---|---|---|
+| Appliance attribute with `ERROR_CODE` or `_FAULT` key is non-zero | `ApplianceFault` | Warning |
+| Appliance attribute with `FILTER_CHANGE` or `MAINTENANCE_DUE` key is `"1"` | `ApplianceMaintenance` | Info |
 
 ---
 

--- a/agents/iot-gateway/__tests__/handlers.test.ts
+++ b/agents/iot-gateway/__tests__/handlers.test.ts
@@ -1,4 +1,4 @@
-import { handleNestEvent, handleEcobeeEvent, handleMoenFloEvent, handleHoneywellHomeEvent, handleSmartThingsEvent, handleEnphaseEvent, handleTeslaEvent } from "../handlers";
+import { handleNestEvent, handleEcobeeEvent, handleMoenFloEvent, handleHoneywellHomeEvent, handleSmartThingsEvent, handleEnphaseEvent, handleTeslaEvent, handleLGThinQEvent } from "../handlers";
 import type {
   NestWebhookEvent,
   EcobeeWebhookEvent,
@@ -7,6 +7,7 @@ import type {
   SmartThingsDeviceEvent,
   EnphaseSystemEvent,
   TeslaPowerwallEvent,
+  LGThinQPCCEvent,
 } from "../types";
 
 const RAW = "{}";
@@ -759,6 +760,86 @@ describe("handleTeslaEvent", () => {
 
     it("returns null when charge is above 20 % with grid connected", () => {
       expect(handleTeslaEvent(teslaEvent({ chargePercent: 50 }), RAW)).toBeNull();
+    });
+  });
+});
+
+// ── handleLGThinQEvent ────────────────────────────────────────────────────────
+
+describe("handleLGThinQEvent", () => {
+  function lgEvent(overrides: Partial<LGThinQPCCEvent>): LGThinQPCCEvent {
+    return {
+      deviceId: "kr.KR.HRA-ADDDCCD0",
+      type:     "FAIL_CODE",
+      code:     "0F",
+      severity: "HIGH",
+      ...overrides,
+    };
+  }
+
+  describe("guard conditions", () => {
+    it("returns null when deviceId is absent", () => {
+      expect(handleLGThinQEvent(lgEvent({ deviceId: "" }), RAW)).toBeNull();
+    });
+
+    it("returns null for an unknown event type", () => {
+      expect(handleLGThinQEvent(lgEvent({ type: "UNKNOWN_TYPE" }), RAW)).toBeNull();
+    });
+  });
+
+  describe("fault events", () => {
+    it("returns ApplianceFault for FAIL_CODE with HIGH severity", () => {
+      const r = handleLGThinQEvent(lgEvent({ type: "FAIL_CODE", severity: "HIGH" }), RAW);
+      expect(r?.eventType).toEqual({ ApplianceFault: null });
+      expect(r?.externalDeviceId).toBe("kr.KR.HRA-ADDDCCD0");
+    });
+
+    it("returns ApplianceFault for FAIL_CODE with MEDIUM severity", () => {
+      const r = handleLGThinQEvent(lgEvent({ type: "FAIL_CODE", severity: "MEDIUM" }), RAW);
+      expect(r?.eventType).toEqual({ ApplianceFault: null });
+    });
+
+    it("returns null for FAIL_CODE with LOW severity (noise suppression)", () => {
+      expect(handleLGThinQEvent(lgEvent({ type: "FAIL_CODE", severity: "LOW" }), RAW)).toBeNull();
+    });
+
+    it("returns ApplianceFault for FAULT type with HIGH severity", () => {
+      const r = handleLGThinQEvent(lgEvent({ type: "FAULT", severity: "HIGH" }), RAW);
+      expect(r?.eventType).toEqual({ ApplianceFault: null });
+    });
+
+    it("handles lowercase type and severity via normalisation", () => {
+      const r = handleLGThinQEvent(lgEvent({ type: "fail_code", severity: "high" }), RAW);
+      expect(r?.eventType).toEqual({ ApplianceFault: null });
+    });
+
+    it("returns ApplianceFault when severity is absent (not LOW)", () => {
+      const r = handleLGThinQEvent(lgEvent({ type: "FAIL_CODE", severity: undefined }), RAW);
+      expect(r?.eventType).toEqual({ ApplianceFault: null });
+    });
+  });
+
+  describe("maintenance events", () => {
+    it("returns ApplianceMaintenance for MAINTENANCE type", () => {
+      const r = handleLGThinQEvent(
+        lgEvent({ type: "MAINTENANCE", code: "FILTER_REPLACE", severity: "LOW" }),
+        RAW
+      );
+      expect(r?.eventType).toEqual({ ApplianceMaintenance: null });
+      expect(r?.externalDeviceId).toBe("kr.KR.HRA-ADDDCCD0");
+    });
+
+    it("returns ApplianceMaintenance regardless of severity for MAINTENANCE type", () => {
+      const r = handleLGThinQEvent(
+        lgEvent({ type: "MAINTENANCE", code: "DESCALE", severity: "HIGH" }),
+        RAW
+      );
+      expect(r?.eventType).toEqual({ ApplianceMaintenance: null });
+    });
+
+    it("handles lowercase maintenance type", () => {
+      const r = handleLGThinQEvent(lgEvent({ type: "maintenance", code: "FILTER" }), RAW);
+      expect(r?.eventType).toEqual({ ApplianceMaintenance: null });
     });
   });
 });

--- a/agents/iot-gateway/__tests__/pollers/geSmartHQ.test.ts
+++ b/agents/iot-gateway/__tests__/pollers/geSmartHQ.test.ts
@@ -1,0 +1,419 @@
+import {
+  loadTokenState,
+  persistTokenState,
+  refreshTokens,
+  ensureFreshToken,
+  detectEventFromAttributes,
+  pollOnce,
+  startGEPoller,
+} from "../../pollers/geSmartHQ";
+import type { GETokenState } from "../../pollers/geSmartHQ";
+
+// ── Module mocks ──────────────────────────────────────────────────────────────
+
+jest.mock("fs");
+jest.mock("../../icp", () => ({
+  recordSensorEvent: jest.fn(),
+}));
+
+import fs from "fs";
+import { recordSensorEvent } from "../../icp";
+
+const mockFs                = fs as jest.Mocked<typeof fs>;
+const mockRecordSensorEvent = recordSensorEvent as jest.Mock;
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const NOW = Date.now();
+const VALID_STATE: GETokenState = {
+  accessToken:  "ge-access-token",
+  refreshToken: "ge-refresh-token",
+  expiresAt:    NOW + 3_600_000,
+};
+const EXPIRED_STATE: GETokenState = {
+  accessToken:  "old-access",
+  refreshToken: "old-refresh",
+  expiresAt:    NOW - 1000,
+};
+
+function mockFetchSequence(responses: Array<{ ok: boolean; status?: number; body: unknown }>): void {
+  let call = 0;
+  global.fetch = jest.fn().mockImplementation(() => {
+    const r = responses[call] ?? responses[responses.length - 1];
+    call++;
+    return Promise.resolve({
+      ok:     r.ok,
+      status: r.status ?? 200,
+      json:   jest.fn().mockResolvedValue(r.body),
+      text:   jest.fn().mockResolvedValue("error"),
+    } as unknown as Response);
+  });
+}
+
+const APPLIANCES_OK = [
+  { applianceId: "APPLIANCE-001", applianceType: "Refrigerator", nickName: "Kitchen Fridge" },
+  { applianceId: "APPLIANCE-002", applianceType: "Dishwasher",   nickName: "Main Dishwasher" },
+];
+
+const ATTRS_HEALTHY  = { attributes: { DOOR_STATUS: { value: "0" }, CYCLE_STATE: { value: "0" } } };
+const ATTRS_FAULT    = { attributes: { DOOR_STATUS: { value: "0" }, ERROR_CODE: { value: "E2" } } };
+const ATTRS_MAINT    = { attributes: { WATER_FILTER_CHANGE: { value: "1" } } };
+
+// ── loadTokenState ────────────────────────────────────────────────────────────
+
+describe("loadTokenState", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    delete process.env.GE_ACCESS_TOKEN;
+    delete process.env.GE_REFRESH_TOKEN;
+  });
+
+  it("returns state from valid file", () => {
+    const stored: GETokenState = { accessToken: "file-at", refreshToken: "file-rt", expiresAt: NOW + 3_600_000 };
+    mockFs.existsSync.mockReturnValue(true);
+    mockFs.readFileSync.mockReturnValue(JSON.stringify(stored));
+
+    expect(loadTokenState()).toEqual(stored);
+  });
+
+  it("falls back to env vars when file is absent", () => {
+    mockFs.existsSync.mockReturnValue(false);
+    process.env.GE_ACCESS_TOKEN  = "env-at";
+    process.env.GE_REFRESH_TOKEN = "env-rt";
+
+    const state = loadTokenState();
+    expect(state?.accessToken).toBe("env-at");
+    expect(state?.refreshToken).toBe("env-rt");
+  });
+
+  it("falls back to env when file is corrupted", () => {
+    mockFs.existsSync.mockReturnValue(true);
+    mockFs.readFileSync.mockReturnValue("not json {{");
+    process.env.GE_ACCESS_TOKEN  = "fallback-at";
+    process.env.GE_REFRESH_TOKEN = "fallback-rt";
+
+    expect(loadTokenState()?.accessToken).toBe("fallback-at");
+  });
+
+  it("returns null when file is absent and env vars are not set", () => {
+    mockFs.existsSync.mockReturnValue(false);
+    expect(loadTokenState()).toBeNull();
+  });
+
+  it("returns null when only accessToken is set but refreshToken is missing", () => {
+    mockFs.existsSync.mockReturnValue(false);
+    process.env.GE_ACCESS_TOKEN = "only-at";
+    expect(loadTokenState()).toBeNull();
+  });
+});
+
+// ── persistTokenState ─────────────────────────────────────────────────────────
+
+describe("persistTokenState", () => {
+  beforeEach(() => jest.resetAllMocks());
+
+  it("writes the token JSON to file", () => {
+    persistTokenState(VALID_STATE);
+    expect(mockFs.writeFileSync).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.stringContaining(VALID_STATE.accessToken),
+      "utf8"
+    );
+  });
+
+  it("updates GE_ACCESS_TOKEN and GE_REFRESH_TOKEN env vars", () => {
+    persistTokenState(VALID_STATE);
+    expect(process.env.GE_ACCESS_TOKEN).toBe(VALID_STATE.accessToken);
+    expect(process.env.GE_REFRESH_TOKEN).toBe(VALID_STATE.refreshToken);
+  });
+
+  it("does not throw when file write fails", () => {
+    mockFs.writeFileSync.mockImplementation(() => { throw new Error("disk full"); });
+    expect(() => persistTokenState(VALID_STATE)).not.toThrow();
+  });
+});
+
+// ── refreshTokens ─────────────────────────────────────────────────────────────
+
+describe("refreshTokens", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    process.env.GE_CLIENT_ID     = "client-id";
+    process.env.GE_CLIENT_SECRET = "client-secret";
+    mockFs.writeFileSync.mockReturnValue(undefined);
+  });
+
+  afterEach(() => {
+    delete process.env.GE_CLIENT_ID;
+    delete process.env.GE_CLIENT_SECRET;
+  });
+
+  it("throws when GE_CLIENT_ID is absent", async () => {
+    delete process.env.GE_CLIENT_ID;
+    await expect(refreshTokens(EXPIRED_STATE)).rejects.toThrow("GE_CLIENT_ID");
+  });
+
+  it("throws when GE_CLIENT_SECRET is absent", async () => {
+    delete process.env.GE_CLIENT_SECRET;
+    await expect(refreshTokens(EXPIRED_STATE)).rejects.toThrow("GE_CLIENT_SECRET");
+  });
+
+  it("POSTs to /oauth/token with Basic auth and returns updated state", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok:   true,
+      json: jest.fn().mockResolvedValue({
+        access_token:  "new-at",
+        refresh_token: "new-rt",
+        expires_in:    3600,
+      }),
+    } as unknown as Response);
+
+    const state = await refreshTokens(EXPIRED_STATE);
+
+    const [url, init] = (global.fetch as jest.Mock).mock.calls[0] as [string, RequestInit];
+    expect(url).toContain("/oauth/token");
+    expect((init.headers as Record<string, string>)["Authorization"]).toMatch(/^Basic /);
+    const body = new URLSearchParams(init.body as string);
+    expect(body.get("grant_type")).toBe("refresh_token");
+    expect(body.get("refresh_token")).toBe(EXPIRED_STATE.refreshToken);
+
+    expect(state.accessToken).toBe("new-at");
+    expect(state.refreshToken).toBe("new-rt");
+    expect(state.expiresAt).toBeGreaterThan(Date.now());
+  });
+
+  it("throws when token refresh fails", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false, status: 401,
+      text: jest.fn().mockResolvedValue("Unauthorized"),
+    } as unknown as Response);
+
+    await expect(refreshTokens(EXPIRED_STATE)).rejects.toThrow("token refresh failed");
+  });
+});
+
+// ── ensureFreshToken ──────────────────────────────────────────────────────────
+
+describe("ensureFreshToken", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    process.env.GE_CLIENT_ID     = "client-id";
+    process.env.GE_CLIENT_SECRET = "client-secret";
+    mockFs.writeFileSync.mockReturnValue(undefined);
+  });
+
+  it("returns the same state when token is still fresh", async () => {
+    global.fetch = jest.fn();
+    const result = await ensureFreshToken(VALID_STATE);
+    expect(result).toBe(VALID_STATE);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("calls refreshTokens when token is within the refresh buffer", async () => {
+    const almostExpired: GETokenState = { ...VALID_STATE, expiresAt: NOW + 2 * 60 * 1000 };
+    global.fetch = jest.fn().mockResolvedValue({
+      ok:   true,
+      json: jest.fn().mockResolvedValue({ access_token: "fresh", refresh_token: "fresh-rt", expires_in: 3600 }),
+    } as unknown as Response);
+
+    const result = await ensureFreshToken(almostExpired);
+    expect(result.accessToken).toBe("fresh");
+  });
+});
+
+// ── detectEventFromAttributes ─────────────────────────────────────────────────
+
+describe("detectEventFromAttributes", () => {
+  const ID  = "APP-001";
+  const RAW = "{}";
+
+  it("returns null when all attributes are normal", () => {
+    const attrs = { DOOR_STATUS: { value: "0" }, CYCLE_STATE: { value: "0" } };
+    expect(detectEventFromAttributes(ID, attrs, RAW)).toBeNull();
+  });
+
+  it("returns ApplianceFault when an ERROR_CODE is non-zero", () => {
+    const attrs = { ERROR_CODE: { value: "E2" } };
+    const r = detectEventFromAttributes(ID, attrs, RAW);
+    expect(r?.eventType).toEqual({ ApplianceFault: null });
+    expect(r?.externalDeviceId).toBe(ID);
+  });
+
+  it("returns ApplianceFault when a _FAULT key is non-zero", () => {
+    const attrs = { MOTOR_FAULT: { value: "1" } };
+    expect(detectEventFromAttributes(ID, attrs, RAW)?.eventType).toEqual({ ApplianceFault: null });
+  });
+
+  it("returns ApplianceFault when FAULT_CODE is non-zero", () => {
+    const attrs = { FAULT_CODE: { value: "F5" } };
+    expect(detectEventFromAttributes(ID, attrs, RAW)?.eventType).toEqual({ ApplianceFault: null });
+  });
+
+  it("does not flag ERROR_CODE with value '0'", () => {
+    const attrs = { ERROR_CODE: { value: "0" } };
+    expect(detectEventFromAttributes(ID, attrs, RAW)).toBeNull();
+  });
+
+  it("does not flag ERROR_CODE with empty value", () => {
+    const attrs = { ERROR_CODE: { value: "" } };
+    expect(detectEventFromAttributes(ID, attrs, RAW)).toBeNull();
+  });
+
+  it("returns ApplianceMaintenance when WATER_FILTER_CHANGE is '1'", () => {
+    const attrs = { WATER_FILTER_CHANGE: { value: "1" } };
+    const r = detectEventFromAttributes(ID, attrs, RAW);
+    expect(r?.eventType).toEqual({ ApplianceMaintenance: null });
+  });
+
+  it("returns ApplianceMaintenance when MAINTENANCE_DUE is '1'", () => {
+    const attrs = { MAINTENANCE_DUE: { value: "1" } };
+    expect(detectEventFromAttributes(ID, attrs, RAW)?.eventType).toEqual({ ApplianceMaintenance: null });
+  });
+
+  it("returns ApplianceMaintenance for DESCALE over a fault (maintenance priority)", () => {
+    const attrs = { DESCALE: { value: "1" }, ERROR_CODE: { value: "E1" } };
+    expect(detectEventFromAttributes(ID, attrs, RAW)?.eventType).toEqual({ ApplianceMaintenance: null });
+  });
+
+  it("does not flag WATER_FILTER_CHANGE with value '0'", () => {
+    const attrs = { WATER_FILTER_CHANGE: { value: "0" } };
+    expect(detectEventFromAttributes(ID, attrs, RAW)).toBeNull();
+  });
+});
+
+// ── pollOnce ──────────────────────────────────────────────────────────────────
+
+describe("pollOnce", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    mockRecordSensorEvent.mockResolvedValue({ success: true, eventId: "evt-1" });
+  });
+
+  it("fetches appliance list with Bearer token", async () => {
+    mockFetchSequence([
+      { ok: true, body: APPLIANCES_OK },
+      { ok: true, body: ATTRS_HEALTHY },
+      { ok: true, body: ATTRS_HEALTHY },
+    ]);
+
+    await pollOnce(VALID_STATE);
+
+    const [url, init] = (global.fetch as jest.Mock).mock.calls[0] as [string, RequestInit];
+    expect(url).toContain("/api/v1/appliance");
+    expect((init.headers as Record<string, string>)["Authorization"]).toBe(`Bearer ${VALID_STATE.accessToken}`);
+  });
+
+  it("does not call recordSensorEvent when all appliances are healthy", async () => {
+    mockFetchSequence([
+      { ok: true, body: APPLIANCES_OK },
+      { ok: true, body: ATTRS_HEALTHY },
+      { ok: true, body: ATTRS_HEALTHY },
+    ]);
+
+    await pollOnce(VALID_STATE);
+    expect(mockRecordSensorEvent).not.toHaveBeenCalled();
+  });
+
+  it("calls recordSensorEvent with ApplianceFault when an appliance has an error code", async () => {
+    mockFetchSequence([
+      { ok: true, body: [APPLIANCES_OK[0]] },
+      { ok: true, body: ATTRS_FAULT },
+    ]);
+
+    await pollOnce(VALID_STATE);
+
+    expect(mockRecordSensorEvent).toHaveBeenCalledTimes(1);
+    expect(mockRecordSensorEvent.mock.calls[0][0].eventType).toEqual({ ApplianceFault: null });
+    expect(mockRecordSensorEvent.mock.calls[0][0].externalDeviceId).toBe("APPLIANCE-001");
+  });
+
+  it("calls recordSensorEvent with ApplianceMaintenance when filter is due", async () => {
+    mockFetchSequence([
+      { ok: true, body: [APPLIANCES_OK[0]] },
+      { ok: true, body: ATTRS_MAINT },
+    ]);
+
+    await pollOnce(VALID_STATE);
+
+    expect(mockRecordSensorEvent).toHaveBeenCalledTimes(1);
+    expect(mockRecordSensorEvent.mock.calls[0][0].eventType).toEqual({ ApplianceMaintenance: null });
+  });
+
+  it("stops and returns when appliance list fetch fails", async () => {
+    mockFetchSequence([{ ok: false, status: 503, body: "unavailable" }]);
+
+    await expect(pollOnce(VALID_STATE)).resolves.toBeUndefined();
+    expect(mockRecordSensorEvent).not.toHaveBeenCalled();
+    expect((global.fetch as jest.Mock).mock.calls).toHaveLength(1);
+  });
+
+  it("skips an appliance when its attribute fetch fails with non-404", async () => {
+    mockFetchSequence([
+      { ok: true,  body: [APPLIANCES_OK[0]] },
+      { ok: false, status: 500, body: "server error" },
+    ]);
+
+    await expect(pollOnce(VALID_STATE)).resolves.toBeUndefined();
+    expect(mockRecordSensorEvent).not.toHaveBeenCalled();
+  });
+
+  it("silently skips an appliance when its attribute fetch returns 404", async () => {
+    mockFetchSequence([
+      { ok: true,  body: [APPLIANCES_OK[0]] },
+      { ok: false, status: 404, body: "not found" },
+    ]);
+
+    await expect(pollOnce(VALID_STATE)).resolves.toBeUndefined();
+    expect(mockRecordSensorEvent).not.toHaveBeenCalled();
+  });
+
+  it("returns an empty list gracefully", async () => {
+    mockFetchSequence([{ ok: true, body: [] }]);
+
+    await expect(pollOnce(VALID_STATE)).resolves.toBeUndefined();
+    expect(mockRecordSensorEvent).not.toHaveBeenCalled();
+  });
+
+  it("logs canister error but does not throw when recordSensorEvent fails", async () => {
+    mockFetchSequence([
+      { ok: true, body: [APPLIANCES_OK[0]] },
+      { ok: true, body: ATTRS_FAULT },
+    ]);
+    mockRecordSensorEvent.mockResolvedValue({ success: false, error: "Unauthorized" });
+
+    await expect(pollOnce(VALID_STATE)).resolves.toBeUndefined();
+  });
+});
+
+// ── startGEPoller ─────────────────────────────────────────────────────────────
+
+describe("startGEPoller", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    delete process.env.GE_ACCESS_TOKEN;
+    delete process.env.GE_REFRESH_TOKEN;
+    mockFs.existsSync.mockReturnValue(false);
+  });
+
+  it("returns a no-op stop function when tokens are absent", () => {
+    const stop = startGEPoller();
+    expect(typeof stop).toBe("function");
+    expect(() => stop()).not.toThrow();
+  });
+
+  it("the no-op stop function is idempotent", () => {
+    const stop = startGEPoller();
+    expect(() => { stop(); stop(); }).not.toThrow();
+  });
+
+  it("starts polling and returns a stop function when tokens are present", () => {
+    process.env.GE_ACCESS_TOKEN  = "ge-at";
+    process.env.GE_REFRESH_TOKEN = "ge-rt";
+
+    global.fetch = jest.fn().mockRejectedValue(new Error("no network in test"));
+
+    const stop = startGEPoller(60_000);
+    expect(typeof stop).toBe("function");
+    stop();
+  });
+});

--- a/agents/iot-gateway/handlers.ts
+++ b/agents/iot-gateway/handlers.ts
@@ -15,6 +15,7 @@ import type {
   SmartThingsDeviceEvent,
   EnphaseSystemEvent,
   TeslaPowerwallEvent,
+  LGThinQPCCEvent,
 } from "./types";
 
 // ── Nest ─────────────────────────────────────────────────────────────────────
@@ -471,6 +472,44 @@ export function handleMoenFloEvent(
         unit: "L/min",
         rawPayload: raw,
       };
+  }
+
+  return null;
+}
+
+// ── LG ThinQ ─────────────────────────────────────────────────────────────────
+
+export function handleLGThinQEvent(
+  event: LGThinQPCCEvent,
+  raw: string
+): SensorReading | null {
+  if (!event.deviceId) return null;
+
+  const externalDeviceId = event.deviceId;
+  const type     = (event.type     ?? "").toUpperCase();
+  const severity = (event.severity ?? "").toUpperCase();
+
+  // Maintenance events — filter replacement, descaling, cleaning reminders.
+  if (type === "MAINTENANCE") {
+    return {
+      externalDeviceId,
+      eventType: { ApplianceMaintenance: null } as SensorEventType,
+      value: 0,
+      unit: "",
+      rawPayload: raw,
+    };
+  }
+
+  // Fault events — FAIL_CODE or FAULT; skip LOW severity to avoid noise.
+  if (type === "FAIL_CODE" || type === "FAULT") {
+    if (severity === "LOW") return null;
+    return {
+      externalDeviceId,
+      eventType: { ApplianceFault: null } as SensorEventType,
+      value: 0,
+      unit: "",
+      rawPayload: raw,
+    };
   }
 
   return null;

--- a/agents/iot-gateway/icp.ts
+++ b/agents/iot-gateway/icp.ts
@@ -29,6 +29,8 @@ const SensorEventTypeIDL = IDL.Variant({
   LowProduction: IDL.Null,
   BatteryLow: IDL.Null,
   GridOutage: IDL.Null,
+  ApplianceFault: IDL.Null,
+  ApplianceMaintenance: IDL.Null,
 });
 
 const SensorDeviceIDL = IDL.Record({
@@ -51,6 +53,8 @@ const SensorDeviceIDL = IDL.Record({
     HomeAssistant: IDL.Null,
     EnphaseEnvoy: IDL.Null,
     TeslaPowerwall: IDL.Null,
+    LGThinQ: IDL.Null,
+    GESmartHQ: IDL.Null,
   }),
   name: IDL.Text,
   registeredAt: IDL.Int,

--- a/agents/iot-gateway/pollers/geSmartHQ.ts
+++ b/agents/iot-gateway/pollers/geSmartHQ.ts
@@ -1,0 +1,259 @@
+/**
+ * GE Appliances / SmartHQ REST polling script.
+ *
+ * Uses the official SmartHQ Platform API (api.whrcloud.com) with OAuth 2.0.
+ * Access tokens are refreshed proactively 5 minutes before expiry and
+ * persisted to GE_TOKENS_FILE so they survive restarts.
+ *
+ * Poll interval: 5 minutes (conservative — no documented rate limits).
+ * Each poll fetches all registered appliances, then queries each appliance's
+ * attributes for fault codes and maintenance flags.
+ *
+ * Required env vars (see .env.example):
+ *   GE_CLIENT_ID      — SmartHQ Platform API client_id
+ *   GE_CLIENT_SECRET  — SmartHQ Platform API client_secret
+ *   GE_ACCESS_TOKEN   — obtained via /oauth/callback/ge on first setup
+ *   GE_REFRESH_TOKEN  — obtained via /oauth/callback/ge on first setup
+ *   GE_TOKENS_FILE    — optional; path to token persistence file
+ */
+
+import fs from "fs";
+import path from "path";
+import { recordSensorEvent } from "../icp";
+import type { SensorEventType, SensorReading, GEAppliance, GEApplianceAttributes } from "../types";
+
+const GE_API         = "https://api.whrcloud.com";
+const REFRESH_BUFFER = 5 * 60 * 1000; // refresh 5 min before expiry
+
+const TOKENS_FILE = process.env.GE_TOKENS_FILE
+  ?? path.resolve(process.cwd(), ".ge-tokens.json");
+
+// ── Token state ───────────────────────────────────────────────────────────────
+
+export interface GETokenState {
+  accessToken:  string;
+  refreshToken: string;
+  expiresAt:    number; // ms epoch
+}
+
+export function loadTokenState(): GETokenState | null {
+  if (fs.existsSync(TOKENS_FILE)) {
+    try {
+      const parsed = JSON.parse(fs.readFileSync(TOKENS_FILE, "utf8")) as GETokenState;
+      if (parsed.accessToken && parsed.refreshToken && parsed.expiresAt) {
+        return parsed;
+      }
+    } catch {
+      console.warn("[ge-poller] corrupted token file — falling back to env vars");
+    }
+  }
+
+  const accessToken  = process.env.GE_ACCESS_TOKEN;
+  const refreshToken = process.env.GE_REFRESH_TOKEN;
+  if (!accessToken || !refreshToken) return null;
+
+  return {
+    accessToken,
+    refreshToken,
+    expiresAt: Date.now() + 60 * 60 * 1000, // assume 1 h if unknown
+  };
+}
+
+export function persistTokenState(state: GETokenState): void {
+  try {
+    fs.writeFileSync(TOKENS_FILE, JSON.stringify(state, null, 2), "utf8");
+  } catch (err) {
+    console.warn("[ge-poller] failed to persist tokens:", err);
+  }
+  process.env.GE_ACCESS_TOKEN  = state.accessToken;
+  process.env.GE_REFRESH_TOKEN = state.refreshToken;
+}
+
+export async function refreshTokens(state: GETokenState): Promise<GETokenState> {
+  const clientId     = process.env.GE_CLIENT_ID;
+  const clientSecret = process.env.GE_CLIENT_SECRET;
+  if (!clientId)     throw new Error("[ge-poller] GE_CLIENT_ID is required for token refresh");
+  if (!clientSecret) throw new Error("[ge-poller] GE_CLIENT_SECRET is required for token refresh");
+
+  const credentials = Buffer.from(`${clientId}:${clientSecret}`).toString("base64");
+  const body = new URLSearchParams({
+    grant_type:    "refresh_token",
+    refresh_token: state.refreshToken,
+  });
+
+  const resp = await fetch(`${GE_API}/oauth/token`, {
+    method: "POST",
+    headers: {
+      "Content-Type":  "application/x-www-form-urlencoded",
+      "Authorization": `Basic ${credentials}`,
+    },
+    body: body.toString(),
+  });
+
+  if (!resp.ok) {
+    const text = await resp.text();
+    throw new Error(`[ge-poller] token refresh failed (${resp.status}): ${text}`);
+  }
+
+  const data = await resp.json() as {
+    access_token:  string;
+    refresh_token: string;
+    expires_in:    number;
+  };
+
+  const newState: GETokenState = {
+    accessToken:  data.access_token,
+    refreshToken: data.refresh_token,
+    expiresAt:    Date.now() + data.expires_in * 1000,
+  };
+
+  persistTokenState(newState);
+  console.log(`[ge-poller] tokens refreshed — next expiry in ${Math.round(data.expires_in / 60)} min`);
+  return newState;
+}
+
+export async function ensureFreshToken(state: GETokenState): Promise<GETokenState> {
+  if (Date.now() < state.expiresAt - REFRESH_BUFFER) return state;
+  return refreshTokens(state);
+}
+
+// ── Fault / maintenance detection ─────────────────────────────────────────────
+
+// GE attribute key patterns that indicate a fault (non-zero value).
+const FAULT_KEY_PATTERNS  = ["ERROR_CODE", "_FAULT", "FAULT_CODE"];
+// GE attribute key patterns that indicate maintenance is due (value "1").
+const MAINT_KEY_PATTERNS  = ["FILTER_CHANGE", "FILTER_REPLACEMENT", "MAINTENANCE_DUE", "DESCALE"];
+
+export function detectEventFromAttributes(
+  applianceId: string,
+  attrs: Record<string, { value: string }>,
+  raw: string
+): SensorReading | null {
+  for (const [key, attr] of Object.entries(attrs)) {
+    const k = key.toUpperCase();
+
+    // Maintenance takes priority so a filter-change isn't mis-classified as a fault.
+    if (MAINT_KEY_PATTERNS.some(p => k.includes(p)) && attr.value === "1") {
+      return {
+        externalDeviceId: applianceId,
+        eventType: { ApplianceMaintenance: null } as SensorEventType,
+        value: 0,
+        unit: "",
+        rawPayload: raw,
+      };
+    }
+
+    if (FAULT_KEY_PATTERNS.some(p => k.includes(p)) && attr.value && attr.value !== "0") {
+      return {
+        externalDeviceId: applianceId,
+        eventType: { ApplianceFault: null } as SensorEventType,
+        value: 0,
+        unit: "",
+        rawPayload: raw,
+      };
+    }
+  }
+  return null;
+}
+
+// ── Poll ──────────────────────────────────────────────────────────────────────
+
+export async function pollOnce(state: GETokenState): Promise<void> {
+  const headers = {
+    Authorization: `Bearer ${state.accessToken}`,
+    "Content-Type": "application/json",
+  };
+
+  // 1. Fetch appliance list.
+  const listResp = await fetch(`${GE_API}/api/v1/appliance`, { headers });
+  if (!listResp.ok) {
+    console.error(`[ge-poller] appliance list failed (${listResp.status}): ${await listResp.text()}`);
+    return;
+  }
+
+  const appliances = await listResp.json() as GEAppliance[];
+  if (!Array.isArray(appliances) || appliances.length === 0) return;
+
+  // 2. For each appliance, fetch attributes and check for faults / maintenance.
+  for (const appliance of appliances) {
+    const { applianceId } = appliance;
+    if (!applianceId) continue;
+
+    const attrResp = await fetch(`${GE_API}/api/v1/appliance/${encodeURIComponent(applianceId)}/attribute`, {
+      headers,
+    });
+
+    if (!attrResp.ok) {
+      // 404 is expected for unconfigured appliance types — suppress.
+      if (attrResp.status !== 404) {
+        console.error(
+          `[ge-poller] attribute fetch failed for ${applianceId} ` +
+          `(${attrResp.status}): ${await attrResp.text()}`
+        );
+      }
+      continue;
+    }
+
+    const attrData = await attrResp.json() as GEApplianceAttributes;
+    const attrs    = attrData.attributes ?? {};
+    const raw      = JSON.stringify({ applianceId, attrs });
+    const reading  = detectEventFromAttributes(applianceId, attrs, raw);
+
+    if (!reading) continue;
+
+    const eventName = Object.keys(reading.eventType)[0];
+    const label     = appliance.nickName ?? applianceId;
+    console.log(`[ge-poller] ${eventName} appliance=${applianceId} (${label})`);
+
+    const result = await recordSensorEvent(reading);
+    if (result.success) {
+      console.log(
+        `[ge-poller] recorded eventId=${result.eventId}` +
+        (result.jobId ? ` jobId=${result.jobId}` : "")
+      );
+    } else {
+      console.error(`[ge-poller] canister error: ${result.error}`);
+    }
+  }
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/**
+ * Starts the GE SmartHQ polling loop. Returns a stop function.
+ * No-ops silently when tokens are absent — safe to call unconditionally.
+ */
+export function startGEPoller(intervalMs = 5 * 60 * 1000): () => void {
+  const initial = loadTokenState();
+  if (!initial) {
+    console.warn("[ge-poller] GE_ACCESS_TOKEN or GE_REFRESH_TOKEN not set — poller disabled");
+    return () => {};
+  }
+
+  let currentState = initial;
+  let stopped      = false;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+
+  async function tick(): Promise<void> {
+    if (stopped) return;
+    try {
+      currentState = await ensureFreshToken(currentState);
+      await pollOnce(currentState);
+    } catch (err) {
+      console.error("[ge-poller] tick error:", err);
+    } finally {
+      if (!stopped) {
+        timer = setTimeout(tick, intervalMs);
+      }
+    }
+  }
+
+  console.log(`[ge-poller] starting — interval=${intervalMs / 1000}s`);
+  tick();
+
+  return () => {
+    stopped = true;
+    if (timer) clearTimeout(timer);
+    console.log("[ge-poller] stopped");
+  };
+}

--- a/agents/iot-gateway/server.ts
+++ b/agents/iot-gateway/server.ts
@@ -9,12 +9,15 @@
  *   POST /webhooks/ecobee          — Ecobee thermostat alerts
  *   POST /webhooks/moen-flo        — Moen Flo water-leak detection
  *   POST /webhooks/smartthings     — SmartThings capability events (+ CONFIRMATION lifecycle)
+ *   POST /webhooks/lgthinq         — LG ThinQ PCC fault/maintenance callbacks
  *   GET  /oauth/callback/honeywell — Honeywell Home OAuth 2.0 callback (initial setup)
+ *   GET  /oauth/callback/ge        — GE SmartHQ OAuth 2.0 callback (initial setup)
  *
  * Webhook authenticity:
  *   - Nest:     Validates the Google-Cloud-Token header against NEST_WEBHOOK_SECRET
  *   - Ecobee:   Validates X-Ecobee-Signature HMAC-SHA256 against ECOBEE_WEBHOOK_SECRET
  *   - Moen Flo: Validates X-Moen-Signature HMAC-SHA256 against MOEN_FLO_WEBHOOK_SECRET
+ *   - LG ThinQ: Validates Authorization Bearer against LG_THINQ_PAT
  *
  * GET /health — returns gateway status and the service identity principal
  */
@@ -24,18 +27,20 @@ import crypto from "crypto";
 import express, { Request, Response, NextFunction } from "express";
 import cors from "cors";
 import rateLimit from "express-rate-limit";
-import { handleNestEvent, handleEcobeeEvent, handleMoenFloEvent, handleHoneywellHomeEvent, handleSmartThingsEvent } from "./handlers";
+import { handleNestEvent, handleEcobeeEvent, handleMoenFloEvent, handleHoneywellHomeEvent, handleSmartThingsEvent, handleLGThinQEvent } from "./handlers";
 import { recordSensorEvent, getGatewayPrincipal } from "./icp";
 import { startEcobeePoller } from "./pollers/ecobee";
 import { startHoneywellPoller, persistTokenState as persistHoneywellTokens } from "./pollers/honeywellHome";
 import { startEnphasePoller } from "./pollers/enphase";
 import { startTeslaPoller } from "./pollers/teslaGateway";
+import { startGEPoller, persistTokenState as persistGETokens } from "./pollers/geSmartHQ";
 import type {
   NestWebhookEvent,
   EcobeeWebhookEvent,
   MoenFloWebhookEvent,
   HoneywellDevice,
   SmartThingsWebhookBody,
+  LGThinQPCCEvent,
 } from "./types";
 
 const app = express();
@@ -66,6 +71,13 @@ const nestLimiter = rateLimit({
 const smartThingsLimiter = rateLimit({
   windowMs: 60 * 1000, // 1 minute
   max: 120, // SmartThings hubs can send many device events in bursts
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
+const lgThinQLimiter = rateLimit({
+  windowMs: 60 * 1000, // 1 minute
+  max: 60,
   standardHeaders: true,
   legacyHeaders: false,
 });
@@ -357,18 +369,116 @@ app.get("/oauth/callback/honeywell", async (req: Request, res: Response): Promis
   }
 });
 
+// ── POST /webhooks/lgthinq ────────────────────────────────────────────────────
+// LG ThinQ PCC (Proactive Customer Care) fault and maintenance callbacks.
+// Validates the Authorization Bearer header against LG_THINQ_PAT.
+app.post("/webhooks/lgthinq", lgThinQLimiter, async (req: Request, res: Response): Promise<void> => {
+  const bearerToken = (req.headers["authorization"] ?? "").replace(/^Bearer\s+/i, "");
+  const expectedPat = process.env.LG_THINQ_PAT;
+
+  if (expectedPat && bearerToken !== expectedPat) {
+    console.warn("[lgthinq] rejected — invalid PAT");
+    res.status(401).json({ error: "Unauthorized" });
+    return;
+  }
+
+  const body = req.body as LGThinQPCCEvent;
+  const raw  = JSON.stringify(body);
+
+  const reading = handleLGThinQEvent(body, raw);
+  if (!reading) {
+    res.json({ status: "ignored", reason: "no actionable reading" });
+    return;
+  }
+
+  console.log(`[lgthinq] event: ${Object.keys(reading.eventType)[0]} device=${reading.externalDeviceId}`);
+  const result = await recordSensorEvent(reading);
+
+  if (result.success) {
+    console.log(`[lgthinq] recorded eventId=${result.eventId}${result.jobId ? ` jobId=${result.jobId}` : ""}`);
+    res.json({ status: "recorded", eventId: result.eventId, jobId: result.jobId });
+  } else {
+    console.error(`[lgthinq] canister error: ${result.error}`);
+    res.status(500).json({ status: "error", error: result.error });
+  }
+});
+
+// ── GET /oauth/callback/ge ────────────────────────────────────────────────────
+// One-time setup: exchanges the GE SmartHQ OAuth authorization code for tokens.
+app.get("/oauth/callback/ge", async (req: Request, res: Response): Promise<void> => {
+  const code = req.query.code as string | undefined;
+  if (!code) {
+    res.status(400).send("Missing code parameter");
+    return;
+  }
+
+  const clientId     = process.env.GE_CLIENT_ID;
+  const clientSecret = process.env.GE_CLIENT_SECRET;
+  if (!clientId || !clientSecret) {
+    res.status(500).send("GE_CLIENT_ID and GE_CLIENT_SECRET must be set in .env");
+    return;
+  }
+
+  const redirectUri  = `http://localhost:${port}/oauth/callback/ge`;
+  const credentials  = Buffer.from(`${clientId}:${clientSecret}`).toString("base64");
+  const body = new URLSearchParams({
+    grant_type:   "authorization_code",
+    code,
+    redirect_uri: redirectUri,
+  });
+
+  try {
+    const tokenResp = await fetch("https://api.whrcloud.com/oauth/token", {
+      method: "POST",
+      headers: {
+        "Content-Type":  "application/x-www-form-urlencoded",
+        "Authorization": `Basic ${credentials}`,
+      },
+      body: body.toString(),
+    });
+
+    if (!tokenResp.ok) {
+      const text = await tokenResp.text();
+      res.status(502).send(`GE SmartHQ token exchange failed (${tokenResp.status}): ${text}`);
+      return;
+    }
+
+    const data = await tokenResp.json() as {
+      access_token:  string;
+      refresh_token: string;
+      expires_in:    number;
+    };
+
+    persistGETokens({
+      accessToken:  data.access_token,
+      refreshToken: data.refresh_token,
+      expiresAt:    Date.now() + data.expires_in * 1000,
+    });
+
+    console.log("[ge] OAuth callback — tokens saved. Restart gateway to start polling.");
+    res.send(
+      "<h2>GE SmartHQ connected!</h2>" +
+      "<p>Tokens saved. Restart the IoT gateway to begin polling.</p>"
+    );
+  } catch (err) {
+    console.error("[ge] OAuth callback error:", err);
+    res.status(500).send("Internal error during token exchange");
+  }
+});
+
 // ── GET /health ───────────────────────────────────────────────────────────────
 app.get("/health", (_req: Request, res: Response) => {
   res.json({
     ok: true,
     gatewayPrincipal: getGatewayPrincipal(),
     sensorCanisterId: process.env.SENSOR_CANISTER_ID ?? "(not set)",
-    platforms: ["nest", "ecobee", "moen-flo", "smartthings", "honeywell-home", "enphase", "tesla-powerwall"],
+    platforms: ["nest", "ecobee", "moen-flo", "smartthings", "honeywell-home", "enphase", "tesla-powerwall", "lgthinq", "ge-smarthq"],
     pollers: {
       ecobee:    !!process.env.ECOBEE_CLIENT_ID,
       honeywell: !!process.env.HONEYWELL_CLIENT_ID,
       enphase:   !!process.env.ENPHASE_ENVOY_IP,
       tesla:     !!(process.env.TESLA_EMAIL && process.env.TESLA_POWERWALL_SERIAL),
+      ge:        !!process.env.GE_CLIENT_ID,
     },
   });
 });
@@ -391,5 +501,8 @@ app.listen(port, () => {
   }
   if (process.env.TESLA_EMAIL && process.env.TESLA_POWERWALL_SERIAL) {
     startTeslaPoller();
+  }
+  if (process.env.GE_CLIENT_ID) {
+    startGEPoller();
   }
 });

--- a/agents/iot-gateway/types.ts
+++ b/agents/iot-gateway/types.ts
@@ -18,7 +18,9 @@ export type SensorEventType =
   | { SolarFault: null }
   | { LowProduction: null }
   | { BatteryLow: null }
-  | { GridOutage: null };
+  | { GridOutage: null }
+  | { ApplianceFault: null }
+  | { ApplianceMaintenance: null };
 
 // ── Normalized internal representation ───────────────────────────────────────
 export interface SensorReading {
@@ -161,6 +163,39 @@ export interface SmartThingsWebhookBody {
     installedApp?: { installedAppId: string };
     events: Array<{ deviceEvent?: SmartThingsDeviceEvent }>;
   };
+}
+
+// ── LG ThinQ ─────────────────────────────────────────────────────────────────
+
+/** PCC (Proactive Customer Care) callback payload from LG ThinQ. */
+export interface LGThinQPCCEvent {
+  deviceId:    string;
+  deviceType?: string;
+  /** "FAIL_CODE" | "FAULT" | "MAINTENANCE" — upper-cased by LG */
+  type:        string;
+  /** Platform-specific fault or maintenance code, e.g. "0F", "FILTER_REPLACE" */
+  code:        string;
+  /** "HIGH" | "MEDIUM" | "LOW" — present on fault events */
+  severity?:   string;
+  message?:    string;
+}
+
+// ── GE SmartHQ ───────────────────────────────────────────────────────────────
+
+export interface GEAppliance {
+  applianceId:   string;
+  applianceType?: string;
+  nickName?:     string;
+}
+
+export interface GEAttributeValue {
+  value:      string;
+  timestamp?: string;
+}
+
+export interface GEApplianceAttributes {
+  applianceId: string;
+  attributes:  Record<string, GEAttributeValue>;
 }
 
 // ── Moen Flo ─────────────────────────────────────────────────────────────────

--- a/backend/sensor/main.mo
+++ b/backend/sensor/main.mo
@@ -44,6 +44,7 @@ persistent actor Sensor {
     #RingAlarm; #HoneywellHome; #RheemEcoNet; #Sense;
     #EmporiaVue; #Rachio; #SmartThings; #HomeAssistant;
     #EnphaseEnvoy; #TeslaPowerwall;
+    #LGThinQ; #GESmartHQ;
   };
 
   public type SensorEventType = {
@@ -57,8 +58,10 @@ persistent actor Sensor {
     #HighTemperature; // Nest/Ecobee informational high
     #SolarFault;      // Enphase inverter error or system offline
     #LowProduction;   // Enphase production near-zero during daylight
-    #BatteryLow;      // Tesla Powerwall charge critically low
-    #GridOutage;      // Tesla Powerwall: grid disconnected (islanded)
+    #BatteryLow;          // Tesla Powerwall charge critically low
+    #GridOutage;          // Tesla Powerwall: grid disconnected (islanded)
+    #ApplianceFault;      // LG ThinQ / GE SmartHQ appliance fault or error code
+    #ApplianceMaintenance; // LG ThinQ / GE SmartHQ maintenance due (filter, descaling …)
   };
 
   public type Severity = { #Info; #Warning; #Critical };
@@ -200,8 +203,10 @@ persistent actor Sensor {
       case (#HvacFilterDue)   { #Info     };
       case (#SolarFault)      { #Critical };
       case (#LowProduction)   { #Warning  };
-      case (#BatteryLow)      { #Critical };
-      case (#GridOutage)      { #Warning  };
+      case (#BatteryLow)          { #Critical };
+      case (#GridOutage)          { #Warning  };
+      case (#ApplianceFault)      { #Warning  };
+      case (#ApplianceMaintenance){ #Info     };
     }
   };
 


### PR DESCRIPTION
## Summary

- **LG ThinQ** (`POST /webhooks/lgthinq`): receives PCC fault/maintenance callbacks; authenticates via `Authorization: Bearer <LG_THINQ_PAT>`; maps `FAIL_CODE`/`FAULT` (HIGH/MEDIUM) → `ApplianceFault`, `MAINTENANCE` → `ApplianceMaintenance`, LOW severity suppressed.
- **GE Appliances / SmartHQ** (`pollers/geSmartHQ.ts`): polls `/api/v1/appliance` list + `/api/v1/appliance/{id}/attribute` every 5 min; OAuth 2.0 with proactive token refresh (5-min buffer) and file persistence; `GET /oauth/callback/ge` one-time setup; detects fault codes → `ApplianceFault` and filter/maintenance flags → `ApplianceMaintenance`.
- **Shared**: `ApplianceFault` (Warning) and `ApplianceMaintenance` (Info) added to Motoko sensor canister, TypeScript types, and Candid IDL. Neither severity triggers auto-job creation.
- **47 new unit tests** (243 total, all passing).

Closes #273, #274

## Test plan

- [ ] `cd agents/iot-gateway && npm test` — all 243 tests pass
- [ ] LG ThinQ: register `https://YOUR_DOMAIN/webhooks/lgthinq` in the LG Developer Portal; send a test PCC event — confirm `ApplianceFault` / `ApplianceMaintenance` recorded in sensor canister
- [ ] LG ThinQ: confirm that LOW-severity `FAIL_CODE` events return `{"status":"ignored"}`
- [ ] GE SmartHQ: visit `GET /oauth/callback/ge` flow — confirm `.ge-tokens.json` is created and `GE SmartHQ connected!` is shown
- [ ] GE SmartHQ: set a non-zero `ERROR_CODE` on a test appliance fixture — confirm `ApplianceFault` event recorded
- [ ] `GET /health` returns `pollers.ge: true` when `GE_CLIENT_ID` is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)