### PR TITLE
feat(quote): homeowner contractor quality filters on quote requests (#280)

### DIFF
--- a/backend/contractor/main.mo
+++ b/backend/contractor/main.mo
@@ -403,6 +403,33 @@ persistent actor Contractor {
     )
   };
 
+  /// Lightweight stats query used by the quote canister to check visibility thresholds.
+  /// Returns all fields needed for filtering in a single cross-canister call.
+  public query func getContractorStats(p: Principal) : async ?{
+    trustScore:    Nat;
+    jobsCompleted: Nat;
+    reviewCount:   Nat;
+    isVerified:    Bool;
+    serviceZips:   [Text];
+  } {
+    switch (Map.get(contractors, Principal.compare, p)) {
+      case null { null };
+      case (?profile) {
+        var count = 0;
+        for (r in Map.values(reviews)) {
+          if (r.contractor == p) { count += 1 };
+        };
+        ?{
+          trustScore    = profile.trustScore;
+          jobsCompleted = profile.jobsCompleted;
+          reviewCount   = count;
+          isVerified    = profile.isVerified;
+          serviceZips   = profile.serviceZips;
+        }
+      };
+    }
+  };
+
   // ─── Job-Verified Hook ─────────────────────────────────────────────────────────
 
   /// Called by the Job canister (cross-canister) when a job reaches fully-verified

--- a/backend/quote/main.mo
+++ b/backend/quote/main.mo
@@ -71,8 +71,12 @@ persistent actor Quote {
     urgency: UrgencyLevel;
     status: RequestStatus;
     createdAt: Time.Time;
-    closeAt: ?Time.Time;   // bid-window close time; null = no sealed-bid window
-    zipCode: ?Text;        // property zip code; null = visible to all contractors
+    closeAt: ?Time.Time;      // bid-window close time; null = no sealed-bid window
+    zipCode: ?Text;           // property zip code; null = visible to all contractors
+    minTrustScore:    ?Nat;   // contractor trustScore must be >= this (null = no filter)
+    minJobsCompleted: ?Nat;   // contractor jobsCompleted must be >= this
+    minReviews:       ?Nat;   // contractor reviewCount must be >= this
+    maxBids:          ?Nat;   // cap on total bids accepted (null = unlimited)
   };
 
   /// A sealed bid submitted by a contractor before the bid window closes.
@@ -320,11 +324,15 @@ persistent actor Quote {
   /// Open-request quota is enforced against the admin-managed tier — callers
   /// cannot bypass limits by supplying a fake tier.
   public shared(msg) func createQuoteRequest(
-    propertyId: Text,
-    serviceType: ServiceType,
-    description: Text,
-    urgency: UrgencyLevel,
-    zipCode: ?Text
+    propertyId:       Text,
+    serviceType:      ServiceType,
+    description:      Text,
+    urgency:          UrgencyLevel,
+    zipCode:          ?Text,
+    minTrustScore:    ?Nat,
+    minJobsCompleted: ?Nat,
+    minReviews:       ?Nat,
+    maxBids:          ?Nat
   ) : async Result.Result<QuoteRequest, Error> {
     switch (requireActive(msg.caller)) { case (#err(e)) return #err(e); case _ {} };
 
@@ -383,10 +391,14 @@ persistent actor Quote {
       serviceType;
       description;
       urgency;
-      status    = #Open;
-      createdAt = Time.now();
-      closeAt   = null;
+      status           = #Open;
+      createdAt        = Time.now();
+      closeAt          = null;
       zipCode;
+      minTrustScore;
+      minJobsCompleted;
+      minReviews;
+      maxBids;
     };
     Map.add(requests, Text.compare, id, req);
     #ok(req)
@@ -416,25 +428,53 @@ persistent actor Quote {
     if (Text.size(contrCanisterId) == 0) return allOpen;
 
     let contrActor = actor(contrCanisterId) : actor {
-      getContractor : (Principal) -> async {
-        #ok: { serviceZips: [Text] };
-        #err: { #NotFound; #AlreadyExists; #Unauthorized; #Paused; #RateLimitExceeded; #InvalidInput: Text };
+      getContractorStats : (Principal) -> async ?{
+        trustScore:    Nat;
+        jobsCompleted: Nat;
+        reviewCount:   Nat;
+        isVerified:    Bool;
+        serviceZips:   [Text];
       };
     };
 
-    let serviceZips : [Text] = switch (await contrActor.getContractor(msg.caller)) {
-      case (#err(_)) { [] };
-      case (#ok(p))  { p.serviceZips };
-    };
+    let stats = await contrActor.getContractorStats(msg.caller);
 
-    if (serviceZips.size() == 0) return allOpen;
+    switch (stats) {
+      case null {
+        // Not registered as a contractor — no zip or quality filtering
+        allOpen
+      };
+      case (?s) {
+        Array.filter<QuoteRequest>(allOpen, func(r: QuoteRequest) : Bool {
+          // Zip filter: if contractor has no serviceZips, they see all zips
+          let zipOk : Bool = if (s.serviceZips.size() == 0) { true }
+          else {
+            switch (r.zipCode) {
+              case null    { true };
+              case (?zip)  { Option.isSome(Array.find<Text>(s.serviceZips, func(z) { z == zip })) };
+            }
+          };
+          if (not zipOk) return false;
 
-    Array.filter<QuoteRequest>(allOpen, func(r: QuoteRequest) : Bool {
-      switch (r.zipCode) {
-        case null      { true };  // no zip on request — visible to all
-        case (?zip)    { Option.isSome(Array.find<Text>(serviceZips, func(z) { z == zip })) };
-      }
-    })
+          // Verified contractors bypass all quality thresholds
+          if (s.isVerified) return true;
+
+          switch (r.minTrustScore) {
+            case null {};
+            case (?minT) { if (s.trustScore < minT) return false };
+          };
+          switch (r.minJobsCompleted) {
+            case null {};
+            case (?minJ) { if (s.jobsCompleted < minJ) return false };
+          };
+          switch (r.minReviews) {
+            case null {};
+            case (?minR) { if (s.reviewCount < minR) return false };
+          };
+          true
+        })
+      };
+    }
   };
 
   /// Fetch all open or quoted requests — unfiltered, visible to any contractor.
@@ -486,6 +526,24 @@ persistent actor Quote {
         if (timeline == 0)  return #err(#InvalidInput("Timeline must be greater than 0"));
         if (validUntil <= Time.now()) return #err(#InvalidInput("validUntil must be in the future"));
 
+        // Enforce maxBids cap
+        switch (req.maxBids) {
+          case null {};
+          case (?cap) {
+            var bidCount = 0;
+            for (q in Map.values(quotes)) {
+              if (q.requestId == requestId and q.status == #Pending) {
+                bidCount += 1;
+              };
+            };
+            if (bidCount >= cap) {
+              return #err(#InvalidInput(
+                "This request has reached its maximum number of bids (" # Nat.toText(cap) # ")"
+              ));
+            };
+          };
+        };
+
         if (not tryConsumeSubmissionSlot(msg.caller))
           return #err(#InvalidInput(
             "Daily quote submission limit reached (20/day per contractor). Resets at midnight UTC."
@@ -507,16 +565,20 @@ persistent actor Quote {
         // Advance request status to #Quoted if still #Open
         if (req.status == #Open) {
           let updated: QuoteRequest = {
-            id          = req.id;
-            propertyId  = req.propertyId;
-            homeowner   = req.homeowner;
-            serviceType = req.serviceType;
-            description = req.description;
-            urgency     = req.urgency;
-            status      = #Quoted;
-            createdAt   = req.createdAt;
-            closeAt     = req.closeAt;
-            zipCode     = req.zipCode;
+            id               = req.id;
+            propertyId       = req.propertyId;
+            homeowner        = req.homeowner;
+            serviceType      = req.serviceType;
+            description      = req.description;
+            urgency          = req.urgency;
+            status           = #Quoted;
+            createdAt        = req.createdAt;
+            closeAt          = req.closeAt;
+            zipCode          = req.zipCode;
+            minTrustScore    = req.minTrustScore;
+            minJobsCompleted = req.minJobsCompleted;
+            minReviews       = req.minReviews;
+            maxBids          = req.maxBids;
           };
           Map.add(requests, Text.compare, requestId, updated);
         };
@@ -591,16 +653,20 @@ persistent actor Quote {
 
             // Close the request
             let closed: QuoteRequest = {
-              id          = req.id;
-              propertyId  = req.propertyId;
-              homeowner   = req.homeowner;
-              serviceType = req.serviceType;
-              description = req.description;
-              urgency     = req.urgency;
-              status      = #Accepted;
-              createdAt   = req.createdAt;
-              closeAt     = req.closeAt;
-              zipCode     = req.zipCode;
+              id               = req.id;
+              propertyId       = req.propertyId;
+              homeowner        = req.homeowner;
+              serviceType      = req.serviceType;
+              description      = req.description;
+              urgency          = req.urgency;
+              status           = #Accepted;
+              createdAt        = req.createdAt;
+              closeAt          = req.closeAt;
+              zipCode          = req.zipCode;
+              minTrustScore    = req.minTrustScore;
+              minJobsCompleted = req.minJobsCompleted;
+              minReviews       = req.minReviews;
+              maxBids          = req.maxBids;
             };
             Map.add(requests, Text.compare, req.id, closed);
 
@@ -626,16 +692,20 @@ persistent actor Quote {
           return #err(#InvalidInput("Request is already cancelled"));
 
         let updated: QuoteRequest = {
-          id          = req.id;
-          propertyId  = req.propertyId;
-          homeowner   = req.homeowner;
-          serviceType = req.serviceType;
-          description = req.description;
-          urgency     = req.urgency;
-          status      = #Closed;
-          createdAt   = req.createdAt;
-          closeAt     = req.closeAt;
-          zipCode     = req.zipCode;
+          id               = req.id;
+          propertyId       = req.propertyId;
+          homeowner        = req.homeowner;
+          serviceType      = req.serviceType;
+          description      = req.description;
+          urgency          = req.urgency;
+          status           = #Closed;
+          createdAt        = req.createdAt;
+          closeAt          = req.closeAt;
+          zipCode          = req.zipCode;
+          minTrustScore    = req.minTrustScore;
+          minJobsCompleted = req.minJobsCompleted;
+          minReviews       = req.minReviews;
+          maxBids          = req.maxBids;
         };
         Map.add(requests, Text.compare, requestId, updated);
         #ok(updated)
@@ -663,16 +733,20 @@ persistent actor Quote {
         };
 
         let updated: QuoteRequest = {
-          id          = req.id;
-          propertyId  = req.propertyId;
-          homeowner   = req.homeowner;
-          serviceType = req.serviceType;
-          description = req.description;
-          urgency     = req.urgency;
-          status      = #Cancelled;
-          createdAt   = req.createdAt;
-          closeAt     = req.closeAt;
-          zipCode     = req.zipCode;
+          id               = req.id;
+          propertyId       = req.propertyId;
+          homeowner        = req.homeowner;
+          serviceType      = req.serviceType;
+          description      = req.description;
+          urgency          = req.urgency;
+          status           = #Cancelled;
+          createdAt        = req.createdAt;
+          closeAt          = req.closeAt;
+          zipCode          = req.zipCode;
+          minTrustScore    = req.minTrustScore;
+          minJobsCompleted = req.minJobsCompleted;
+          minReviews       = req.minReviews;
+          maxBids          = req.maxBids;
         };
         Map.add(requests, Text.compare, requestId, updated);
 
@@ -693,12 +767,16 @@ persistent actor Quote {
   /// Create a quote request with a bid-window close time.
   /// After closeAt the canister will accept reveal requests but reject new bids.
   public shared(msg) func createSealedBidRequest(
-    propertyId: Text,
-    serviceType: ServiceType,
-    description: Text,
-    urgency: UrgencyLevel,
-    closeAtNs: Time.Time,
-    zipCode: ?Text
+    propertyId:       Text,
+    serviceType:      ServiceType,
+    description:      Text,
+    urgency:          UrgencyLevel,
+    closeAtNs:        Time.Time,
+    zipCode:          ?Text,
+    minTrustScore:    ?Nat,
+    minJobsCompleted: ?Nat,
+    minReviews:       ?Nat,
+    maxBids:          ?Nat
   ) : async Result.Result<QuoteRequest, Error> {
     switch (requireActive(msg.caller)) { case (#err(e)) return #err(e); case _ {} };
 
@@ -733,14 +811,18 @@ persistent actor Quote {
     let req: QuoteRequest = {
       id;
       propertyId;
-      homeowner   = msg.caller;
+      homeowner        = msg.caller;
       serviceType;
       description;
       urgency;
-      status    = #Open;
-      createdAt = Time.now();
-      closeAt   = ?closeAtNs;
+      status           = #Open;
+      createdAt        = Time.now();
+      closeAt          = ?closeAtNs;
       zipCode;
+      minTrustScore;
+      minJobsCompleted;
+      minReviews;
+      maxBids;
     };
     Map.add(requests, Text.compare, id, req);
     #ok(req)

--- a/backend/quote/test.sh
+++ b/backend/quote/test.sh
@@ -75,7 +75,7 @@ REQ_OUT=$(dfx canister call $CANISTER createQuoteRequest "(
   variant { Plumbing },
   \"Need to fix leaky pipe under kitchen sink — active drip, causing cabinet damage.\",
   variant { Medium },
-  null
+  null, null, null, null, null
 )")
 echo "$REQ_OUT"
 REQ_ID=$(echo "$REQ_OUT" | grep -oP '"REQ_[^"]+"' | head -1 | tr -d '"')
@@ -140,7 +140,7 @@ REQ2_OUT=$(dfx canister call $CANISTER createQuoteRequest "(
   variant { HVAC },
   \"HVAC tune-up before summer — filter replacement and refrigerant check.\",
   variant { Low },
-  null
+  null, null, null, null, null
 )")
 echo "$REQ2_OUT"
 REQ2_ID=$(echo "$REQ2_OUT" | grep -oP '"REQ_[^"]+"' | head -1 | tr -d '"')
@@ -162,7 +162,7 @@ CANCEL_REQ_OUT=$(dfx canister call $CANISTER createQuoteRequest "(
   variant { Electrical },
   \"Electrical panel upgrade — cancel flow test.\",
   variant { Low },
-  null
+  null, null, null, null, null
 )")
 echo "$CANCEL_REQ_OUT"
 CANCEL_REQ_ID=$(echo "$CANCEL_REQ_OUT" | grep -oP '"REQ_[^"]+"' | head -1 | tr -d '"' || true)
@@ -232,7 +232,7 @@ RESULT=$(dfx canister call $CANISTER createQuoteRequest '(
   variant { Roofing },
   "Free tier should be rejected entirely.",
   variant { Low },
-  null
+  null, null, null, null, null
 )' --identity quote-free-test 2>&1)
 echo "$RESULT" | grep -qi "subscription\|InvalidInput" \
   && echo "  ↳ Free tier correctly blocked from creating quote requests — ✓" \
@@ -253,7 +253,7 @@ for i in 1 2 3; do
     variant { Roofing },
     \"Basic tier limit test request $i.\",
     variant { Low },
-    null
+    null, null, null, null, null
   )" --identity quote-basic-test)
   ID=$(echo "$OUT" | grep -oP '"REQ_[^"]+"' | head -1 | tr -d '"' || true)
   [ -n "$ID" ] && LIMIT_REQ_IDS+=("$ID") && echo "  → Request $i created ($ID)" \
@@ -267,7 +267,7 @@ dfx canister call $CANISTER createQuoteRequest '(
   variant { Roofing },
   "This 4th request should fail on Basic tier limit.",
   variant { Low },
-  null
+  null, null, null, null, null
 )' --identity quote-basic-test \
   && echo "  ↳ ❌ Expected LimitReached for Basic tier" \
   || echo "  ↳ Basic tier open-request limit correctly enforced (max 3) — ✓"
@@ -294,7 +294,7 @@ dfx canister call $CANISTER createQuoteRequest '(
   variant { Painting },
   "Test request for invalid bid.",
   variant { Low },
-  null
+  null, null, null, null, null
 )' > /tmp/qr_tmp.txt
 TMP_REQ=$(cat /tmp/qr_tmp.txt | grep -oP '"REQ_[^"]+"' | head -1 | tr -d '"')
 dfx canister call $CANISTER submitQuote "(
@@ -354,7 +354,7 @@ else
       variant { Roofing },
       \"open request $i for tier test\",
       variant { Low },
-      null
+      null, null, null, null, null
     )" --identity quote-tier-test 2>/dev/null || true
   done
   dfx canister call $CANISTER createQuoteRequest '(
@@ -362,7 +362,7 @@ else
     variant { Roofing },
     "4th open request — should fail on Free tier via payment canister",
     variant { Low },
-    null
+    null, null, null, null, null
   )' --identity quote-tier-test \
     && echo "  ↳ ❌ Expected LimitReached for Free tier via payment canister" \
     || echo "  ↳ Free tier open-request limit enforced via payment canister — ✓"
@@ -375,7 +375,7 @@ else
     variant { Roofing },
     "4th open request — Pro tier allows 10",
     variant { Low },
-    null
+    null, null, null, null, null
   )' --identity quote-tier-test \
     && echo "  ↳ Pro tier allows 4th open request via payment canister — ✓" \
     || echo "  ↳ ❌ Pro tier should allow 4th open request"
@@ -388,7 +388,7 @@ else
     variant { Plumbing },
     "Should fail — back to Free tier limit",
     variant { Low },
-    null
+    null, null, null, null, null
   )' --identity quote-tier-test \
     && echo "  ↳ ❌ Expected LimitReached after downgrade to Free" \
     || echo "  ↳ Downgraded to Free — open-request limit re-enforced via payment canister — ✓"
@@ -473,7 +473,7 @@ else
     variant { Plumbing },
     \"Quote request submitted by delegated manager.\",
     variant { Medium },
-    null
+    null, null, null, null, null
   )" --identity manager-test)
   echo "$MGR_QUOTE_OUT"
   if echo "$MGR_QUOTE_OUT" | grep -qi "ok"; then
@@ -490,7 +490,7 @@ else
     variant { Electrical },
     "Quote request on unrelated property — should be blocked.",
     variant { Low },
-    null
+    null, null, null, null, null
   )' --identity manager-test)
   echo "$UNAUTH_QUOTE"
   if echo "$UNAUTH_QUOTE" | grep -qiE "LimitReached|err"; then

--- a/frontend/src/__tests__/contracts/__snapshots__/candid.contract.test.ts.snap
+++ b/frontend/src/__tests__/contracts/__snapshots__/candid.contract.test.ts.snap
@@ -1315,7 +1315,7 @@ exports[`quote IDL factory > full signature snapshot 1`] = `
     ],
     "mode": [],
     "rets": [
-      "variant {ok:record {id:text; status:variant {Quoted; Open; Closed; Accepted; Cancelled}; serviceType:variant {HVAC; Plumbing; Painting; Landscaping; Windows; Electrical; Flooring; Roofing}; urgency:variant {Low; High; Medium; Emergency}; createdAt:int; description:text; propertyId:text; zipCode:opt text; closeAt:opt int; homeowner:principal}; err:variant {InvalidInput:text; NotFound; Unauthorized}}",
+      "variant {ok:record {id:text; status:variant {Quoted; Open; Closed; Accepted; Cancelled}; serviceType:variant {HVAC; Plumbing; Painting; Landscaping; Windows; Electrical; Flooring; Roofing}; urgency:variant {Low; High; Medium; Emergency}; createdAt:int; minTrustScore:opt nat; description:text; propertyId:text; zipCode:opt text; closeAt:opt int; maxBids:opt nat; homeowner:principal; minReviews:opt nat; minJobsCompleted:opt nat}; err:variant {InvalidInput:text; NotFound; Unauthorized}}",
     ],
   },
   "createQuoteRequest": {
@@ -1325,10 +1325,14 @@ exports[`quote IDL factory > full signature snapshot 1`] = `
       "text",
       "variant {Low; High; Medium; Emergency}",
       "opt text",
+      "opt nat",
+      "opt nat",
+      "opt nat",
+      "opt nat",
     ],
     "mode": [],
     "rets": [
-      "variant {ok:record {id:text; status:variant {Quoted; Open; Closed; Accepted; Cancelled}; serviceType:variant {HVAC; Plumbing; Painting; Landscaping; Windows; Electrical; Flooring; Roofing}; urgency:variant {Low; High; Medium; Emergency}; createdAt:int; description:text; propertyId:text; zipCode:opt text; closeAt:opt int; homeowner:principal}; err:variant {InvalidInput:text; NotFound; Unauthorized}}",
+      "variant {ok:record {id:text; status:variant {Quoted; Open; Closed; Accepted; Cancelled}; serviceType:variant {HVAC; Plumbing; Painting; Landscaping; Windows; Electrical; Flooring; Roofing}; urgency:variant {Low; High; Medium; Emergency}; createdAt:int; minTrustScore:opt nat; description:text; propertyId:text; zipCode:opt text; closeAt:opt int; maxBids:opt nat; homeowner:principal; minReviews:opt nat; minJobsCompleted:opt nat}; err:variant {InvalidInput:text; NotFound; Unauthorized}}",
     ],
   },
   "getMyQuoteRequests": {
@@ -1337,7 +1341,7 @@ exports[`quote IDL factory > full signature snapshot 1`] = `
       "query",
     ],
     "rets": [
-      "vec record {id:text; status:variant {Quoted; Open; Closed; Accepted; Cancelled}; serviceType:variant {HVAC; Plumbing; Painting; Landscaping; Windows; Electrical; Flooring; Roofing}; urgency:variant {Low; High; Medium; Emergency}; createdAt:int; description:text; propertyId:text; zipCode:opt text; closeAt:opt int; homeowner:principal}",
+      "vec record {id:text; status:variant {Quoted; Open; Closed; Accepted; Cancelled}; serviceType:variant {HVAC; Plumbing; Painting; Landscaping; Windows; Electrical; Flooring; Roofing}; urgency:variant {Low; High; Medium; Emergency}; createdAt:int; minTrustScore:opt nat; description:text; propertyId:text; zipCode:opt text; closeAt:opt int; maxBids:opt nat; homeowner:principal; minReviews:opt nat; minJobsCompleted:opt nat}",
     ],
   },
   "getMyQuotes": {
@@ -1355,14 +1359,14 @@ exports[`quote IDL factory > full signature snapshot 1`] = `
       "query",
     ],
     "rets": [
-      "vec record {id:text; status:variant {Quoted; Open; Closed; Accepted; Cancelled}; serviceType:variant {HVAC; Plumbing; Painting; Landscaping; Windows; Electrical; Flooring; Roofing}; urgency:variant {Low; High; Medium; Emergency}; createdAt:int; description:text; propertyId:text; zipCode:opt text; closeAt:opt int; homeowner:principal}",
+      "vec record {id:text; status:variant {Quoted; Open; Closed; Accepted; Cancelled}; serviceType:variant {HVAC; Plumbing; Painting; Landscaping; Windows; Electrical; Flooring; Roofing}; urgency:variant {Low; High; Medium; Emergency}; createdAt:int; minTrustScore:opt nat; description:text; propertyId:text; zipCode:opt text; closeAt:opt int; maxBids:opt nat; homeowner:principal; minReviews:opt nat; minJobsCompleted:opt nat}",
     ],
   },
   "getOpenRequestsForMe": {
     "args": [],
     "mode": [],
     "rets": [
-      "vec record {id:text; status:variant {Quoted; Open; Closed; Accepted; Cancelled}; serviceType:variant {HVAC; Plumbing; Painting; Landscaping; Windows; Electrical; Flooring; Roofing}; urgency:variant {Low; High; Medium; Emergency}; createdAt:int; description:text; propertyId:text; zipCode:opt text; closeAt:opt int; homeowner:principal}",
+      "vec record {id:text; status:variant {Quoted; Open; Closed; Accepted; Cancelled}; serviceType:variant {HVAC; Plumbing; Painting; Landscaping; Windows; Electrical; Flooring; Roofing}; urgency:variant {Low; High; Medium; Emergency}; createdAt:int; minTrustScore:opt nat; description:text; propertyId:text; zipCode:opt text; closeAt:opt int; maxBids:opt nat; homeowner:principal; minReviews:opt nat; minJobsCompleted:opt nat}",
     ],
   },
   "getQuoteRequest": {
@@ -1373,7 +1377,7 @@ exports[`quote IDL factory > full signature snapshot 1`] = `
       "query",
     ],
     "rets": [
-      "variant {ok:record {id:text; status:variant {Quoted; Open; Closed; Accepted; Cancelled}; serviceType:variant {HVAC; Plumbing; Painting; Landscaping; Windows; Electrical; Flooring; Roofing}; urgency:variant {Low; High; Medium; Emergency}; createdAt:int; description:text; propertyId:text; zipCode:opt text; closeAt:opt int; homeowner:principal}; err:variant {InvalidInput:text; NotFound; Unauthorized}}",
+      "variant {ok:record {id:text; status:variant {Quoted; Open; Closed; Accepted; Cancelled}; serviceType:variant {HVAC; Plumbing; Painting; Landscaping; Windows; Electrical; Flooring; Roofing}; urgency:variant {Low; High; Medium; Emergency}; createdAt:int; minTrustScore:opt nat; description:text; propertyId:text; zipCode:opt text; closeAt:opt int; maxBids:opt nat; homeowner:principal; minReviews:opt nat; minJobsCompleted:opt nat}; err:variant {InvalidInput:text; NotFound; Unauthorized}}",
     ],
   },
   "getQuotesForRequest": {

--- a/frontend/src/__tests__/services/__snapshots__/candidContracts.test.ts.snap
+++ b/frontend/src/__tests__/services/__snapshots__/candidContracts.test.ts.snap
@@ -193,7 +193,7 @@ exports[`Candid contract snapshots — method arity > quote 1`] = `
 "acceptQuote(1) -> (1)
 cancelQuoteRequest(1) -> (1)
 closeQuoteRequest(1) -> (1)
-createQuoteRequest(5) -> (1)
+createQuoteRequest(9) -> (1)
 getMyQuoteRequests(0) -> (1) [query]
 getMyQuotes(0) -> (1) [query]
 getOpenRequests(0) -> (1) [query]

--- a/frontend/src/pages/ContractorDashboardPage.tsx
+++ b/frontend/src/pages/ContractorDashboardPage.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { Briefcase, Star, Zap, Clock, ChevronDown, ChevronUp, X, Send, UserCog, PenLine, CheckCircle2 } from "lucide-react";
+import { Briefcase, Star, Zap, Clock, ChevronDown, ChevronUp, X, Send, UserCog, PenLine, CheckCircle2, Lock } from "lucide-react";
 import { Layout } from "@/components/Layout";
 import { Button } from "@/components/Button";
 import { Badge } from "@/components/Badge";
@@ -164,17 +164,40 @@ function SubmitQuoteModal({ request, onSubmit, onClose }: SubmitModalProps) {
 
 // ─── Lead Card ───────────────────────────────────────────────────────────────
 
+interface ContractorStats {
+  trustScore:    number;
+  jobsCompleted: number;
+  reviewCount:   number;
+  isVerified:    boolean;
+}
+
 interface LeadCardProps {
   request: QuoteRequest;
   alreadyQuoted: boolean;
   isNew: boolean;
   onQuote: (r: QuoteRequest) => void;
+  contractorStats: ContractorStats | null;
 }
 
-function LeadCard({ request, alreadyQuoted, isNew, onQuote }: LeadCardProps) {
+/** Returns an array of human-readable reasons why this request is locked, or [] if open. */
+function getLockReasons(req: QuoteRequest, stats: ContractorStats | null): string[] {
+  if (!stats || stats.isVerified) return [];
+  const reasons: string[] = [];
+  if (req.minTrustScore    != null && stats.trustScore    < req.minTrustScore)
+    reasons.push(`${Math.round(req.minTrustScore / 20)}★ minimum rating (your score: ${Math.round(stats.trustScore / 20)}★)`);
+  if (req.minJobsCompleted != null && stats.jobsCompleted < req.minJobsCompleted)
+    reasons.push(`${req.minJobsCompleted} completed jobs required (you have ${stats.jobsCompleted})`);
+  if (req.minReviews       != null && stats.reviewCount   < req.minReviews)
+    reasons.push(`${req.minReviews} reviews required (you have ${stats.reviewCount})`);
+  return reasons;
+}
+
+function LeadCard({ request, alreadyQuoted, isNew, onQuote, contractorStats }: LeadCardProps) {
   const [expanded, setExpanded] = useState(false);
   const color = URGENCY_COLOR[request.urgency] ?? UI.inkLight;
   const bg    = URGENCY_BG[request.urgency]    ?? UI.paper;
+  const lockReasons = getLockReasons(request, contractorStats);
+  const isLocked = lockReasons.length > 0;
 
   return (
     <div style={{
@@ -227,7 +250,22 @@ function LeadCard({ request, alreadyQuoted, isNew, onQuote }: LeadCardProps) {
           <div style={{ display: "flex", gap: "1.5rem", fontFamily: UI.mono, fontSize: "0.6rem", color: UI.inkLight, marginBottom: "1rem" }}>
             <span>Request ID: <strong style={{ color: UI.ink }}>{request.id}</strong></span>
           </div>
-          {alreadyQuoted ? (
+
+          {isLocked ? (
+            <div style={{ border: `1px solid ${UI.rule}`, padding: "0.875rem 1rem" }}>
+              <div style={{ display: "flex", alignItems: "center", gap: "0.375rem", fontFamily: UI.mono, fontSize: "0.6rem", letterSpacing: "0.08em", textTransform: "uppercase", color: UI.inkLight, marginBottom: "0.5rem" }}>
+                <Lock size={11} /> Requirements not met
+              </div>
+              {lockReasons.map((r) => (
+                <p key={r} style={{ fontFamily: UI.mono, fontSize: "0.6rem", color: UI.inkLight, lineHeight: 1.6 }}>
+                  · {r}
+                </p>
+              ))}
+              <p style={{ fontFamily: UI.mono, fontSize: "0.55rem", color: UI.inkLight, marginTop: "0.5rem", lineHeight: 1.5 }}>
+                Complete more verified jobs to unlock this request.
+              </p>
+            </div>
+          ) : alreadyQuoted ? (
             <div style={{ display: "inline-flex", alignItems: "center", gap: "0.375rem", padding: "0.5rem 1rem", border: `1px solid ${UI.sage}`, fontFamily: UI.mono, fontSize: "0.65rem", letterSpacing: "0.08em", textTransform: "uppercase", color: UI.sage }}>
               Quote submitted
             </div>
@@ -253,6 +291,7 @@ export default function ContractorDashboardPage() {
   const navigate        = useNavigate();
   const { lastLoginAt } = useAuthStore();
   const [profile,       setProfile]       = useState<ContractorProfile | null>(null);
+  const [reviewCount,   setReviewCount]   = useState(0);
   const [openRequests,  setOpenRequests]  = useState<QuoteRequest[]>([]);
   const [pendingJobs,   setPendingJobs]   = useState<Job[]>([]);
   const [myBids,        setMyBids]        = useState<Quote[]>([]);
@@ -267,7 +306,17 @@ export default function ContractorDashboardPage() {
 
   useEffect(() => {
     Promise.all([
-      contractorService.getMyProfile().then(setProfile).catch((e) => console.error("[ContractorDashboard] profile load failed:", e)),
+      contractorService.getMyProfile()
+        .then((p) => {
+          setProfile(p);
+          // Fetch review count once we have the profile's principal ID
+          if (p?.id) {
+            contractorService.getReviewsForContractor(p.id)
+              .then((rs) => setReviewCount(rs.length))
+              .catch(() => {});
+          }
+        })
+        .catch((e) => console.error("[ContractorDashboard] profile load failed:", e)),
       quoteService.getOpenRequests().then(setOpenRequests).catch((e) => console.error("[ContractorDashboard] open requests load failed:", e)),
       jobService.getJobsPendingMySignature().then(setPendingJobs).catch((e) => console.error("[ContractorDashboard] pending jobs load failed:", e)),
       quoteService.getMyBids().then(setMyBids).catch((e) => console.error("[ContractorDashboard] my bids load failed:", e)),
@@ -311,6 +360,10 @@ export default function ContractorDashboardPage() {
       setSigningJobId(null);
     }
   };
+
+  const contractorStats: ContractorStats | null = profile
+    ? { trustScore: profile.trustScore, jobsCompleted: profile.jobsCompleted, reviewCount, isVerified: profile.isVerified }
+    : null;
 
   const newLeadsCount   = openRequests.filter((r) => !submittedIds.has(r.id)).length;
   const newSinceLogin   = countNew(openRequests, lastLoginAt);
@@ -516,6 +569,7 @@ export default function ContractorDashboardPage() {
                     alreadyQuoted={submittedIds.has(req.id)}
                     isNew={isNewSince(req.createdAt, lastLoginAt)}
                     onQuote={setModalRequest}
+                    contractorStats={contractorStats}
                   />
                 ))}
               </div>

--- a/frontend/src/pages/QuoteRequestPage.tsx
+++ b/frontend/src/pages/QuoteRequestPage.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
-import { ArrowLeft, Send, Zap, User } from "lucide-react";
+import { ArrowLeft, Send, Zap, User, ChevronDown, ChevronUp, Lock } from "lucide-react";
 import { Layout } from "@/components/Layout";
 import { Button } from "@/components/Button";
 import { PhotoQuotaDisplay } from "@/components/PhotoQuotaDisplay";
@@ -52,14 +52,19 @@ export default function QuoteRequestPage() {
   const [tierLimit,   setTierLimit]   = useState(3);
   const [propertyJobs, setPropertyJobs] = useState<Job[]>([]);
   const [priceRange,  setPriceRange]  = useState<PriceRange | null>(null);
+  const [showRequirements, setShowRequirements] = useState(false);
   const [form, setForm] = useState({
-    propertyId:  properties[0] ? String(properties[0].id) : "",
-    serviceType: prefill?.serviceType ?? SERVICE_TYPES[0],
-    subCategory: "",
-    urgency:     "medium" as Urgency,
-    description: "",
-    budgetMin:   "",
-    budgetMax:   "",
+    propertyId:       properties[0] ? String(properties[0].id) : "",
+    serviceType:      prefill?.serviceType ?? SERVICE_TYPES[0],
+    subCategory:      "",
+    urgency:          "medium" as Urgency,
+    description:      "",
+    budgetMin:        "",
+    budgetMax:        "",
+    minRating:        "",   // 1–5 stars; maps to trustScore 0–100
+    minJobsCompleted: "",
+    minReviews:       "",
+    maxBids:          "",   // "" | "3" | "5"
   });
 
   useEffect(() => {
@@ -125,9 +130,15 @@ export default function QuoteRequestPage() {
     if (!form.description.trim()) { toast.error("Please describe the work needed"); return; }
     setLoading(true);
     try {
+      // Map 1–5 star rating to 0–100 trust score (1★=20, 2★=40, … 5★=100)
+      const minTrustScore    = form.minRating        ? Number(form.minRating)        * 20 : undefined;
+      const minJobsCompleted = form.minJobsCompleted ? Number(form.minJobsCompleted)      : undefined;
+      const minReviews       = form.minReviews       ? Number(form.minReviews)             : undefined;
+      const maxBids          = form.maxBids          ? Number(form.maxBids)                : undefined;
       const req = await quoteService.createRequest({
         propertyId: form.propertyId, serviceType: form.serviceType,
         urgency: form.urgency, description: form.description,
+        minTrustScore, minJobsCompleted, minReviews, maxBids,
       });
       toast.success("Quote request sent to contractors!");
       navigate(`/quotes/${req.id}`);
@@ -305,6 +316,90 @@ export default function QuoteRequestPage() {
           <div>
             <label className="form-label" htmlFor="description">Describe the work needed *</label>
             <textarea id="description" className="form-input" rows={4} placeholder="Describe the issue or project in detail. Include any relevant measurements, materials, or constraints." value={form.description} onChange={(e) => update("description", e.target.value)} style={{ resize: "vertical" }} />
+          </div>
+
+          {/* Contractor requirements (collapsed by default) */}
+          <div style={{ border: `1px solid ${UI.rule}` }}>
+            <button
+              type="button"
+              onClick={() => setShowRequirements((v) => !v)}
+              style={{ width: "100%", display: "flex", alignItems: "center", justifyContent: "space-between", padding: "0.875rem 1rem", background: "none", border: "none", cursor: "pointer" }}
+            >
+              <div style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
+                <Lock size={12} color={UI.inkLight} />
+                <span style={{ fontFamily: UI.mono, fontSize: "0.65rem", letterSpacing: "0.1em", textTransform: "uppercase", color: UI.inkLight }}>
+                  Contractor requirements
+                </span>
+                <span style={{ fontFamily: UI.mono, fontSize: "0.55rem", color: UI.inkLight }}>(optional)</span>
+              </div>
+              {showRequirements ? <ChevronUp size={13} color={UI.inkLight} /> : <ChevronDown size={13} color={UI.inkLight} />}
+            </button>
+
+            {showRequirements && (
+              <div style={{ borderTop: `1px solid ${UI.rule}`, padding: "1rem" }}>
+                <p style={{ fontFamily: UI.mono, fontSize: "0.6rem", color: UI.inkLight, marginBottom: "1rem", lineHeight: 1.6 }}>
+                  Only contractors who meet these minimums will see your request.{" "}
+                  <strong style={{ color: UI.ink }}>Verified contractors are always eligible regardless of these minimums.</strong>
+                </p>
+
+                <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "1rem", marginBottom: "1rem" }}>
+                  <div>
+                    <label className="form-label">Min rating (stars)</label>
+                    <select
+                      className="form-input"
+                      value={form.minRating}
+                      onChange={(e) => update("minRating", e.target.value)}
+                    >
+                      <option value="">No minimum</option>
+                      <option value="1">1★ or higher</option>
+                      <option value="2">2★ or higher</option>
+                      <option value="3">3★ or higher</option>
+                      <option value="4">4★ or higher</option>
+                      <option value="5">5★ only</option>
+                    </select>
+                  </div>
+                  <div>
+                    <label className="form-label">Max bids</label>
+                    <select
+                      className="form-input"
+                      value={form.maxBids}
+                      onChange={(e) => update("maxBids", e.target.value)}
+                    >
+                      <option value="">Unlimited</option>
+                      <option value="3">3 bids</option>
+                      <option value="5">5 bids</option>
+                    </select>
+                  </div>
+                </div>
+
+                <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "1rem" }}>
+                  <div>
+                    <label className="form-label">Min completed jobs</label>
+                    <input
+                      type="number" min="0" placeholder="e.g. 5"
+                      className="form-input"
+                      value={form.minJobsCompleted}
+                      onChange={(e) => update("minJobsCompleted", e.target.value)}
+                    />
+                  </div>
+                  <div>
+                    <label className="form-label">Min reviews</label>
+                    <input
+                      type="number" min="0" placeholder="e.g. 3"
+                      className="form-input"
+                      value={form.minReviews}
+                      onChange={(e) => update("minReviews", e.target.value)}
+                    />
+                  </div>
+                </div>
+
+                {(form.minRating || form.minJobsCompleted || form.minReviews || form.maxBids) && (
+                  <p style={{ fontFamily: UI.mono, fontSize: "0.55rem", color: UI.rust, marginTop: "0.75rem", lineHeight: 1.6 }}>
+                    Filters active — fewer contractors may qualify. If no bids arrive, consider relaxing the requirements.
+                  </p>
+                )}
+              </div>
+            )}
           </div>
 
           <Button loading={loading} disabled={atLimit} onClick={handleSubmit} icon={<Send size={14} />} size="lg" style={{ width: "100%" }}>

--- a/frontend/src/pages/QuoteRequestPage.tsx
+++ b/frontend/src/pages/QuoteRequestPage.tsx
@@ -344,8 +344,9 @@ export default function QuoteRequestPage() {
 
                 <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "1rem", marginBottom: "1rem" }}>
                   <div>
-                    <label className="form-label">Min rating (stars)</label>
+                    <label className="form-label" htmlFor="min-rating">Min rating (stars)</label>
                     <select
+                      id="min-rating"
                       className="form-input"
                       value={form.minRating}
                       onChange={(e) => update("minRating", e.target.value)}
@@ -359,8 +360,9 @@ export default function QuoteRequestPage() {
                     </select>
                   </div>
                   <div>
-                    <label className="form-label">Max bids</label>
+                    <label className="form-label" htmlFor="max-bids">Max bids</label>
                     <select
+                      id="max-bids"
                       className="form-input"
                       value={form.maxBids}
                       onChange={(e) => update("maxBids", e.target.value)}
@@ -374,8 +376,9 @@ export default function QuoteRequestPage() {
 
                 <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "1rem" }}>
                   <div>
-                    <label className="form-label">Min completed jobs</label>
+                    <label className="form-label" htmlFor="min-jobs-completed">Min completed jobs</label>
                     <input
+                      id="min-jobs-completed"
                       type="number" min="0" placeholder="e.g. 5"
                       className="form-input"
                       value={form.minJobsCompleted}
@@ -383,8 +386,9 @@ export default function QuoteRequestPage() {
                     />
                   </div>
                   <div>
-                    <label className="form-label">Min reviews</label>
+                    <label className="form-label" htmlFor="min-reviews">Min reviews</label>
                     <input
+                      id="min-reviews"
                       type="number" min="0" placeholder="e.g. 3"
                       className="form-input"
                       value={form.minReviews}

--- a/frontend/src/services/contractor.ts
+++ b/frontend/src/services/contractor.ts
@@ -312,6 +312,20 @@ function createContractorService() {
     }));
   },
 
+  async getReviewsForContractor(principalText: string): Promise<{ id: string; rating: number; comment: string; jobId: string; createdAt: number }[]> {
+    if (typeof window !== "undefined" && (window as any).__e2e_properties) return [];
+    const { Principal: P } = await import("@icp-sdk/core/principal");
+    const a = await getActor();
+    const raw = await a.getReviewsForContractor(P.fromText(principalText)) as any[];
+    return raw.map((r: any) => ({
+      id:        r.id,
+      rating:    Number(r.rating),
+      comment:   r.comment,
+      jobId:     r.jobId,
+      createdAt: Number(r.createdAt) / 1_000_000,
+    }));
+  },
+
   async getBySpecialty(specialty: string): Promise<ContractorProfile[]> {
     const a = await getActor();
     const result = await a.getBySpecialty({ [specialty]: null }) as any[];

--- a/frontend/src/services/quote.ts
+++ b/frontend/src/services/quote.ts
@@ -20,16 +20,20 @@ export const idlFactory = ({ IDL }: any) => {
     Pending: IDL.Null, Accepted: IDL.Null, Rejected: IDL.Null, Expired: IDL.Null,
   });
   const QuoteRequest = IDL.Record({
-    id:          IDL.Text,
-    propertyId:  IDL.Text,
-    homeowner:   IDL.Principal,
-    serviceType: ServiceType,
-    description: IDL.Text,
-    urgency:     UrgencyLevel,
-    status:      RequestStatus,
-    zipCode:     IDL.Opt(IDL.Text),
-    createdAt:   IDL.Int,
-    closeAt:     IDL.Opt(IDL.Int),
+    id:               IDL.Text,
+    propertyId:       IDL.Text,
+    homeowner:        IDL.Principal,
+    serviceType:      ServiceType,
+    description:      IDL.Text,
+    urgency:          UrgencyLevel,
+    status:           RequestStatus,
+    zipCode:          IDL.Opt(IDL.Text),
+    createdAt:        IDL.Int,
+    closeAt:          IDL.Opt(IDL.Int),
+    minTrustScore:    IDL.Opt(IDL.Nat),
+    minJobsCompleted: IDL.Opt(IDL.Nat),
+    minReviews:       IDL.Opt(IDL.Nat),
+    maxBids:          IDL.Opt(IDL.Nat),
   });
   const Quote = IDL.Record({
     id:         IDL.Text,
@@ -48,7 +52,8 @@ export const idlFactory = ({ IDL }: any) => {
   });
   return IDL.Service({
     createQuoteRequest: IDL.Func(
-      [IDL.Text, ServiceType, IDL.Text, UrgencyLevel, IDL.Opt(IDL.Text)],
+      [IDL.Text, ServiceType, IDL.Text, UrgencyLevel, IDL.Opt(IDL.Text),
+       IDL.Opt(IDL.Nat), IDL.Opt(IDL.Nat), IDL.Opt(IDL.Nat), IDL.Opt(IDL.Nat)],
       [IDL.Variant({ ok: QuoteRequest, err: Error })],
       []
     ),
@@ -101,16 +106,20 @@ export type QuoteRequestStatus = "open" | "quoted" | "accepted" | "closed" | "ca
 export type QuoteStatus = "pending" | "accepted" | "rejected" | "expired";
 
 export interface QuoteRequest {
-  id:          string;
-  propertyId:  string;
-  homeowner:   string;   // principal text
-  serviceType: string;
-  urgency:     Urgency;
-  description: string;
-  status:      QuoteRequestStatus;
-  zipCode?:    string;   // 5-digit zip for location filtering; undefined = visible to all
-  createdAt:   number;   // ms
-  closeAt?:    number;   // ms — bid window close time; undefined = no sealed-bid window
+  id:               string;
+  propertyId:       string;
+  homeowner:        string;   // principal text
+  serviceType:      string;
+  urgency:          Urgency;
+  description:      string;
+  status:           QuoteRequestStatus;
+  zipCode?:         string;   // 5-digit zip for location filtering; undefined = visible to all
+  createdAt:        number;   // ms
+  closeAt?:         number;   // ms — bid window close time; undefined = no sealed-bid window
+  minTrustScore?:   number;   // contractor trustScore must be >= this
+  minJobsCompleted?: number;  // contractor jobsCompleted must be >= this
+  minReviews?:      number;   // contractor reviewCount must be >= this
+  maxBids?:         number;   // max bids cap (3 or 5)
 }
 
 export interface Quote {
@@ -144,21 +153,33 @@ function mapVariant<T>(map: Record<string, T>, raw: any, field: string): T {
 }
 
 function fromRequest(raw: any): QuoteRequest {
-  const closeAtArr = raw.closeAt as bigint[] | undefined;
-  const zipArr = raw.zipCode as string[] | undefined;
+  const closeAtArr          = raw.closeAt          as bigint[]  | undefined;
+  const zipArr              = raw.zipCode           as string[]  | undefined;
+  const minTrustScoreArr    = raw.minTrustScore     as bigint[]  | undefined;
+  const minJobsCompletedArr = raw.minJobsCompleted  as bigint[]  | undefined;
+  const minReviewsArr       = raw.minReviews        as bigint[]  | undefined;
+  const maxBidsArr          = raw.maxBids           as bigint[]  | undefined;
   return {
-    id:          raw.id,
-    propertyId:  raw.propertyId,
-    homeowner:   raw.homeowner.toText(),
-    serviceType: Object.keys(raw.serviceType)[0],
-    urgency:     mapVariant(URGENCY_MAP, raw.urgency, "urgency"),
-    description: raw.description,
-    status:      mapVariant(REQUEST_STATUS_MAP, raw.status, "requestStatus"),
-    zipCode:     zipArr && zipArr.length > 0 ? zipArr[0] : undefined,
-    createdAt:   Number(raw.createdAt) / 1_000_000,
-    closeAt:     closeAtArr && closeAtArr.length > 0
-                   ? Number(closeAtArr[0]) / 1_000_000
-                   : undefined,
+    id:               raw.id,
+    propertyId:       raw.propertyId,
+    homeowner:        raw.homeowner.toText(),
+    serviceType:      Object.keys(raw.serviceType)[0],
+    urgency:          mapVariant(URGENCY_MAP, raw.urgency, "urgency"),
+    description:      raw.description,
+    status:           mapVariant(REQUEST_STATUS_MAP, raw.status, "requestStatus"),
+    zipCode:          zipArr && zipArr.length > 0 ? zipArr[0] : undefined,
+    createdAt:        Number(raw.createdAt) / 1_000_000,
+    closeAt:          closeAtArr && closeAtArr.length > 0
+                        ? Number(closeAtArr[0]) / 1_000_000
+                        : undefined,
+    minTrustScore:    minTrustScoreArr && minTrustScoreArr.length > 0
+                        ? Number(minTrustScoreArr[0]) : undefined,
+    minJobsCompleted: minJobsCompletedArr && minJobsCompletedArr.length > 0
+                        ? Number(minJobsCompletedArr[0]) : undefined,
+    minReviews:       minReviewsArr && minReviewsArr.length > 0
+                        ? Number(minReviewsArr[0]) : undefined,
+    maxBids:          maxBidsArr && maxBidsArr.length > 0
+                        ? Number(maxBidsArr[0]) : undefined,
   };
 }
 
@@ -225,7 +246,11 @@ function createQuoteService() {
       { [req.serviceType]: null },
       req.description,
       { [urgencyKey]: null },
-      req.zipCode ? [req.zipCode] : []
+      req.zipCode        ? [req.zipCode]                             : [],
+      req.minTrustScore    != null ? [BigInt(req.minTrustScore)]    : [],
+      req.minJobsCompleted != null ? [BigInt(req.minJobsCompleted)] : [],
+      req.minReviews       != null ? [BigInt(req.minReviews)]       : [],
+      req.maxBids          != null ? [BigInt(req.maxBids)]          : []
     );
     return unwrapRequest(result);
   },

--- a/scripts/seed.sh
+++ b/scripts/seed.sh
@@ -281,7 +281,8 @@ if [ -n "$PROP1_ID" ]; then
     \"$PROP1_ID\",
     variant { Electrical },
     \"Breaker keeps tripping on kitchen circuit. GFCIs installed but issue persists. 200A panel, house built 1998.\",
-    variant { Medium }
+    variant { Medium },
+    null, null, null, null, null
   )" 2>/dev/null || echo "")
   echo "$REQ_OUT"
   REQ1_ID=$(echo "$REQ_OUT" | grep -oP '"REQ_[^"]+"' | head -1 | tr -d '"' || true)
@@ -292,7 +293,8 @@ if [ -n "$PROP1_ID" ]; then
       \"$PROP2_ID\",
       variant { Plumbing },
       \"Slow drain in master bathroom. Snaking has not resolved it — may need hydro-jetting.\",
-      variant { Low }
+      variant { Low },
+      null, null, null, null, null
     )" 2>/dev/null || echo "  ↳ Quote request 2 skipped (ok)"
   fi
 

--- a/scripts/test-cross-canister.sh
+++ b/scripts/test-cross-canister.sh
@@ -131,7 +131,8 @@ for I in 1 2 3; do
     \"PROP_XCANISTER_1\",
     variant { Roofing },
     \"Cross-canister tier test request $I.\",
-    variant { Low }
+    variant { Low },
+    null, null, null, null, null
   )" > /dev/null && echo "    → Request $I created"
 done
 
@@ -141,7 +142,8 @@ dfx canister call quote createQuoteRequest '(
   "PROP_XCANISTER_1",
   variant { Roofing },
   "4th request should fail on Free tier.",
-  variant { Low }
+  variant { Low },
+  null, null, null, null, null
 )' && echo "  ⚠️  Created — limit not enforced" \
   || echo "  ✓ Free tier limit (3 open requests) enforced"
 
@@ -155,7 +157,8 @@ dfx canister call quote createQuoteRequest '(
   "PROP_XCANISTER_1",
   variant { Roofing },
   "4th request should succeed on Pro tier.",
-  variant { Low }
+  variant { Low },
+  null, null, null, null, null
 )' && echo "  ✓ Pro tier allows more than 3 open requests" \
   || echo "  ⚠️  Failed — tier upgrade may not have taken effect"
 

--- a/tests/e2e/quote-flow.spec.ts
+++ b/tests/e2e/quote-flow.spec.ts
@@ -207,6 +207,49 @@ test.describe("QF — accept bid flow", () => {
   });
 });
 
+// ── QF.5e — Contractor requirements section ───────────────────────────────────
+
+test.describe("QF — contractor requirements section", () => {
+  test.beforeEach(async ({ page }) => {
+    await injectTestAuth(page);
+    await injectSubscription(page);
+    await injectTestProperties(page);
+  });
+
+  // QF.5e-1 — section toggle is present, collapsed by default
+  test("'Contractor requirements' toggle is visible and section is collapsed by default", async ({ page }) => {
+    await page.goto("/quotes/new");
+    await expect(page.getByText(/contractor requirements/i)).toBeVisible();
+    // Min rating select is hidden while collapsed
+    await expect(page.getByLabel(/min rating/i)).not.toBeVisible();
+  });
+
+  // QF.5e-2 — toggling expands all four inputs
+  test("expanding the section reveals all four requirement inputs", async ({ page }) => {
+    await page.goto("/quotes/new");
+    await page.getByText(/contractor requirements/i).click();
+    await expect(page.getByLabel(/min rating/i)).toBeVisible();
+    await expect(page.getByLabel(/min completed jobs/i)).toBeVisible();
+    await expect(page.getByLabel(/min reviews/i)).toBeVisible();
+    await expect(page.getByLabel(/max bids/i)).toBeVisible();
+  });
+
+  // QF.5e-3 — verified contractor helper text is shown when expanded
+  test("helper text about verified contractors appears when expanded", async ({ page }) => {
+    await page.goto("/quotes/new");
+    await page.getByText(/contractor requirements/i).click();
+    await expect(page.getByText(/verified contractors are always eligible/i)).toBeVisible();
+  });
+
+  // QF.5e-4 — filter warning shown when any requirement is set
+  test("shows filter-active warning when a requirement is selected", async ({ page }) => {
+    await page.goto("/quotes/new");
+    await page.getByText(/contractor requirements/i).click();
+    await page.getByLabel(/max bids/i).selectOption("3");
+    await expect(page.getByText(/filters active/i)).toBeVisible();
+  });
+});
+
 // ── QF.6 & QF.7 — Tier limit enforcement ─────────────────────────────────────
 
 test.describe("QF — open-quote tier limit", () => {


### PR DESCRIPTION
## Summary

- Homeowners can now set optional quality thresholds on quote requests: minimum rating (1–5★ → trust score), minimum completed jobs, minimum reviews, and a max-bid cap (3 or 5)
- Contractor canister: new `getContractorStats` query returns all needed fields (trustScore, jobsCompleted, reviewCount, isVerified, serviceZips) in a single cross-canister call
- Quote canister: `getOpenRequestsForMe()` cross-calls `getContractorStats` and filters out requests where the caller's stats fall below thresholds; `isVerified = true` bypasses all thresholds; `submitQuote` enforces the `maxBids` cap
- Frontend: `QuoteRequestPage` gains a collapsible "Contractor requirements" section (collapsed by default) with all four inputs and a filter-active warning
- Frontend: `ContractorDashboardPage` `LeadCard` shows a per-reason locked state when the contractor doesn't meet thresholds, with guidance to complete more verified jobs

## Test plan

- [ ] `npm run test:e2e` — 4 new QF.5e tests pass (requirements toggle, inputs visible, helper text, filter-active warning)
- [ ] Existing QF.1–QF.7 tests unaffected (new section is collapsed, doesn't interfere)
- [ ] Existing CD contractor-dashboard tests unaffected (locked state only appears when `minTrustScore`/`minJobsCompleted`/`minReviews` fields are set, which injected E2E requests don't set)
- [ ] Manual: create request with min rating 3★ → only contractors with trustScore ≥ 60 appear in their `getOpenRequestsForMe()`
- [ ] Manual: create request with maxBids=3, submit 3 bids from different contractors → 4th bid returns error "reached its maximum"
- [ ] Manual: verified contractor with trustScore=0 still sees a high-threshold request

🤖 Generated with [Claude Code](https://claude.com/claude-code)