### PR TITLE
feat(report): machine-readable property risk profile for insurance carriers (#278)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,6 +178,8 @@ jobs:
           dfx canister call contractor  setJobCanisterId        "(\"$JOB_ID\")"
           dfx canister call sensor      setJobCanisterId        "(\"$JOB_ID\")"
           dfx canister call report      setPropertyCanisterId   "(\"$PROPERTY_ID\")"
+          dfx canister call report      setSensorCanisterId     "(\"$SENSOR_ID\")"
+          dfx canister call report      setRiskJobCanisterId    "(\"$JOB_ID\")"
 
           # ── Tier propagation wiring ──────────────────────────────────────────
           dfx canister call property addAdmin "(principal \"$PAYMENT_ID\")"
@@ -287,6 +289,8 @@ jobs:
           dfx canister call contractor  setJobCanisterId        "(\"$JOB_ID\")"
           dfx canister call sensor      setJobCanisterId        "(\"$JOB_ID\")"
           dfx canister call report      setPropertyCanisterId   "(\"$PROPERTY_ID\")"
+          dfx canister call report      setSensorCanisterId     "(\"$SENSOR_ID\")"
+          dfx canister call report      setRiskJobCanisterId    "(\"$JOB_ID\")"
 
           dfx canister call property addAdmin "(principal \"$PAYMENT_ID\")"
           dfx canister call quote    addAdmin "(principal \"$PAYMENT_ID\")"

--- a/backend/report/main.mo
+++ b/backend/report/main.mo
@@ -603,6 +603,325 @@ persistent actor Report {
     #ok(())
   };
 
+  // ─── Risk Profile API (#278) ──────────────────────────────────────────────────
+
+  /// Per-device summary included in RiskProfile.
+  public type SensorSummary = {
+    deviceId:    Text;
+    name:        Text;
+    source:      Text;   // "Nest" | "Ecobee" | …
+    isActive:    Bool;
+    lastEventAt: ?Int;   // ns timestamp, null = no events recorded
+    eventCount:  Nat;
+  };
+
+  /// Per-alert summary (Critical/Warning) included in RiskProfile.
+  public type AlertSummary = {
+    alertId:   Text;
+    eventType: Text;
+    severity:  Text;    // "Critical" | "Warning"
+    timestamp: Int;     // ns
+    resolvedByJobId: ?Text;   // null = still open
+  };
+
+  /// Machine-readable property health report for insurance carrier underwriting.
+  /// Intended for periodic export — always fetched live from job/sensor canisters.
+  public type RiskProfile = {
+    schemaVersion:    Text;   // "homegentic-risk/1.0"
+    token:            Text;
+    propertyId:       Text;
+    generatedAt:      Int;
+    expiresAt:        ?Int;   // null = never
+    maintenanceScore: Nat;    // 0-100
+    verificationLevel: Text;
+    sensorCoverage:   [SensorSummary];
+    recentAlerts:     [AlertSummary];
+    openJobs:         Nat;
+    verifiedJobCount: Nat;
+    permitCount:      Nat;
+  };
+
+  public type RiskProfileError = {
+    #NotFound;
+    #Expired;
+    #Unauthorized;
+    #InvalidInput : Text;
+  };
+
+  // ─── Risk Profile Stable State ───────────────────────────────────────────────
+
+  private var sensorCanisterId : Text = "";
+  private var riskJobCanisterId : Text = "";
+
+  private let riskProfiles = Map.empty<Text, RiskProfile>();
+
+  // ─── Risk Profile Helpers ────────────────────────────────────────────────────
+
+  private func computeMaintenanceScore(
+    alerts:          [AlertSummary],
+    openOldJobCount: Nat,
+    verifiedWithPermit: Nat,
+    hasSensors:      Bool,
+    isVerified:      Bool
+  ) : Nat {
+    var score : Int = 100;
+
+    // −5 per unresolved Critical alert, cap −30
+    var critPenalty : Int = 0;
+    for (a in alerts.vals()) {
+      if (a.severity == "Critical" and a.resolvedByJobId == null) {
+        critPenalty += 5;
+      }
+    };
+    if (critPenalty > 30) { critPenalty := 30 };
+    score -= critPenalty;
+
+    // −3 per open job older than 90 days, cap −20
+    var oldJobPenalty : Int = openOldJobCount * 3;
+    if (oldJobPenalty > 20) { oldJobPenalty := 20 };
+    score -= oldJobPenalty;
+
+    // +5 per verified job with permit, cap +20
+    var permitBonus : Int = verifiedWithPermit * 5;
+    if (permitBonus > 20) { permitBonus := 20 };
+    score += permitBonus;
+
+    // −10 if no sensor coverage
+    if (not hasSensors) { score -= 10 };
+
+    // −15 if unverified
+    if (not isVerified) { score -= 15 };
+
+    // clamp 0–100
+    if (score < 0) { 0 } else if (score > 100) { 100 } else { Int.abs(score) }
+  };
+
+  /// Generate a time-limited risk profile token. Fetches live data from
+  /// job and sensor canisters via cross-canister queries.
+  public shared(msg) func generateRiskProfile(
+    propertyId:     Text,
+    expiryDays:     ?Nat,
+    verificationLevel: Text
+  ) : async Result.Result<RiskProfile, RiskProfileError> {
+    if (Principal.isAnonymous(msg.caller)) return #err(#Unauthorized);
+    if (Text.size(propertyId) == 0) return #err(#InvalidInput("propertyId required"));
+
+    let now = Time.now();
+    let NINETY_DAYS_NS : Int = 90 * 24 * 3600 * 1_000_000_000;
+
+    // ── Fetch sensor data ───────────────────────────────────────────────────
+    var sensorCoverage : [SensorSummary] = [];
+    var recentAlerts   : [AlertSummary]  = [];
+
+    if (Text.size(sensorCanisterId) > 0) {
+      let sensorActor = actor(sensorCanisterId) : actor {
+        getDevicesForProperty : (Text)        -> async [{
+          id: Text; name: Text; source: { #Nest; #Ecobee; #MoenFlo; #Manual;
+            #RingAlarm; #HoneywellHome; #RheemEcoNet; #Sense;
+            #EmporiaVue; #Rachio; #SmartThings; #HomeAssistant;
+            #EnphaseEnvoy; #TeslaPowerwall; #LGThinQ; #GESmartHQ; };
+          isActive: Bool; registeredAt: Int; propertyId: Text; homeowner: Principal;
+          externalDeviceId: Text;
+        }];
+        getEventsForProperty : (Text, Nat)    -> async [{
+          id: Text; eventType: { #WaterLeak; #LeakDetected; #FloodRisk; #LowTemperature;
+            #HvacAlert; #HvacFilterDue; #HighHumidity; #HighTemperature;
+            #SolarFault; #LowProduction; #BatteryLow; #GridOutage;
+            #ApplianceFault; #ApplianceMaintenance; };
+          timestamp: Int; severity: { #Info; #Warning; #Critical }; jobId: ?Text;
+        }];
+      };
+
+      let rawDevices = await sensorActor.getDevicesForProperty(propertyId);
+      sensorCoverage := Array.map(rawDevices, func(d: {
+        id: Text; name: Text; source: { #Nest; #Ecobee; #MoenFlo; #Manual;
+          #RingAlarm; #HoneywellHome; #RheemEcoNet; #Sense;
+          #EmporiaVue; #Rachio; #SmartThings; #HomeAssistant;
+          #EnphaseEnvoy; #TeslaPowerwall; #LGThinQ; #GESmartHQ; };
+        isActive: Bool; registeredAt: Int; propertyId: Text; homeowner: Principal;
+        externalDeviceId: Text;
+      }) : SensorSummary {
+        let sourceName = switch (d.source) {
+          case (#Nest)            { "Nest"            };
+          case (#Ecobee)          { "Ecobee"          };
+          case (#MoenFlo)         { "MoenFlo"         };
+          case (#Manual)          { "Manual"          };
+          case (#RingAlarm)       { "RingAlarm"       };
+          case (#HoneywellHome)   { "HoneywellHome"   };
+          case (#RheemEcoNet)     { "RheemEcoNet"     };
+          case (#Sense)           { "Sense"           };
+          case (#EmporiaVue)      { "EmporiaVue"      };
+          case (#Rachio)          { "Rachio"          };
+          case (#SmartThings)     { "SmartThings"     };
+          case (#HomeAssistant)   { "HomeAssistant"   };
+          case (#EnphaseEnvoy)    { "EnphaseEnvoy"    };
+          case (#TeslaPowerwall)  { "TeslaPowerwall"  };
+          case (#LGThinQ)         { "LGThinQ"         };
+          case (#GESmartHQ)       { "GESmartHQ"       };
+        };
+        { deviceId = d.id; name = d.name; source = sourceName;
+          isActive = d.isActive; lastEventAt = null; eventCount = 0; }
+      });
+
+      let rawEvents = await sensorActor.getEventsForProperty(propertyId, 50);
+      var alertAcc : [AlertSummary] = [];
+      for (e in rawEvents.vals()) {
+        let sev = switch (e.severity) {
+          case (#Critical) { "Critical" };
+          case (#Warning)  { "Warning"  };
+          case (#Info)     { "" };
+        };
+        if (sev != "") {
+          let evtName = switch (e.eventType) {
+            case (#WaterLeak)            { "WaterLeak"            };
+            case (#LeakDetected)         { "LeakDetected"         };
+            case (#FloodRisk)            { "FloodRisk"            };
+            case (#LowTemperature)       { "LowTemperature"       };
+            case (#HvacAlert)            { "HvacAlert"            };
+            case (#HvacFilterDue)        { "HvacFilterDue"        };
+            case (#HighHumidity)         { "HighHumidity"         };
+            case (#HighTemperature)      { "HighTemperature"      };
+            case (#SolarFault)           { "SolarFault"           };
+            case (#LowProduction)        { "LowProduction"        };
+            case (#BatteryLow)           { "BatteryLow"           };
+            case (#GridOutage)           { "GridOutage"           };
+            case (#ApplianceFault)       { "ApplianceFault"       };
+            case (#ApplianceMaintenance) { "ApplianceMaintenance" };
+          };
+          alertAcc := Array.concat(alertAcc, [{
+            alertId = e.id; eventType = evtName; severity = sev;
+            timestamp = e.timestamp; resolvedByJobId = e.jobId;
+          }]);
+        };
+      };
+      recentAlerts := alertAcc;
+    };
+
+    // ── Fetch job data ──────────────────────────────────────────────────────
+    var openJobs         : Nat = 0;
+    var openOldJobCount  : Nat = 0;
+    var verifiedJobCount : Nat = 0;
+    var permitCount      : Nat = 0;
+    var verifiedWithPermit : Nat = 0;
+
+    if (Text.size(riskJobCanisterId) > 0) {
+      let jobActor = actor(riskJobCanisterId) : actor {
+        getJobsForProperty : (Text) -> async {
+          #ok : [{
+            id: Text; propertyId: Text; homeowner: Principal; contractor: ?Principal;
+            title: Text; serviceType: {
+              #Roofing; #HVAC; #Plumbing; #Electrical;
+              #Painting; #Flooring; #Windows; #Landscaping;
+            };
+            description: Text; contractorName: ?Text; amount: Nat;
+            completedDate: Int; permitNumber: ?Text; warrantyMonths: ?Nat;
+            isDiy: Bool; status: {
+              #Pending; #InProgress; #Completed; #Verified;
+              #PendingHomeownerApproval; #RejectedByHomeowner;
+            };
+            verified: Bool; homeownerSigned: Bool; contractorSigned: Bool;
+            createdAt: Int; sourceQuoteId: ?Text;
+          }];
+          #err : { #NotFound; #Unauthorized; #InvalidInput: Text;
+                   #AlreadyVerified; #TierLimitReached: Text; };
+        };
+      };
+
+      let jobResult = await jobActor.getJobsForProperty(propertyId);
+      switch (jobResult) {
+        case (#err(_)) {};
+        case (#ok(allJobs)) {
+          for (j in allJobs.vals()) {
+            let isOpen = switch (j.status) {
+              case (#Pending)    { true };
+              case (#InProgress) { true };
+              case _ { false };
+            };
+            if (isOpen) {
+              openJobs += 1;
+              if (now - j.createdAt > NINETY_DAYS_NS) {
+                openOldJobCount += 1;
+              };
+            };
+            if (j.verified) {
+              verifiedJobCount += 1;
+              switch (j.permitNumber) {
+                case (?_) {
+                  permitCount += 1;
+                  verifiedWithPermit += 1;
+                };
+                case null {};
+              };
+            };
+          };
+        };
+      };
+    };
+
+    // ── Compute score ───────────────────────────────────────────────────────
+    let hasSensors  = sensorCoverage.size() > 0;
+    let isVerifiedProp = verificationLevel != "Unverified" and verificationLevel != "PendingReview";
+    let score = computeMaintenanceScore(
+      recentAlerts, openOldJobCount, verifiedWithPermit, hasSensors, isVerifiedProp
+    );
+
+    // ── Issue token ─────────────────────────────────────────────────────────
+    let randBytes = await Random.blob();
+    let token = "RISK_" # blobToHex(randBytes);
+
+    let expiresAt : ?Int = switch (expiryDays) {
+      case null    { null };
+      case (?days) { ?(now + (days * 24 * 3600 * 1_000_000_000)) };
+    };
+
+    let profile : RiskProfile = {
+      schemaVersion     = "homegentic-risk/1.0";
+      token;
+      propertyId;
+      generatedAt       = now;
+      expiresAt;
+      maintenanceScore  = score;
+      verificationLevel;
+      sensorCoverage;
+      recentAlerts;
+      openJobs;
+      verifiedJobCount;
+      permitCount;
+    };
+    Map.add(riskProfiles, Text.compare, token, profile);
+    #ok(profile)
+  };
+
+  /// Retrieve a previously generated risk profile by token.
+  public query func getRiskProfile(token: Text) : async Result.Result<RiskProfile, RiskProfileError> {
+    switch (Map.get(riskProfiles, Text.compare, token)) {
+      case null { #err(#NotFound) };
+      case (?p) {
+        switch (p.expiresAt) {
+          case (?exp) {
+            if (Time.now() > exp) { return #err(#Expired) };
+          };
+          case null {};
+        };
+        #ok(p)
+      };
+    }
+  };
+
+  /// Wire the report canister to the sensor canister. Admin only.
+  public shared(msg) func setSensorCanisterId(id: Text) : async Result.Result<(), Error> {
+    if (not isAdmin(msg.caller)) return #err(#Unauthorized);
+    sensorCanisterId := id;
+    #ok(())
+  };
+
+  /// Wire the report canister to the job canister for risk profile queries. Admin only.
+  public shared(msg) func setRiskJobCanisterId(id: Text) : async Result.Result<(), Error> {
+    if (not isAdmin(msg.caller)) return #err(#Unauthorized);
+    riskJobCanisterId := id;
+    #ok(())
+  };
+
   // ─── Score Certificate API (4.2.1) ───────────────────────────────────────────
 
   /// Issue an on-chain score certificate. Stores the payload (no personal data)

--- a/frontend/src/__tests__/contracts/__snapshots__/candid.contract.test.ts.snap
+++ b/frontend/src/__tests__/contracts/__snapshots__/candid.contract.test.ts.snap
@@ -1436,6 +1436,17 @@ exports[`report IDL factory > full signature snapshot 1`] = `
       "variant {ok:record {snapshotId:text; token:text; expiresAt:opt int; createdAt:int; createdBy:principal; propertyId:text; isActive:bool; viewCount:nat; visibility:variant {BuyerOnly; Public}}; err:variant {UnverifiedProperty; InvalidInput:text; NotFound; Unauthorized; Revoked; Expired}}",
     ],
   },
+  "generateRiskProfile": {
+    "args": [
+      "text",
+      "opt nat",
+      "text",
+    ],
+    "mode": [],
+    "rets": [
+      "variant {ok:record {sensorCoverage:vec record {source:text; name:text; isActive:bool; deviceId:text; lastEventAt:opt int; eventCount:nat}; token:text; expiresAt:opt int; generatedAt:int; maintenanceScore:nat; propertyId:text; recentAlerts:vec record {alertId:text; resolvedByJobId:opt text; timestamp:int; severity:text; eventType:text}; verificationLevel:text; schemaVersion:text; verifiedJobCount:nat; permitCount:nat; openJobs:nat}; err:variant {InvalidInput:text; NotFound; Unauthorized; Expired}}",
+    ],
+  },
   "getReport": {
     "args": [
       "text",
@@ -1443,6 +1454,17 @@ exports[`report IDL factory > full signature snapshot 1`] = `
     "mode": [],
     "rets": [
       "variant {ok:record {record {snapshotId:text; token:text; expiresAt:opt int; createdAt:int; createdBy:principal; propertyId:text; isActive:bool; viewCount:nat; visibility:variant {BuyerOnly; Public}}; record {snapshotId:text; propertyType:text; city:text; generatedAt:int; generatedBy:principal; jobs:vec record {status:text; serviceType:text; permitNumber:opt text; date:text; description:text; amountCents:nat; isVerified:bool; warrantyMonths:opt nat; isDiy:bool; contractorName:opt text}; squareFeet:nat; propertyId:text; zipCode:text; state:text; totalAmountCents:nat; diyJobCount:nat; address:text; verificationLevel:text; verifiedJobCount:nat; permitCount:nat; yearBuilt:nat; rooms:opt vec record {paintBrand:text; name:text; floorType:text; paintColor:text; fixtureCount:nat; paintCode:text}; recurringServices:vec record {status:text; serviceType:text; lastVisitDate:opt text; providerName:text; totalVisits:nat; frequency:text; startDate:text}}}; err:variant {UnverifiedProperty; InvalidInput:text; NotFound; Unauthorized; Revoked; Expired}}",
+    ],
+  },
+  "getRiskProfile": {
+    "args": [
+      "text",
+    ],
+    "mode": [
+      "query",
+    ],
+    "rets": [
+      "variant {ok:record {sensorCoverage:vec record {source:text; name:text; isActive:bool; deviceId:text; lastEventAt:opt int; eventCount:nat}; token:text; expiresAt:opt int; generatedAt:int; maintenanceScore:nat; propertyId:text; recentAlerts:vec record {alertId:text; resolvedByJobId:opt text; timestamp:int; severity:text; eventType:text}; verificationLevel:text; schemaVersion:text; verifiedJobCount:nat; permitCount:nat; openJobs:nat}; err:variant {InvalidInput:text; NotFound; Unauthorized; Expired}}",
     ],
   },
   "listShareLinks": {

--- a/frontend/src/__tests__/contracts/candid.contract.test.ts
+++ b/frontend/src/__tests__/contracts/candid.contract.test.ts
@@ -503,7 +503,9 @@ describe("report IDL factory", () => {
     const svc = extractService(reportIdlFactory);
     expect(Object.keys(svc).sort()).toEqual([
       "generateReport",
+      "generateRiskProfile",
       "getReport",
+      "getRiskProfile",
       "listShareLinks",
       "revokeShareLink",
     ]);

--- a/frontend/src/__tests__/services/__snapshots__/candidContracts.test.ts.snap
+++ b/frontend/src/__tests__/services/__snapshots__/candidContracts.test.ts.snap
@@ -217,7 +217,9 @@ updateStatus(2) -> (1)"
 
 exports[`Candid contract snapshots — method arity > report 1`] = `
 "generateReport(11) -> (1)
+generateRiskProfile(3) -> (1)
 getReport(1) -> (1)
+getRiskProfile(1) -> (1) [query]
 listShareLinks(1) -> (1)
 revokeShareLink(1) -> (1)"
 `;

--- a/frontend/src/components/InsuranceShareModal.tsx
+++ b/frontend/src/components/InsuranceShareModal.tsx
@@ -1,0 +1,253 @@
+import React, { useState } from "react";
+import { X, Copy, Download, Shield, CheckCircle } from "lucide-react";
+import { Button } from "@/components/Button";
+import { reportService, type RiskProfile } from "@/services/report";
+import type { Property } from "@/services/property";
+import toast from "react-hot-toast";
+import { COLORS, FONTS } from "@/theme";
+
+const UI = {
+  ink:      COLORS.plum,
+  paper:    COLORS.white,
+  rule:     COLORS.rule,
+  rust:     COLORS.sage,
+  inkLight: COLORS.plumMid,
+  serif:    FONTS.serif,
+  mono:     FONTS.sans,
+};
+
+const EXPIRY_OPTIONS = [
+  { label: "30 days",  value: 30 },
+  { label: "90 days",  value: 90 },
+  { label: "1 year",   value: 365 },
+  { label: "Never",    value: null },
+] as const;
+
+const GRADE_COLORS: Record<string, string> = {
+  A: "#2a7a4b",
+  B: "#4a8f3f",
+  C: "#d4a017",
+  D: "#c97a1a",
+  F: "#c94c2e",
+};
+
+interface InsuranceShareModalProps {
+  property: Property;
+  onClose:  () => void;
+}
+
+export function InsuranceShareModal({ property, onClose }: InsuranceShareModalProps) {
+  const [profile,    setProfile]    = useState<RiskProfile | null>(null);
+  const [generating, setGenerating] = useState(false);
+  const [copied,     setCopied]     = useState(false);
+  const [expiryDays, setExpiryDays] = useState<number | null>(90);
+
+  const propertyId       = String(property.id);
+  const verificationLevel = property.verificationLevel ?? "Unverified";
+
+  const handleGenerate = async () => {
+    setGenerating(true);
+    try {
+      const p = await reportService.generateRiskProfile(propertyId, verificationLevel, expiryDays);
+      setProfile(p);
+    } catch (err: any) {
+      toast.error(err?.message ?? "Failed to generate risk profile");
+    } finally {
+      setGenerating(false);
+    }
+  };
+
+  const handleCopy = async () => {
+    if (!profile) return;
+    const url = reportService.riskProfileUrl(profile.token);
+    await navigator.clipboard.writeText(url);
+    setCopied(true);
+    toast.success("Link copied");
+    setTimeout(() => setCopied(false), 2500);
+  };
+
+  const handleDownload = () => {
+    if (!profile) return;
+    const json = JSON.stringify({
+      schema:           profile.schemaVersion,
+      token:            profile.token,
+      verificationUrl:  reportService.riskProfileUrl(profile.token),
+      propertyId:       profile.propertyId,
+      generatedAt:      new Date(profile.generatedAt).toISOString(),
+      expiresAt:        profile.expiresAt ? new Date(profile.expiresAt).toISOString() : null,
+      maintenanceScore: profile.maintenanceScore,
+      grade:            reportService.maintenanceGrade(profile.maintenanceScore),
+      verificationLevel: profile.verificationLevel,
+      sensorCoverage:   profile.sensorCoverage,
+      recentAlerts:     profile.recentAlerts,
+      openIssues:       profile.openJobs,
+      verifiedJobs:     profile.verifiedJobCount,
+      permittedWork:    profile.permitCount,
+    }, null, 2);
+    const blob = new Blob([json], { type: "application/json" });
+    const url  = URL.createObjectURL(blob);
+    const a    = document.createElement("a");
+    a.href     = url;
+    a.download = `homegentic-risk-${propertyId}-${Date.now()}.json`;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const grade       = profile ? reportService.maintenanceGrade(profile.maintenanceScore) : null;
+  const gradeColor  = grade ? GRADE_COLORS[grade] ?? UI.ink : UI.ink;
+  const shareUrl    = profile ? reportService.riskProfileUrl(profile.token) : "";
+
+  return (
+    <div style={{
+      position: "fixed", inset: 0, background: "rgba(14,14,12,0.55)",
+      display: "flex", alignItems: "center", justifyContent: "center",
+      zIndex: 1000, padding: "1rem",
+    }}>
+      <div style={{
+        background: UI.paper, border: `1px solid ${UI.rule}`,
+        maxWidth: 540, width: "100%", padding: "2rem",
+        boxShadow: "0 8px 32px rgba(14,14,12,0.18)",
+        display: "flex", flexDirection: "column", gap: "1.5rem",
+        maxHeight: "90vh", overflowY: "auto",
+      }}>
+        {/* Header */}
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start" }}>
+          <div>
+            <div style={{ display: "flex", alignItems: "center", gap: "0.5rem", marginBottom: "0.25rem" }}>
+              <Shield size={18} color={UI.rust} />
+              <span style={{ fontFamily: UI.mono, fontSize: "0.65rem", textTransform: "uppercase", letterSpacing: "0.08em", color: UI.rust }}>
+                Insurance Risk Report
+              </span>
+            </div>
+            <h2 style={{ fontFamily: UI.serif, fontSize: "1.3rem", fontWeight: 700, color: UI.ink, margin: 0 }}>
+              Share with Carrier
+            </h2>
+            <p style={{ fontFamily: UI.mono, fontSize: "0.75rem", color: UI.inkLight, margin: "0.25rem 0 0" }}>
+              {property.address}
+            </p>
+          </div>
+          <button onClick={onClose} style={{ background: "none", border: "none", cursor: "pointer", color: UI.inkLight, padding: "0.25rem" }}>
+            <X size={20} />
+          </button>
+        </div>
+
+        {!profile ? (
+          <>
+            {/* Expiry selector */}
+            <div>
+              <label style={{ fontFamily: UI.mono, fontSize: "0.65rem", textTransform: "uppercase", letterSpacing: "0.08em", color: UI.inkLight, display: "block", marginBottom: "0.5rem" }}>
+                Link expiry
+              </label>
+              <div style={{ display: "flex", gap: "0.5rem", flexWrap: "wrap" }}>
+                {EXPIRY_OPTIONS.map((opt) => (
+                  <button
+                    key={String(opt.value)}
+                    onClick={() => setExpiryDays(opt.value)}
+                    style={{
+                      padding: "0.35rem 0.75rem",
+                      border: `1px solid ${expiryDays === opt.value ? UI.rust : UI.rule}`,
+                      background: expiryDays === opt.value ? UI.rust : "transparent",
+                      color: expiryDays === opt.value ? UI.paper : UI.ink,
+                      fontFamily: UI.mono, fontSize: "0.75rem",
+                      cursor: "pointer",
+                    }}
+                  >
+                    {opt.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            <div style={{ fontSize: "0.8rem", fontFamily: UI.mono, color: UI.inkLight, background: "#f9f7f3", border: `1px solid ${UI.rule}`, padding: "0.85rem 1rem", lineHeight: 1.6 }}>
+              Generates a machine-readable JSON report with your property's maintenance score, sensor coverage, open alerts, and verified work history. Share the link with your insurance carrier for underwriting.
+            </div>
+
+            <Button onClick={handleGenerate} disabled={generating} style={{ alignSelf: "flex-start" }}>
+              {generating ? "Generating…" : "Generate Risk Profile"}
+            </Button>
+          </>
+        ) : (
+          <>
+            {/* Score display */}
+            <div style={{
+              border: `1px solid ${UI.rule}`, padding: "1.25rem",
+              display: "flex", alignItems: "center", gap: "1.25rem",
+            }}>
+              <div style={{ textAlign: "center", minWidth: 64 }}>
+                <div style={{ fontFamily: UI.serif, fontSize: "2.5rem", fontWeight: 900, color: gradeColor, lineHeight: 1 }}>
+                  {grade}
+                </div>
+                <div style={{ fontFamily: UI.mono, fontSize: "0.6rem", textTransform: "uppercase", letterSpacing: "0.08em", color: UI.inkLight, marginTop: "0.2rem" }}>
+                  Grade
+                </div>
+              </div>
+              <div style={{ borderLeft: `1px solid ${UI.rule}`, paddingLeft: "1.25rem" }}>
+                <div style={{ fontFamily: UI.serif, fontSize: "2rem", fontWeight: 700, color: UI.ink, lineHeight: 1 }}>
+                  {profile.maintenanceScore}<span style={{ fontSize: "1rem", color: UI.inkLight }}>/100</span>
+                </div>
+                <div style={{ fontFamily: UI.mono, fontSize: "0.65rem", textTransform: "uppercase", letterSpacing: "0.08em", color: UI.inkLight, marginTop: "0.2rem" }}>
+                  Maintenance Score
+                </div>
+                <div style={{ display: "flex", gap: "1rem", marginTop: "0.5rem", flexWrap: "wrap" }}>
+                  {[
+                    { label: "Sensors",   value: profile.sensorCoverage.length },
+                    { label: "Open jobs", value: profile.openJobs },
+                    { label: "Verified",  value: profile.verifiedJobCount },
+                    { label: "Permits",   value: profile.permitCount },
+                  ].map(({ label, value }) => (
+                    <div key={label} style={{ textAlign: "center" }}>
+                      <div style={{ fontFamily: UI.mono, fontSize: "0.9rem", fontWeight: 600, color: UI.ink }}>{value}</div>
+                      <div style={{ fontFamily: UI.mono, fontSize: "0.6rem", color: UI.inkLight }}>{label}</div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+
+            {/* Share URL */}
+            <div>
+              <label style={{ fontFamily: UI.mono, fontSize: "0.65rem", textTransform: "uppercase", letterSpacing: "0.08em", color: UI.inkLight, display: "block", marginBottom: "0.4rem" }}>
+                Verification link
+              </label>
+              <div style={{ display: "flex", gap: "0.5rem", alignItems: "center" }}>
+                <div style={{
+                  flex: 1, fontFamily: UI.mono, fontSize: "0.72rem", color: UI.inkLight,
+                  border: `1px solid ${UI.rule}`, padding: "0.5rem 0.75rem",
+                  overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap",
+                }}>
+                  {shareUrl}
+                </div>
+                <button
+                  onClick={handleCopy}
+                  style={{ border: `1px solid ${UI.rule}`, background: "transparent", cursor: "pointer", padding: "0.5rem 0.75rem", display: "flex", alignItems: "center", gap: "0.35rem", fontFamily: UI.mono, fontSize: "0.72rem", color: UI.ink }}
+                >
+                  {copied ? <CheckCircle size={14} color="#2a7a4b" /> : <Copy size={14} />}
+                  {copied ? "Copied" : "Copy"}
+                </button>
+              </div>
+            </div>
+
+            {/* Actions */}
+            <div style={{ display: "flex", gap: "0.75rem" }}>
+              <Button onClick={handleDownload} style={{ display: "flex", alignItems: "center", gap: "0.4rem" }}>
+                <Download size={14} /> Download JSON
+              </Button>
+              <button
+                onClick={() => setProfile(null)}
+                style={{ fontFamily: UI.mono, fontSize: "0.72rem", color: UI.inkLight, background: "none", border: `1px solid ${UI.rule}`, padding: "0.5rem 0.85rem", cursor: "pointer" }}
+              >
+                Generate new
+              </button>
+            </div>
+
+            {profile.expiresAt && (
+              <p style={{ fontFamily: UI.mono, fontSize: "0.65rem", color: UI.inkLight, margin: 0 }}>
+                Expires {new Date(profile.expiresAt).toLocaleDateString()}
+              </p>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/InsuranceShareModal.tsx
+++ b/frontend/src/components/InsuranceShareModal.tsx
@@ -103,7 +103,7 @@ export function InsuranceShareModal({ property, onClose }: InsuranceShareModalPr
       display: "flex", alignItems: "center", justifyContent: "center",
       zIndex: 1000, padding: "1rem",
     }}>
-      <div style={{
+      <div data-testid="insurance-modal" style={{
         background: UI.paper, border: `1px solid ${UI.rule}`,
         maxWidth: 540, width: "100%", padding: "2rem",
         boxShadow: "0 8px 32px rgba(14,14,12,0.18)",

--- a/frontend/src/pages/PropertyDetailPage.tsx
+++ b/frontend/src/pages/PropertyDetailPage.tsx
@@ -5,6 +5,7 @@ import { Layout } from "@/components/Layout";
 import { Button } from "@/components/Button";
 import { Badge } from "@/components/Badge";
 import { GenerateReportModal }     from "@/components/GenerateReportModal";
+import { InsuranceShareModal }     from "@/components/InsuranceShareModal";
 import { LogJobModal }              from "@/components/LogJobModal";
 import { RequestQuoteModal }        from "@/components/RequestQuoteModal";
 import { InviteContractorModal }    from "@/components/InviteContractorModal";
@@ -64,6 +65,7 @@ type Tab = "timeline" | "jobs" | "rooms" | "documents" | "bills" | "settings";
 
 interface ModalState {
   report:        boolean;
+  insurance:     boolean;
   logJob:        boolean;
   quote:         boolean;
   verify:        boolean;
@@ -77,6 +79,7 @@ interface ModalState {
 
 const MODALS_CLOSED: ModalState = {
   report:        false,
+  insurance:     false,
   logJob:        false,
   quote:         false,
   verify:        false,
@@ -276,6 +279,9 @@ export default function PropertyDetailPage() {
               <>
                 <Button variant="outline" icon={<Share2 size={14} />} onClick={() => setModals((m) => ({ ...m, report: true }))}>
                   Share Report
+                </Button>
+                <Button variant="outline" icon={<Shield size={14} />} onClick={() => setModals((m) => ({ ...m, insurance: true }))}>
+                  Insurance Report
                 </Button>
                 {!fsboRecord?.isFsbo && (
                   <Button
@@ -532,6 +538,10 @@ export default function PropertyDetailPage() {
 
       {modals.report && (
         <GenerateReportModal property={property} onClose={() => setModals((m) => ({ ...m, report: false }))} />
+      )}
+
+      {modals.insurance && (
+        <InsuranceShareModal property={property} onClose={() => setModals((m) => ({ ...m, insurance: false }))} />
       )}
 
       <LogJobModal

--- a/frontend/src/services/report.ts
+++ b/frontend/src/services/report.ts
@@ -104,6 +104,45 @@ export const idlFactory = ({ IDL }: any) => {
     UnverifiedProperty:  IDL.Null,
   });
 
+  const SensorSummary = IDL.Record({
+    deviceId:    IDL.Text,
+    name:        IDL.Text,
+    source:      IDL.Text,
+    isActive:    IDL.Bool,
+    lastEventAt: IDL.Opt(IDL.Int),
+    eventCount:  IDL.Nat,
+  });
+
+  const AlertSummary = IDL.Record({
+    alertId:         IDL.Text,
+    eventType:       IDL.Text,
+    severity:        IDL.Text,
+    timestamp:       IDL.Int,
+    resolvedByJobId: IDL.Opt(IDL.Text),
+  });
+
+  const RiskProfile = IDL.Record({
+    schemaVersion:    IDL.Text,
+    token:            IDL.Text,
+    propertyId:       IDL.Text,
+    generatedAt:      IDL.Int,
+    expiresAt:        IDL.Opt(IDL.Int),
+    maintenanceScore: IDL.Nat,
+    verificationLevel: IDL.Text,
+    sensorCoverage:   IDL.Vec(SensorSummary),
+    recentAlerts:     IDL.Vec(AlertSummary),
+    openJobs:         IDL.Nat,
+    verifiedJobCount: IDL.Nat,
+    permitCount:      IDL.Nat,
+  });
+
+  const RiskProfileError = IDL.Variant({
+    NotFound:     IDL.Null,
+    Expired:      IDL.Null,
+    Unauthorized: IDL.Null,
+    InvalidInput: IDL.Text,
+  });
+
   return IDL.Service({
     // Params 1-6 match the original interface; 7-11 are new trailing opt args.
     generateReport: IDL.Func(
@@ -124,6 +163,16 @@ export const idlFactory = ({ IDL }: any) => {
       [IDL.Text],
       [IDL.Variant({ ok: IDL.Null, err: Error })],
       []
+    ),
+    generateRiskProfile: IDL.Func(
+      [IDL.Text, IDL.Opt(IDL.Nat), IDL.Text],
+      [IDL.Variant({ ok: RiskProfile, err: RiskProfileError })],
+      []
+    ),
+    getRiskProfile: IDL.Func(
+      [IDL.Text],
+      [IDL.Variant({ ok: RiskProfile, err: RiskProfileError })],
+      ["query"]
     ),
   });
 };
@@ -220,6 +269,38 @@ export interface ShareLink {
   viewCount:  number;
   isActive:   boolean;
   createdAt:  number;
+}
+
+export interface SensorSummary {
+  deviceId:    string;
+  name:        string;
+  source:      string;
+  isActive:    boolean;
+  lastEventAt: number | null;   // ms, null = no events
+  eventCount:  number;
+}
+
+export interface AlertSummary {
+  alertId:         string;
+  eventType:       string;
+  severity:        string;   // "Critical" | "Warning"
+  timestamp:       number;   // ms
+  resolvedByJobId: string | null;
+}
+
+export interface RiskProfile {
+  schemaVersion:    string;   // "homegentic-risk/1.0"
+  token:            string;
+  propertyId:       string;
+  generatedAt:      number;   // ms
+  expiresAt:        number | null;
+  maintenanceScore: number;   // 0-100
+  verificationLevel: string;
+  sensorCoverage:   SensorSummary[];
+  recentAlerts:     AlertSummary[];
+  openJobs:         number;
+  verifiedJobCount: number;
+  permitCount:      number;
 }
 
 // ─── Adapters ─────────────────────────────────────────────────────────────────
@@ -347,6 +428,36 @@ function jobInputToCanister(j: JobInput) {
   };
 }
 
+function fromRiskProfile(raw: any): RiskProfile {
+  return {
+    schemaVersion:    raw.schemaVersion,
+    token:            raw.token,
+    propertyId:       raw.propertyId,
+    generatedAt:      Number(raw.generatedAt) / 1_000_000,
+    expiresAt:        raw.expiresAt[0] != null ? Number(raw.expiresAt[0]) / 1_000_000 : null,
+    maintenanceScore: Number(raw.maintenanceScore),
+    verificationLevel: raw.verificationLevel,
+    sensorCoverage:   (raw.sensorCoverage as any[]).map((d: any) => ({
+      deviceId:    d.deviceId,
+      name:        d.name,
+      source:      d.source,
+      isActive:    d.isActive,
+      lastEventAt: d.lastEventAt[0] != null ? Number(d.lastEventAt[0]) / 1_000_000 : null,
+      eventCount:  Number(d.eventCount),
+    })),
+    recentAlerts: (raw.recentAlerts as any[]).map((a: any) => ({
+      alertId:         a.alertId,
+      eventType:       a.eventType,
+      severity:        a.severity,
+      timestamp:       Number(a.timestamp) / 1_000_000,
+      resolvedByJobId: a.resolvedByJobId[0] ?? null,
+    })),
+    openJobs:         Number(raw.openJobs),
+    verifiedJobCount: Number(raw.verifiedJobCount),
+    permitCount:      Number(raw.permitCount),
+  };
+}
+
 // ─── Service factory ──────────────────────────────────────────────────────────
 
 function createReportService() {
@@ -446,6 +557,62 @@ function createReportService() {
       const key = Object.keys(result.err)[0];
       throw new Error(key);
     }
+  },
+
+  async generateRiskProfile(
+    propertyId:        string,
+    verificationLevel: string,
+    expiryDays:        number | null
+  ): Promise<RiskProfile> {
+    if (!REPORT_CANISTER_ID) {
+      return {
+        schemaVersion: "homegentic-risk/1.0",
+        token: `RISK_mock_${Date.now()}`,
+        propertyId,
+        generatedAt: Date.now(),
+        expiresAt: expiryDays ? Date.now() + expiryDays * 86_400_000 : null,
+        maintenanceScore: 78,
+        verificationLevel,
+        sensorCoverage: [],
+        recentAlerts: [],
+        openJobs: 0,
+        verifiedJobCount: 0,
+        permitCount: 0,
+      };
+    }
+    const a = await getActor();
+    const result = await a.generateRiskProfile(
+      propertyId,
+      expiryDays ? [BigInt(expiryDays)] : [],
+      verificationLevel
+    );
+    if ("ok" in result) return fromRiskProfile(result.ok);
+    const key = Object.keys(result.err)[0];
+    const val = result.err[key];
+    throw new Error(typeof val === "string" ? val : key);
+  },
+
+  async getRiskProfile(token: string): Promise<RiskProfile> {
+    const a = await getActor();
+    const result = await a.getRiskProfile(token);
+    if ("ok" in result) return fromRiskProfile(result.ok);
+    const key = Object.keys(result.err)[0];
+    if (key === "Expired")  throw new Error("This risk profile has expired");
+    if (key === "NotFound") throw new Error("Risk profile not found");
+    const val = result.err[key];
+    throw new Error(typeof val === "string" ? val : key);
+  },
+
+  riskProfileUrl(token: string): string {
+    return `${window.location.origin}/verify/${token}`;
+  },
+
+  maintenanceGrade(score: number): string {
+    if (score >= 90) return "A";
+    if (score >= 75) return "B";
+    if (score >= 60) return "C";
+    if (score >= 45) return "D";
+    return "F";
   },
 
   shareUrl(token: string, options?: Partial<DisclosureOptions>): string {

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-DEPLOY_SCRIPT_VERSION="1.5.1"
+DEPLOY_SCRIPT_VERSION="1.5.2"
 ENV=${1:-local}
 
 echo "============================================"
@@ -638,6 +638,14 @@ fi
 if [ -n "$REPORT_ID" ]     && [ -n "$PROPERTY_ID" ]; then
   echo "  Wiring property -> report..."
   icp canister call report     setPropertyCanisterId   "(\"$PROPERTY_ID\")"          -e "$ENV" &
+fi
+if [ -n "$REPORT_ID" ]     && [ -n "$SENSOR_ID" ]; then
+  echo "  Wiring sensor -> report..."
+  icp canister call report     setSensorCanisterId     "(\"$SENSOR_ID\")"            -e "$ENV" &
+fi
+if [ -n "$REPORT_ID" ]     && [ -n "$JOB_ID" ]; then
+  echo "  Wiring job -> report..."
+  icp canister call report     setRiskJobCanisterId    "(\"$JOB_ID\")"              -e "$ENV" &
 fi
 
 wait

--- a/tests/e2e/insurance-risk-profile.spec.ts
+++ b/tests/e2e/insurance-risk-profile.spec.ts
@@ -236,10 +236,11 @@ test.describe("IR.7 — Generate new resets modal", () => {
     const modal = page.locator("[data-testid='insurance-modal']");
     await modal.getByRole("button", { name: /generate risk profile/i }).click();
     await expect(modal.getByText(/maintenance score/i)).toBeVisible();
-    await modal.getByRole("button", { name: /generate new/i }).click();
-    // Back to the generation form — the Generate button reappears
+    const generateNewBtn = modal.locator("button").filter({ hasText: /^Generate new$/ });
+    await expect(generateNewBtn).toBeVisible();
+    await generateNewBtn.click();
+    // Back to the generation form — Generate button and expiry selector reappear
     await expect(modal.getByRole("button", { name: /generate risk profile/i })).toBeVisible();
-    // The score section is gone from the modal
-    await expect(modal.getByText(/maintenance score/i)).not.toBeVisible();
+    await expect(modal.getByText(/link expiry/i)).toBeVisible();
   });
 });

--- a/tests/e2e/insurance-risk-profile.spec.ts
+++ b/tests/e2e/insurance-risk-profile.spec.ts
@@ -10,7 +10,8 @@
  * IR.7  "Generate new" resets modal back to the generation form
  *
  * All tests use window.__e2e_* injection — no canister required.
- * Mock mode returns maintenanceScore: 78 → grade "B".
+ * Modal scoped via data-testid="insurance-modal" to avoid ambiguity with
+ * PropertyDetailPage elements that share text ("Sensors", "Verified", etc.).
  */
 
 import { test, expect } from "@playwright/test";
@@ -19,50 +20,30 @@ import { injectSubscription } from "./helpers/testData";
 
 // ─── shared fixtures ──────────────────────────────────────────────────────────
 
-/** Property at verificationLevel "Basic" — Insurance Report button should show. */
 async function injectVerifiedProperty(page: any) {
   await page.addInitScript(() => {
     (window as any).__e2e_properties = [
       {
-        id: 1,
-        owner: "test-e2e-principal",
-        address: "123 Maple Street",
-        city: "Austin",
-        state: "TX",
-        zipCode: "78701",
-        propertyType: "SingleFamily",
-        yearBuilt: 2001,
-        squareFeet: 2400,
-        verificationLevel: "Basic",
-        tier: "Basic",
-        createdAt: 0,
-        updatedAt: 0,
-        isActive: true,
+        id: 1, owner: "test-e2e-principal",
+        address: "123 Maple Street", city: "Austin", state: "TX", zipCode: "78701",
+        propertyType: "SingleFamily", yearBuilt: 2001, squareFeet: 2400,
+        verificationLevel: "Basic", tier: "Basic",
+        createdAt: 0, updatedAt: 0, isActive: true,
       },
     ];
     (window as any).__e2e_jobs = [];
   });
 }
 
-/** Property at verificationLevel "Unverified" — button must be hidden. */
 async function injectUnverifiedProperty(page: any) {
   await page.addInitScript(() => {
     (window as any).__e2e_properties = [
       {
-        id: 1,
-        owner: "test-e2e-principal",
-        address: "123 Maple Street",
-        city: "Austin",
-        state: "TX",
-        zipCode: "78701",
-        propertyType: "SingleFamily",
-        yearBuilt: 2001,
-        squareFeet: 2400,
-        verificationLevel: "Unverified",
-        tier: "Basic",
-        createdAt: 0,
-        updatedAt: 0,
-        isActive: true,
+        id: 1, owner: "test-e2e-principal",
+        address: "123 Maple Street", city: "Austin", state: "TX", zipCode: "78701",
+        propertyType: "SingleFamily", yearBuilt: 2001, squareFeet: 2400,
+        verificationLevel: "Unverified", tier: "Basic",
+        createdAt: 0, updatedAt: 0, isActive: true,
       },
     ];
     (window as any).__e2e_jobs = [];
@@ -101,15 +82,17 @@ test.describe("IR.2 — InsuranceShareModal opens", () => {
   });
 
   test("modal heading 'Insurance Risk Report' is visible", async ({ page }) => {
-    await expect(page.getByText(/insurance risk report/i)).toBeVisible();
+    const modal = page.locator("[data-testid='insurance-modal']");
+    await expect(modal.getByText(/insurance risk report/i)).toBeVisible();
   });
 
-  test("modal shows the property address", async ({ page }) => {
-    await expect(page.getByText("123 Maple Street")).toBeVisible();
+  test("modal shows 'Share with Carrier' sub-heading", async ({ page }) => {
+    const modal = page.locator("[data-testid='insurance-modal']");
+    await expect(modal.getByRole("heading", { name: /share with carrier/i })).toBeVisible();
   });
 });
 
-// ── IR.3 — Modal expiry options and helper text ───────────────────────────────
+// ── IR.3 — Modal form content ─────────────────────────────────────────────────
 
 test.describe("IR.3 — Modal form content", () => {
   test.beforeEach(async ({ page }) => {
@@ -121,23 +104,28 @@ test.describe("IR.3 — Modal form content", () => {
   });
 
   test("shows 'Link expiry' label", async ({ page }) => {
-    await expect(page.getByText(/link expiry/i)).toBeVisible();
+    const modal = page.locator("[data-testid='insurance-modal']");
+    await expect(modal.getByText(/link expiry/i)).toBeVisible();
   });
 
   test("shows expiry option '90 days'", async ({ page }) => {
-    await expect(page.getByRole("button", { name: "90 days" })).toBeVisible();
+    const modal = page.locator("[data-testid='insurance-modal']");
+    await expect(modal.getByRole("button", { name: "90 days" })).toBeVisible();
   });
 
   test("shows expiry option '1 year'", async ({ page }) => {
-    await expect(page.getByRole("button", { name: "1 year" })).toBeVisible();
+    const modal = page.locator("[data-testid='insurance-modal']");
+    await expect(modal.getByRole("button", { name: "1 year" })).toBeVisible();
   });
 
   test("shows helper text about insurance carrier", async ({ page }) => {
-    await expect(page.getByText(/insurance carrier/i)).toBeVisible();
+    const modal = page.locator("[data-testid='insurance-modal']");
+    await expect(modal.getByText(/insurance carrier/i)).toBeVisible();
   });
 
   test("shows 'Generate Risk Profile' button", async ({ page }) => {
-    await expect(page.getByRole("button", { name: /generate risk profile/i })).toBeVisible();
+    const modal = page.locator("[data-testid='insurance-modal']");
+    await expect(modal.getByRole("button", { name: /generate risk profile/i })).toBeVisible();
   });
 });
 
@@ -150,37 +138,44 @@ test.describe("IR.4 — Score and grade after generating", () => {
     await injectVerifiedProperty(page);
     await page.goto("/properties/1");
     await page.getByRole("button", { name: /insurance report/i }).click();
-    await page.getByRole("button", { name: /generate risk profile/i }).click();
-    // Wait for the score to render (mock returns immediately)
-    await expect(page.getByText(/maintenance score/i)).toBeVisible();
+    const modal = page.locator("[data-testid='insurance-modal']");
+    await modal.getByRole("button", { name: /generate risk profile/i }).click();
+    await expect(modal.getByText(/maintenance score/i)).toBeVisible();
   });
 
   test("shows 'Maintenance Score' label", async ({ page }) => {
-    await expect(page.getByText(/maintenance score/i)).toBeVisible();
+    const modal = page.locator("[data-testid='insurance-modal']");
+    await expect(modal.getByText(/maintenance score/i)).toBeVisible();
   });
 
   test("shows score value with /100 suffix", async ({ page }) => {
-    await expect(page.getByText(/\/100/)).toBeVisible();
+    const modal = page.locator("[data-testid='insurance-modal']");
+    await expect(modal.getByText(/\/100/)).toBeVisible();
   });
 
   test("shows 'Grade' label", async ({ page }) => {
-    await expect(page.getByText("Grade")).toBeVisible();
+    const modal = page.locator("[data-testid='insurance-modal']");
+    await expect(modal.getByText("Grade")).toBeVisible();
   });
 
   test("shows stat chip 'Sensors'", async ({ page }) => {
-    await expect(page.getByText("Sensors")).toBeVisible();
+    const modal = page.locator("[data-testid='insurance-modal']");
+    await expect(modal.getByText("Sensors")).toBeVisible();
   });
 
   test("shows stat chip 'Open jobs'", async ({ page }) => {
-    await expect(page.getByText("Open jobs")).toBeVisible();
+    const modal = page.locator("[data-testid='insurance-modal']");
+    await expect(modal.getByText("Open jobs")).toBeVisible();
   });
 
   test("shows stat chip 'Verified'", async ({ page }) => {
-    await expect(page.getByText("Verified")).toBeVisible();
+    const modal = page.locator("[data-testid='insurance-modal']");
+    await expect(modal.getByText("Verified")).toBeVisible();
   });
 
   test("shows stat chip 'Permits'", async ({ page }) => {
-    await expect(page.getByText("Permits")).toBeVisible();
+    const modal = page.locator("[data-testid='insurance-modal']");
+    await expect(modal.getByText("Permits")).toBeVisible();
   });
 });
 
@@ -193,16 +188,19 @@ test.describe("IR.5 — Verification link section", () => {
     await injectVerifiedProperty(page);
     await page.goto("/properties/1");
     await page.getByRole("button", { name: /insurance report/i }).click();
-    await page.getByRole("button", { name: /generate risk profile/i }).click();
-    await expect(page.getByText(/maintenance score/i)).toBeVisible();
+    const modal = page.locator("[data-testid='insurance-modal']");
+    await modal.getByRole("button", { name: /generate risk profile/i }).click();
+    await expect(modal.getByText(/maintenance score/i)).toBeVisible();
   });
 
   test("shows 'Verification link' label", async ({ page }) => {
-    await expect(page.getByText(/verification link/i)).toBeVisible();
+    const modal = page.locator("[data-testid='insurance-modal']");
+    await expect(modal.getByText(/verification link/i)).toBeVisible();
   });
 
   test("shows 'Copy' button", async ({ page }) => {
-    await expect(page.getByRole("button", { name: /copy/i })).toBeVisible();
+    const modal = page.locator("[data-testid='insurance-modal']");
+    await expect(modal.getByRole("button", { name: /copy/i })).toBeVisible();
   });
 });
 
@@ -215,12 +213,14 @@ test.describe("IR.6 — Download JSON button", () => {
     await injectVerifiedProperty(page);
     await page.goto("/properties/1");
     await page.getByRole("button", { name: /insurance report/i }).click();
-    await page.getByRole("button", { name: /generate risk profile/i }).click();
-    await expect(page.getByText(/maintenance score/i)).toBeVisible();
+    const modal = page.locator("[data-testid='insurance-modal']");
+    await modal.getByRole("button", { name: /generate risk profile/i }).click();
+    await expect(modal.getByText(/maintenance score/i)).toBeVisible();
   });
 
   test("shows 'Download JSON' button", async ({ page }) => {
-    await expect(page.getByRole("button", { name: /download json/i })).toBeVisible();
+    const modal = page.locator("[data-testid='insurance-modal']");
+    await expect(modal.getByRole("button", { name: /download json/i })).toBeVisible();
   });
 });
 
@@ -233,11 +233,13 @@ test.describe("IR.7 — Generate new resets modal", () => {
     await injectVerifiedProperty(page);
     await page.goto("/properties/1");
     await page.getByRole("button", { name: /insurance report/i }).click();
-    await page.getByRole("button", { name: /generate risk profile/i }).click();
-    await expect(page.getByText(/maintenance score/i)).toBeVisible();
-    await page.getByRole("button", { name: /generate new/i }).click();
-    // Back to the generation form
-    await expect(page.getByRole("button", { name: /generate risk profile/i })).toBeVisible();
-    await expect(page.getByText(/maintenance score/i)).not.toBeVisible();
+    const modal = page.locator("[data-testid='insurance-modal']");
+    await modal.getByRole("button", { name: /generate risk profile/i }).click();
+    await expect(modal.getByText(/maintenance score/i)).toBeVisible();
+    await modal.getByRole("button", { name: /generate new/i }).click();
+    // Back to the generation form — the Generate button reappears
+    await expect(modal.getByRole("button", { name: /generate risk profile/i })).toBeVisible();
+    // The score section is gone from the modal
+    await expect(modal.getByText(/maintenance score/i)).not.toBeVisible();
   });
 });

--- a/tests/e2e/insurance-risk-profile.spec.ts
+++ b/tests/e2e/insurance-risk-profile.spec.ts
@@ -1,0 +1,243 @@
+/**
+ * Insurance Risk Profile E2E tests                              (#278)
+ *
+ * IR.1  Verified property shows "Insurance Report" button; unverified does not
+ * IR.2  Clicking the button opens the InsuranceShareModal
+ * IR.3  Modal shows expiry options and helper text
+ * IR.4  Generate Risk Profile renders score, grade, and stat chips
+ * IR.5  Copy link button appears after generation
+ * IR.6  Download JSON button appears after generation
+ * IR.7  "Generate new" resets modal back to the generation form
+ *
+ * All tests use window.__e2e_* injection — no canister required.
+ * Mock mode returns maintenanceScore: 78 → grade "B".
+ */
+
+import { test, expect } from "@playwright/test";
+import { injectTestAuth } from "./helpers/auth";
+import { injectSubscription } from "./helpers/testData";
+
+// ─── shared fixtures ──────────────────────────────────────────────────────────
+
+/** Property at verificationLevel "Basic" — Insurance Report button should show. */
+async function injectVerifiedProperty(page: any) {
+  await page.addInitScript(() => {
+    (window as any).__e2e_properties = [
+      {
+        id: 1,
+        owner: "test-e2e-principal",
+        address: "123 Maple Street",
+        city: "Austin",
+        state: "TX",
+        zipCode: "78701",
+        propertyType: "SingleFamily",
+        yearBuilt: 2001,
+        squareFeet: 2400,
+        verificationLevel: "Basic",
+        tier: "Basic",
+        createdAt: 0,
+        updatedAt: 0,
+        isActive: true,
+      },
+    ];
+    (window as any).__e2e_jobs = [];
+  });
+}
+
+/** Property at verificationLevel "Unverified" — button must be hidden. */
+async function injectUnverifiedProperty(page: any) {
+  await page.addInitScript(() => {
+    (window as any).__e2e_properties = [
+      {
+        id: 1,
+        owner: "test-e2e-principal",
+        address: "123 Maple Street",
+        city: "Austin",
+        state: "TX",
+        zipCode: "78701",
+        propertyType: "SingleFamily",
+        yearBuilt: 2001,
+        squareFeet: 2400,
+        verificationLevel: "Unverified",
+        tier: "Basic",
+        createdAt: 0,
+        updatedAt: 0,
+        isActive: true,
+      },
+    ];
+    (window as any).__e2e_jobs = [];
+  });
+}
+
+// ── IR.1 — Button visibility by verification level ────────────────────────────
+
+test.describe("IR.1 — Insurance Report button visibility", () => {
+  test("button is visible for a verified (Basic) property", async ({ page }) => {
+    await injectTestAuth(page);
+    await injectSubscription(page, "Basic");
+    await injectVerifiedProperty(page);
+    await page.goto("/properties/1");
+    await expect(page.getByRole("button", { name: /insurance report/i })).toBeVisible();
+  });
+
+  test("button is NOT visible for an unverified property", async ({ page }) => {
+    await injectTestAuth(page);
+    await injectSubscription(page, "Basic");
+    await injectUnverifiedProperty(page);
+    await page.goto("/properties/1");
+    await expect(page.getByRole("button", { name: /insurance report/i })).not.toBeVisible();
+  });
+});
+
+// ── IR.2 — Modal opens ────────────────────────────────────────────────────────
+
+test.describe("IR.2 — InsuranceShareModal opens", () => {
+  test.beforeEach(async ({ page }) => {
+    await injectTestAuth(page);
+    await injectSubscription(page, "Basic");
+    await injectVerifiedProperty(page);
+    await page.goto("/properties/1");
+    await page.getByRole("button", { name: /insurance report/i }).click();
+  });
+
+  test("modal heading 'Insurance Risk Report' is visible", async ({ page }) => {
+    await expect(page.getByText(/insurance risk report/i)).toBeVisible();
+  });
+
+  test("modal shows the property address", async ({ page }) => {
+    await expect(page.getByText("123 Maple Street")).toBeVisible();
+  });
+});
+
+// ── IR.3 — Modal expiry options and helper text ───────────────────────────────
+
+test.describe("IR.3 — Modal form content", () => {
+  test.beforeEach(async ({ page }) => {
+    await injectTestAuth(page);
+    await injectSubscription(page, "Basic");
+    await injectVerifiedProperty(page);
+    await page.goto("/properties/1");
+    await page.getByRole("button", { name: /insurance report/i }).click();
+  });
+
+  test("shows 'Link expiry' label", async ({ page }) => {
+    await expect(page.getByText(/link expiry/i)).toBeVisible();
+  });
+
+  test("shows expiry option '90 days'", async ({ page }) => {
+    await expect(page.getByRole("button", { name: "90 days" })).toBeVisible();
+  });
+
+  test("shows expiry option '1 year'", async ({ page }) => {
+    await expect(page.getByRole("button", { name: "1 year" })).toBeVisible();
+  });
+
+  test("shows helper text about insurance carrier", async ({ page }) => {
+    await expect(page.getByText(/insurance carrier/i)).toBeVisible();
+  });
+
+  test("shows 'Generate Risk Profile' button", async ({ page }) => {
+    await expect(page.getByRole("button", { name: /generate risk profile/i })).toBeVisible();
+  });
+});
+
+// ── IR.4 — Score and grade display after generation ───────────────────────────
+
+test.describe("IR.4 — Score and grade after generating", () => {
+  test.beforeEach(async ({ page }) => {
+    await injectTestAuth(page);
+    await injectSubscription(page, "Basic");
+    await injectVerifiedProperty(page);
+    await page.goto("/properties/1");
+    await page.getByRole("button", { name: /insurance report/i }).click();
+    await page.getByRole("button", { name: /generate risk profile/i }).click();
+    // Wait for the score to render (mock returns immediately)
+    await expect(page.getByText(/maintenance score/i)).toBeVisible();
+  });
+
+  test("shows 'Maintenance Score' label", async ({ page }) => {
+    await expect(page.getByText(/maintenance score/i)).toBeVisible();
+  });
+
+  test("shows score value with /100 suffix", async ({ page }) => {
+    await expect(page.getByText(/\/100/)).toBeVisible();
+  });
+
+  test("shows 'Grade' label", async ({ page }) => {
+    await expect(page.getByText("Grade")).toBeVisible();
+  });
+
+  test("shows stat chip 'Sensors'", async ({ page }) => {
+    await expect(page.getByText("Sensors")).toBeVisible();
+  });
+
+  test("shows stat chip 'Open jobs'", async ({ page }) => {
+    await expect(page.getByText("Open jobs")).toBeVisible();
+  });
+
+  test("shows stat chip 'Verified'", async ({ page }) => {
+    await expect(page.getByText("Verified")).toBeVisible();
+  });
+
+  test("shows stat chip 'Permits'", async ({ page }) => {
+    await expect(page.getByText("Permits")).toBeVisible();
+  });
+});
+
+// ── IR.5 — Copy link ──────────────────────────────────────────────────────────
+
+test.describe("IR.5 — Verification link section", () => {
+  test.beforeEach(async ({ page }) => {
+    await injectTestAuth(page);
+    await injectSubscription(page, "Basic");
+    await injectVerifiedProperty(page);
+    await page.goto("/properties/1");
+    await page.getByRole("button", { name: /insurance report/i }).click();
+    await page.getByRole("button", { name: /generate risk profile/i }).click();
+    await expect(page.getByText(/maintenance score/i)).toBeVisible();
+  });
+
+  test("shows 'Verification link' label", async ({ page }) => {
+    await expect(page.getByText(/verification link/i)).toBeVisible();
+  });
+
+  test("shows 'Copy' button", async ({ page }) => {
+    await expect(page.getByRole("button", { name: /copy/i })).toBeVisible();
+  });
+});
+
+// ── IR.6 — Download JSON ──────────────────────────────────────────────────────
+
+test.describe("IR.6 — Download JSON button", () => {
+  test.beforeEach(async ({ page }) => {
+    await injectTestAuth(page);
+    await injectSubscription(page, "Basic");
+    await injectVerifiedProperty(page);
+    await page.goto("/properties/1");
+    await page.getByRole("button", { name: /insurance report/i }).click();
+    await page.getByRole("button", { name: /generate risk profile/i }).click();
+    await expect(page.getByText(/maintenance score/i)).toBeVisible();
+  });
+
+  test("shows 'Download JSON' button", async ({ page }) => {
+    await expect(page.getByRole("button", { name: /download json/i })).toBeVisible();
+  });
+});
+
+// ── IR.7 — "Generate new" resets form ────────────────────────────────────────
+
+test.describe("IR.7 — Generate new resets modal", () => {
+  test("'Generate new' button returns to the generation form", async ({ page }) => {
+    await injectTestAuth(page);
+    await injectSubscription(page, "Basic");
+    await injectVerifiedProperty(page);
+    await page.goto("/properties/1");
+    await page.getByRole("button", { name: /insurance report/i }).click();
+    await page.getByRole("button", { name: /generate risk profile/i }).click();
+    await expect(page.getByText(/maintenance score/i)).toBeVisible();
+    await page.getByRole("button", { name: /generate new/i }).click();
+    // Back to the generation form
+    await expect(page.getByRole("button", { name: /generate risk profile/i })).toBeVisible();
+    await expect(page.getByText(/maintenance score/i)).not.toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `RiskProfile` type and `generateRiskProfile` / `getRiskProfile` methods to the report canister
- Computes a 0–100 maintenance score from live job and sensor data via cross-canister queries
- Generates a time-limited, cryptographically random token for carrier-facing verification
- Frontend: `InsuranceShareModal` with copy-link and download-JSON buttons; "Insurance Report" button on `PropertyDetailPage` (verified properties only)
- `deploy.sh` v1.5.2 wires report ↔ sensor and report ↔ job

## Score formula

| Factor | Adjustment |
|---|---|
| Unresolved Critical alert | −5 each (cap −30) |
| Open job older than 90 days | −3 each (cap −20) |
| Verified job with permit | +5 each (cap +20) |
| No sensor coverage | −10 |
| Property unverified | −15 |

## JSON output schema

```json
{
  "schema": "homegentic-risk/1.0",
  "token": "RISK_<hex>",
  "verificationUrl": "https://<host>/verify/<token>",
  "maintenanceScore": 78,
  "grade": "B",
  "verificationLevel": "Basic",
  "sensorCoverage": [...],
  "recentAlerts": [...],
  "openIssues": 1,
  "verifiedJobs": 4,
  "permittedWork": 2
}
```

## Test plan

- [ ] Verified property shows "Insurance Report" button; unverified does not
- [ ] Modal generates a risk profile with a 0–100 score and A–F grade
- [ ] "Copy" button copies the `/verify/<token>` URL to clipboard
- [ ] "Download JSON" button downloads a valid `homegentic-risk/1.0` JSON file
- [ ] "Generate new" resets the modal to re-generate with different expiry
- [ ] 74/74 unit tests pass (`npx vitest run src/__tests__/contracts/candid.contract.test.ts src/__tests__/services/candidContracts.test.ts`)
- [ ] TypeScript compiles cleanly (`npx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)