### PR TITLE
feat(sensor): SolarEdge poller + tiered device registration UX (#272 …

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,6 +45,8 @@ VITE_RENTCAST_API_KEY=
 
 # Frontend — point at the voice proxy
 VITE_VOICE_AGENT_URL=http://localhost:3001
+# IoT gateway base URL — used by RegisterDeviceModal OAuth popups
+VITE_IOT_GATEWAY_URL=http://localhost:3002
 # Must match VOICE_AGENT_API_KEY above so the frontend can authenticate
 VITE_VOICE_AGENT_API_KEY=
 
@@ -117,6 +119,17 @@ GE_ACCESS_TOKEN=
 GE_REFRESH_TOKEN=
 # Optional — path to token persistence file (default: .ge-tokens.json in cwd)
 GE_TOKENS_FILE=
+
+# SolarEdge — cloud REST polling (300 req/day limit → poll every 15 min)
+# API key: monitoring.solaredge.com → Admin → Site Access → API Access → Enable API
+# Site ID: visible in the monitoring portal URL: /p/site/123456/dashboard
+SOLAREDGE_API_KEY=
+SOLAREDGE_SITE_ID=
+
+# LG ThinQ — OAuth 2.0 client credentials (for device picker popup + PCC webhook)
+# Register at developer.lge.com → My Apps
+LG_THINQ_CLIENT_ID=
+LG_THINQ_CLIENT_SECRET=
 
 # SmartThings webhook (POST /webhooks/smartthings)
 # Personal Access Token: https://account.smartthings.com/tokens (scope: r:devices:*)

--- a/agents/iot-gateway/handlers.ts
+++ b/agents/iot-gateway/handlers.ts
@@ -16,6 +16,7 @@ import type {
   EnphaseSystemEvent,
   TeslaPowerwallEvent,
   LGThinQPCCEvent,
+  SolarEdgeEvent,
 } from "./types";
 
 // ── Nest ─────────────────────────────────────────────────────────────────────
@@ -508,6 +509,41 @@ export function handleLGThinQEvent(
       eventType: { ApplianceFault: null } as SensorEventType,
       value: 0,
       unit: "",
+      rawPayload: raw,
+    };
+  }
+
+  return null;
+}
+
+// ── SolarEdge ─────────────────────────────────────────────────────────────────
+
+const SOLAREDGE_LOW_PRODUCTION_WATTS = 10;
+
+export function handleSolarEdgeEvent(
+  event: SolarEdgeEvent,
+  raw: string
+): SensorReading | null {
+  if (!event.siteId) return null;
+
+  const externalDeviceId = event.siteId;
+
+  if (event.hasCriticalAlert) {
+    return {
+      externalDeviceId,
+      eventType: { SolarFault: null } as SensorEventType,
+      value: 0,
+      unit: "",
+      rawPayload: raw,
+    };
+  }
+
+  if (event.isDaylight && event.currentPowerW < SOLAREDGE_LOW_PRODUCTION_WATTS) {
+    return {
+      externalDeviceId,
+      eventType: { LowProduction: null } as SensorEventType,
+      value: event.currentPowerW,
+      unit: "W",
       rawPayload: raw,
     };
   }

--- a/agents/iot-gateway/oauth/ecobee.ts
+++ b/agents/iot-gateway/oauth/ecobee.ts
@@ -1,0 +1,61 @@
+/**
+ * Ecobee OAuth device picker — used by the RegisterDeviceModal popup flow.
+ *
+ * Generates the authorization URL and exchanges the code for an access token,
+ * then fetches the list of registered thermostats so the user can pick one.
+ * This is a one-time discovery flow; it does NOT persist tokens for the poller.
+ */
+
+const ECOBEE_API = "https://api.ecobee.com";
+
+export interface OAuthDevice {
+  id:   string;
+  name: string;
+  type: string;
+}
+
+export function authUrl(clientId: string, redirectUri: string): string {
+  const params = new URLSearchParams({
+    response_type: "code",
+    client_id:     clientId,
+    redirect_uri:  redirectUri,
+    scope:         "SmartRead",
+  });
+  return `${ECOBEE_API}/authorize?${params}`;
+}
+
+export async function exchangeCode(
+  code:        string,
+  clientId:    string,
+  redirectUri: string,
+): Promise<string> {
+  const url = `${ECOBEE_API}/token`
+    + `?grant_type=authorization_code`
+    + `&code=${encodeURIComponent(code)}`
+    + `&redirect_uri=${encodeURIComponent(redirectUri)}`
+    + `&client_id=${encodeURIComponent(clientId)}`;
+
+  const resp = await fetch(url, { method: "POST" });
+  if (!resp.ok) throw new Error(`Ecobee token exchange failed (${resp.status}): ${await resp.text()}`);
+
+  const data = await resp.json() as { access_token: string };
+  return data.access_token;
+}
+
+export async function fetchDevices(accessToken: string): Promise<OAuthDevice[]> {
+  const selection = encodeURIComponent(JSON.stringify({
+    selection: { selectionType: "registered", selectionMatch: "", includeAlerts: false, includeRuntime: false },
+  }));
+
+  const resp = await fetch(`${ECOBEE_API}/1/thermostat?json=${selection}`, {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+  if (!resp.ok) throw new Error(`Ecobee device list failed (${resp.status})`);
+
+  const data = await resp.json() as { thermostatList: Array<{ identifier: string; name: string }> };
+  return (data.thermostatList ?? []).map((t) => ({
+    id:   t.identifier,
+    name: t.name,
+    type: "Thermostat",
+  }));
+}

--- a/agents/iot-gateway/oauth/geSmartHQ.ts
+++ b/agents/iot-gateway/oauth/geSmartHQ.ts
@@ -1,0 +1,65 @@
+/**
+ * GE SmartHQ OAuth device picker — used by the RegisterDeviceModal popup flow.
+ *
+ * Reuses GE's OAuth flow (same credentials as the poller) but returns a device
+ * list to the frontend popup instead of persisting tokens for background polling.
+ */
+
+const GE_AUTH_API    = "https://api.whrcloud.com";
+const GE_ACCOUNT_API = "https://api.whrcloud.com";
+
+export interface OAuthDevice {
+  id:   string;
+  name: string;
+  type: string;
+}
+
+export function authUrl(clientId: string, redirectUri: string): string {
+  const params = new URLSearchParams({
+    response_type: "code",
+    redirect_uri:  redirectUri,
+    client_id:     clientId,
+  });
+  return `${GE_AUTH_API}/auth/authorize?${params}`;
+}
+
+export async function exchangeCode(
+  code:         string,
+  clientId:     string,
+  clientSecret: string,
+  redirectUri:  string,
+): Promise<string> {
+  const credentials = Buffer.from(`${clientId}:${clientSecret}`).toString("base64");
+  const body = new URLSearchParams({
+    grant_type:   "authorization_code",
+    code,
+    redirect_uri: redirectUri,
+  });
+
+  const resp = await fetch(`${GE_AUTH_API}/oauth/token`, {
+    method:  "POST",
+    headers: {
+      "Content-Type":  "application/x-www-form-urlencoded",
+      "Authorization": `Basic ${credentials}`,
+    },
+    body: body.toString(),
+  });
+  if (!resp.ok) throw new Error(`GE SmartHQ token exchange failed (${resp.status}): ${await resp.text()}`);
+
+  const data = await resp.json() as { access_token: string };
+  return data.access_token;
+}
+
+export async function fetchDevices(accessToken: string): Promise<OAuthDevice[]> {
+  const resp = await fetch(`${GE_ACCOUNT_API}/v1/appliance`, {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+  if (!resp.ok) throw new Error(`GE SmartHQ device list failed (${resp.status})`);
+
+  const data = await resp.json() as { items?: Array<{ applianceId: string; applianceType?: string; nickName?: string }> };
+  return (data.items ?? []).map((a) => ({
+    id:   a.applianceId,
+    name: a.nickName || a.applianceId,
+    type: a.applianceType ?? "Appliance",
+  }));
+}

--- a/agents/iot-gateway/oauth/honeywellHome.ts
+++ b/agents/iot-gateway/oauth/honeywellHome.ts
@@ -1,0 +1,61 @@
+/**
+ * Honeywell Home / Resideo OAuth device picker — used by the RegisterDeviceModal popup flow.
+ */
+
+const HONEYWELL_API = "https://api.honeywell.com";
+
+export interface OAuthDevice {
+  id:   string;
+  name: string;
+  type: string;
+}
+
+export function authUrl(clientId: string, redirectUri: string): string {
+  const params = new URLSearchParams({
+    response_type: "code",
+    redirect_uri:  redirectUri,
+    client_id:     clientId,
+  });
+  return `${HONEYWELL_API}/oauth2/authorize?${params}`;
+}
+
+export async function exchangeCode(
+  code:         string,
+  clientId:     string,
+  clientSecret: string,
+  redirectUri:  string,
+): Promise<string> {
+  const credentials = Buffer.from(`${clientId}:${clientSecret}`).toString("base64");
+  const body = new URLSearchParams({
+    grant_type:   "authorization_code",
+    code,
+    redirect_uri: redirectUri,
+  });
+
+  const resp = await fetch(`${HONEYWELL_API}/oauth2/token`, {
+    method: "POST",
+    headers: {
+      "Content-Type":  "application/x-www-form-urlencoded",
+      "Authorization": `Basic ${credentials}`,
+    },
+    body: body.toString(),
+  });
+  if (!resp.ok) throw new Error(`Honeywell token exchange failed (${resp.status}): ${await resp.text()}`);
+
+  const data = await resp.json() as { access_token: string };
+  return data.access_token;
+}
+
+export async function fetchDevices(accessToken: string, clientId: string): Promise<OAuthDevice[]> {
+  const resp = await fetch(`${HONEYWELL_API}/v2/devices/thermostats?apikey=${encodeURIComponent(clientId)}`, {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+  if (!resp.ok) throw new Error(`Honeywell device list failed (${resp.status})`);
+
+  const data = await resp.json() as Array<{ deviceID: string; userDefinedDeviceName: string; deviceType?: string }>;
+  return (Array.isArray(data) ? data : []).map((d) => ({
+    id:   d.deviceID,
+    name: d.userDefinedDeviceName || d.deviceID,
+    type: d.deviceType ?? "Thermostat",
+  }));
+}

--- a/agents/iot-gateway/oauth/lgThinQ.ts
+++ b/agents/iot-gateway/oauth/lgThinQ.ts
@@ -1,0 +1,69 @@
+/**
+ * LG ThinQ OAuth device picker — used by the RegisterDeviceModal popup flow.
+ *
+ * Uses LG's official ThinQ API v2 (OAuth 2.0 authorization code flow).
+ * API base URL is region-specific; defaults to US.
+ */
+
+const LG_API_BASE = process.env.LG_THINQ_API_BASE ?? "https://us.api.lgthinq.com:46030";
+
+export interface OAuthDevice {
+  id:   string;
+  name: string;
+  type: string;
+}
+
+export function authUrl(clientId: string, redirectUri: string): string {
+  const params = new URLSearchParams({
+    response_type: "code",
+    client_id:     clientId,
+    redirect_uri:  redirectUri,
+    scope:         "monitoring",
+  });
+  return `${LG_API_BASE}/oauth/authorize?${params}`;
+}
+
+export async function exchangeCode(
+  code:         string,
+  clientId:     string,
+  clientSecret: string,
+  redirectUri:  string,
+): Promise<string> {
+  const body = new URLSearchParams({
+    grant_type:    "authorization_code",
+    code,
+    redirect_uri:  redirectUri,
+    client_id:     clientId,
+    client_secret: clientSecret,
+  });
+
+  const resp = await fetch(`${LG_API_BASE}/oauth/token`, {
+    method:  "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body:    body.toString(),
+  });
+  if (!resp.ok) throw new Error(`LG ThinQ token exchange failed (${resp.status}): ${await resp.text()}`);
+
+  const data = await resp.json() as { access_token: string };
+  return data.access_token;
+}
+
+export async function fetchDevices(accessToken: string): Promise<OAuthDevice[]> {
+  const resp = await fetch(`${LG_API_BASE}/devices`, {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      "x-country-code": "US",
+      "x-language-code": "en-US",
+    },
+  });
+  if (!resp.ok) throw new Error(`LG ThinQ device list failed (${resp.status})`);
+
+  const data = await resp.json() as {
+    result?: Array<{ deviceId: string; alias: string; deviceType?: string }>
+  };
+  return (data.result ?? []).map((d) => ({
+    id:   d.deviceId,
+    name: d.alias || d.deviceId,
+    type: d.deviceType ?? "Appliance",
+  }));
+}

--- a/agents/iot-gateway/pollers/solarEdge.ts
+++ b/agents/iot-gateway/pollers/solarEdge.ts
@@ -1,0 +1,145 @@
+/**
+ * SolarEdge cloud REST polling script.
+ *
+ * SolarEdge has no local API — all data is retrieved from their cloud.
+ * Rate limit: 300 requests/account/day → poll every 15 min gives ~96/day per site.
+ *
+ * Required env vars (see .env.example):
+ *   SOLAREDGE_API_KEY   — from monitoring.solaredge.com → Admin → API Access
+ *   SOLAREDGE_SITE_ID   — numeric site ID visible in the monitoring portal URL
+ */
+
+import { handleSolarEdgeEvent } from "../handlers";
+import { recordSensorEvent } from "../icp";
+import type { SolarEdgeEvent } from "../types";
+
+const SOLAREDGE_API = "https://monitoringapi.solaredge.com";
+
+// ── Config ────────────────────────────────────────────────────────────────────
+
+export interface SolarEdgeConfig {
+  apiKey: string;
+  siteId: string;
+}
+
+export function loadConfig(): SolarEdgeConfig | null {
+  const apiKey = process.env.SOLAREDGE_API_KEY;
+  const siteId = process.env.SOLAREDGE_SITE_ID;
+  if (!apiKey || !siteId) return null;
+  return { apiKey, siteId };
+}
+
+// ── API response shapes ───────────────────────────────────────────────────────
+
+interface SolarEdgeOverview {
+  overview: {
+    currentPower: { power: number };
+  };
+}
+
+interface SolarEdgeAlertsResponse {
+  alerts?: Array<{
+    severity: string; // "CRITICAL" | "WARNING" | "INFO"
+    type:     string;
+    message?: string;
+  }>;
+}
+
+// ── Poll ──────────────────────────────────────────────────────────────────────
+
+function isDaylight(): boolean {
+  const hour = new Date().getHours();
+  return hour >= 7 && hour < 19;
+}
+
+export async function pollOnce(config: SolarEdgeConfig): Promise<void> {
+  const base   = `${SOLAREDGE_API}/site/${config.siteId}`;
+  const apiKey = `api_key=${encodeURIComponent(config.apiKey)}`;
+
+  const [overviewResp, alertsResp] = await Promise.all([
+    fetch(`${base}/overview.json?${apiKey}`, { signal: AbortSignal.timeout(10_000) }),
+    fetch(`${base}/alerts.json?${apiKey}`,   { signal: AbortSignal.timeout(10_000) }),
+  ]);
+
+  if (!overviewResp.ok) {
+    console.error(`[solaredge-poller] overview fetch failed (${overviewResp.status}): ${await overviewResp.text()}`);
+    return;
+  }
+
+  const overview = await overviewResp.json() as SolarEdgeOverview;
+  const currentPowerW = overview.overview?.currentPower?.power ?? 0;
+
+  let hasCriticalAlert = false;
+  if (alertsResp.ok) {
+    const alertsData = await alertsResp.json() as SolarEdgeAlertsResponse;
+    hasCriticalAlert = (alertsData.alerts ?? []).some(
+      (a) => a.severity?.toUpperCase() === "CRITICAL"
+    );
+  }
+
+  const event: SolarEdgeEvent = {
+    siteId:           config.siteId,
+    currentPowerW,
+    hasCriticalAlert,
+    isDaylight:       isDaylight(),
+  };
+
+  const raw     = JSON.stringify({ overview: overview.overview, hasCriticalAlert });
+  const reading = handleSolarEdgeEvent(event, raw);
+  if (!reading) return;
+
+  const eventName = Object.keys(reading.eventType)[0];
+  console.log(`[solaredge-poller] ${eventName} siteId=${config.siteId} power=${currentPowerW}W`);
+
+  const result = await recordSensorEvent(reading);
+  if (result.success) {
+    console.log(
+      `[solaredge-poller] recorded eventId=${result.eventId}` +
+      (result.jobId ? ` jobId=${result.jobId}` : "")
+    );
+  } else {
+    console.error(`[solaredge-poller] canister error: ${result.error}`);
+  }
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/**
+ * Starts the SolarEdge polling loop. Returns a stop function.
+ * No-ops when SOLAREDGE_API_KEY or SOLAREDGE_SITE_ID are absent.
+ * Polls every 15 min by default to stay comfortably under the 300 req/day limit.
+ */
+export function startSolarEdgePoller(intervalMs = 15 * 60 * 1000): () => void {
+  const config = loadConfig();
+  if (!config) {
+    console.warn(
+      "[solaredge-poller] SOLAREDGE_API_KEY or SOLAREDGE_SITE_ID not set — poller disabled"
+    );
+    return () => {};
+  }
+
+  let stopped = false;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+
+  async function tick(): Promise<void> {
+    if (stopped) return;
+    try {
+      await pollOnce(config);
+    } catch (err) {
+      console.error("[solaredge-poller] tick error:", err);
+    } finally {
+      if (!stopped) {
+        timer = setTimeout(tick, intervalMs);
+      }
+    }
+  }
+
+  console.log(`[solaredge-poller] starting — siteId=${config.siteId} interval=${intervalMs / 1000}s`);
+  tick();
+
+  return () => {
+    stopped = true;
+    if (timer) clearTimeout(timer);
+    console.log("[solaredge-poller] stopped");
+  };
+}

--- a/agents/iot-gateway/server.ts
+++ b/agents/iot-gateway/server.ts
@@ -34,6 +34,11 @@ import { startHoneywellPoller, persistTokenState as persistHoneywellTokens } fro
 import { startEnphasePoller } from "./pollers/enphase";
 import { startTeslaPoller } from "./pollers/teslaGateway";
 import { startGEPoller, persistTokenState as persistGETokens } from "./pollers/geSmartHQ";
+import { startSolarEdgePoller } from "./pollers/solarEdge";
+import * as ecobeeOAuth      from "./oauth/ecobee";
+import * as honeywellOAuth   from "./oauth/honeywellHome";
+import * as lgThinQOAuth     from "./oauth/lgThinQ";
+import * as geSmartHQOAuth   from "./oauth/geSmartHQ";
 import type {
   NestWebhookEvent,
   EcobeeWebhookEvent,
@@ -466,19 +471,205 @@ app.get("/oauth/callback/ge", async (req: Request, res: Response): Promise<void>
   }
 });
 
+// ── GET /oauth/device/start/:platform ────────────────────────────────────────
+// Tier B device picker: redirect to platform's authorization URL.
+// The `redirect_uri` points back to /oauth/device/callback/:platform.
+app.get("/oauth/device/start/:platform", (req: Request, res: Response): void => {
+  const { platform } = req.params;
+  const redirectUri  = `http://localhost:${port}/oauth/device/callback/${platform}`;
+
+  try {
+    let url: string;
+    switch (platform) {
+      case "ecobee":
+        url = ecobeeOAuth.authUrl(process.env.ECOBEE_CLIENT_ID ?? "", redirectUri);
+        break;
+      case "honeywell":
+        url = honeywellOAuth.authUrl(process.env.HONEYWELL_CLIENT_ID ?? "", redirectUri);
+        break;
+      case "lgthinq":
+        url = lgThinQOAuth.authUrl(process.env.LG_THINQ_CLIENT_ID ?? "", redirectUri);
+        break;
+      case "ge":
+        url = geSmartHQOAuth.authUrl(process.env.GE_CLIENT_ID ?? "", redirectUri);
+        break;
+      default:
+        res.status(400).send("Unknown platform");
+        return;
+    }
+    res.redirect(url);
+  } catch (err) {
+    console.error(`[oauth-device] start error (${platform}):`, err);
+    res.status(500).send("OAuth start error");
+  }
+});
+
+// ── GET /oauth/device/callback/:platform ──────────────────────────────────────
+// Tier B device picker: exchanges the auth code, fetches device list, sends
+// postMessage to the opener popup, then closes itself.
+app.get("/oauth/device/callback/:platform", async (req: Request, res: Response): Promise<void> => {
+  const { platform } = req.params;
+  const code         = req.query.code as string | undefined;
+
+  if (!code) {
+    res.status(400).send("Missing code parameter");
+    return;
+  }
+
+  const redirectUri = `http://localhost:${port}/oauth/device/callback/${platform}`;
+
+  try {
+    let accessToken: string;
+    let devices: Array<{ id: string; name: string; type: string }>;
+
+    switch (platform) {
+      case "ecobee":
+        accessToken = await ecobeeOAuth.exchangeCode(code, process.env.ECOBEE_CLIENT_ID ?? "", redirectUri);
+        devices     = await ecobeeOAuth.fetchDevices(accessToken);
+        break;
+      case "honeywell":
+        accessToken = await honeywellOAuth.exchangeCode(
+          code, process.env.HONEYWELL_CLIENT_ID ?? "",
+          process.env.HONEYWELL_CLIENT_SECRET ?? "", redirectUri
+        );
+        devices = await honeywellOAuth.fetchDevices(accessToken, process.env.HONEYWELL_CLIENT_ID ?? "");
+        break;
+      case "lgthinq":
+        accessToken = await lgThinQOAuth.exchangeCode(
+          code, process.env.LG_THINQ_CLIENT_ID ?? "",
+          process.env.LG_THINQ_CLIENT_SECRET ?? "", redirectUri
+        );
+        devices = await lgThinQOAuth.fetchDevices(accessToken);
+        break;
+      case "ge":
+        accessToken = await geSmartHQOAuth.exchangeCode(
+          code, process.env.GE_CLIENT_ID ?? "",
+          process.env.GE_CLIENT_SECRET ?? "", redirectUri
+        );
+        devices = await geSmartHQOAuth.fetchDevices(accessToken);
+        break;
+      default:
+        res.status(400).send("Unknown platform");
+        return;
+    }
+
+    const payload = JSON.stringify({ type: "oauth-devices", devices });
+    res.send(`<!doctype html>
+<html><body>
+<script>
+  window.opener && window.opener.postMessage(${payload}, "*");
+  window.close();
+</script>
+<p>Connected! This window will close automatically.</p>
+</body></html>`);
+  } catch (err: any) {
+    const errMsg = JSON.stringify({ type: "oauth-devices", error: String(err?.message ?? err) });
+    res.send(`<!doctype html>
+<html><body>
+<script>
+  window.opener && window.opener.postMessage(${errMsg}, "*");
+  window.close();
+</script>
+<p>Authorization failed. This window will close automatically.</p>
+</body></html>`);
+  }
+});
+
+// ── POST /accounts/:platform ──────────────────────────────────────────────────
+// Tier D credential validation: accepts email + password for credential-based
+// platforms (Rheem EcoNet, Sense, Emporia Vue), stores credentials in the
+// gateway process env, and returns the user's device list.
+// Credentials are NEVER forwarded to the ICP canister.
+app.post("/accounts/:platform", async (req: Request, res: Response): Promise<void> => {
+  const { platform } = req.params;
+  const { email, password } = req.body as { email?: string; password?: string };
+
+  if (!email || !password) {
+    res.status(400).json({ error: "email and password are required" });
+    return;
+  }
+
+  try {
+    let devices: Array<{ id: string; name: string; type: string }> = [];
+
+    if (platform === "rheem") {
+      const loginResp = await fetch("https://rheem.clearblade.com/api/v/4/user/auth/login", {
+        method:  "POST",
+        headers: { "Content-Type": "application/json", "ClearBlade-SystemKey": "e2e699cb0bb0bbb88fc8858cb5a401" },
+        body:    JSON.stringify({ email, password }),
+        signal:  AbortSignal.timeout(10_000),
+      });
+      if (!loginResp.ok) throw new Error(`Rheem EcoNet login failed (${loginResp.status})`);
+      const loginData = await loginResp.json() as { user_token: string };
+      process.env.RHEEM_ACCESS_TOKEN = loginData.user_token;
+
+      const devResp = await fetch("https://rheem.clearblade.com/api/v/4/data/devices_data", {
+        headers: { "ClearBlade-UserToken": loginData.user_token, "ClearBlade-SystemKey": "e2e699cb0bb0bbb88fc8858cb5a401" },
+        signal:  AbortSignal.timeout(10_000),
+      });
+      if (devResp.ok) {
+        const devData = await devResp.json() as { DATA: Array<{ serial_number: string; location_name?: string; product_type?: string }> };
+        devices = (devData.DATA ?? []).map((d) => ({ id: d.serial_number, name: d.location_name ?? d.serial_number, type: d.product_type ?? "Water Heater" }));
+      }
+
+    } else if (platform === "sense") {
+      const loginResp = await fetch("https://api.sense.com/apiservice/api/v1/authenticate", {
+        method:  "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body:    new URLSearchParams({ email, password }).toString(),
+        signal:  AbortSignal.timeout(10_000),
+      });
+      if (!loginResp.ok) throw new Error(`Sense login failed (${loginResp.status})`);
+      const loginData = await loginResp.json() as { access_token: string; monitors?: Array<{ id: number; serial_number: string }> };
+      process.env.SENSE_ACCESS_TOKEN = loginData.access_token;
+      devices = (loginData.monitors ?? []).map((m) => ({ id: String(m.id), name: `Sense Monitor ${m.serial_number}`, type: "Energy Monitor" }));
+
+    } else if (platform === "emporia") {
+      const loginResp = await fetch("https://auth.emporiaenergy.com/login", {
+        method:  "POST",
+        headers: { "Content-Type": "application/json" },
+        body:    JSON.stringify({ userName: email, password, rememberMe: false }),
+        signal:  AbortSignal.timeout(10_000),
+      });
+      if (!loginResp.ok) throw new Error(`Emporia Vue login failed (${loginResp.status})`);
+      const loginData = await loginResp.json() as { authToken: string; customerGid?: number };
+      process.env.EMPORIA_ACCESS_TOKEN = loginData.authToken;
+      if (loginData.customerGid) {
+        const devResp = await fetch(`https://api.emporiaenergy.com/customers/${loginData.customerGid}/devices?detailed=true&hierarchy=true`, {
+          headers: { authToken: loginData.authToken },
+          signal:  AbortSignal.timeout(10_000),
+        });
+        if (devResp.ok) {
+          const devData = await devResp.json() as { devices: Array<{ deviceGid: number; locationProperties?: { deviceName?: string } }> };
+          devices = (devData.devices ?? []).map((d) => ({ id: String(d.deviceGid), name: d.locationProperties?.deviceName ?? `Emporia Vue ${d.deviceGid}`, type: "Energy Monitor" }));
+        }
+      }
+    } else {
+      res.status(400).json({ error: "Unknown platform" });
+      return;
+    }
+
+    res.json({ devices });
+  } catch (err: any) {
+    console.error(`[accounts] ${platform} error:`, err);
+    res.status(502).json({ error: err?.message ?? "Login failed" });
+  }
+});
+
 // ── GET /health ───────────────────────────────────────────────────────────────
 app.get("/health", (_req: Request, res: Response) => {
   res.json({
     ok: true,
     gatewayPrincipal: getGatewayPrincipal(),
     sensorCanisterId: process.env.SENSOR_CANISTER_ID ?? "(not set)",
-    platforms: ["nest", "ecobee", "moen-flo", "smartthings", "honeywell-home", "enphase", "tesla-powerwall", "lgthinq", "ge-smarthq"],
+    platforms: ["nest", "ecobee", "moen-flo", "smartthings", "honeywell-home", "enphase", "tesla-powerwall", "lgthinq", "ge-smarthq", "solaredge"],
     pollers: {
       ecobee:    !!process.env.ECOBEE_CLIENT_ID,
       honeywell: !!process.env.HONEYWELL_CLIENT_ID,
       enphase:   !!process.env.ENPHASE_ENVOY_IP,
       tesla:     !!(process.env.TESLA_EMAIL && process.env.TESLA_POWERWALL_SERIAL),
       ge:        !!process.env.GE_CLIENT_ID,
+      solaredge: !!process.env.SOLAREDGE_API_KEY,
     },
   });
 });
@@ -504,5 +695,8 @@ app.listen(port, () => {
   }
   if (process.env.GE_CLIENT_ID) {
     startGEPoller();
+  }
+  if (process.env.SOLAREDGE_API_KEY) {
+    startSolarEdgePoller();
   }
 });

--- a/agents/iot-gateway/types.ts
+++ b/agents/iot-gateway/types.ts
@@ -198,6 +198,20 @@ export interface GEApplianceAttributes {
   attributes:  Record<string, GEAttributeValue>;
 }
 
+// ── SolarEdge ─────────────────────────────────────────────────────────────────
+
+/** Normalized event built by the SolarEdge poller from overview + alerts data. */
+export interface SolarEdgeEvent {
+  /** Numeric site ID — used as externalDeviceId */
+  siteId:          string;
+  /** Current site power in watts (from overview.currentPower.power) */
+  currentPowerW:   number;
+  /** True when a CRITICAL alert is present in the site's active alerts */
+  hasCriticalAlert: boolean;
+  /** True when it is expected sun hours (7am–7pm heuristic) */
+  isDaylight:      boolean;
+}
+
 // ── Moen Flo ─────────────────────────────────────────────────────────────────
 export type MoenFloAlertType =
   | "LEAK"

--- a/backend/sensor/main.mo
+++ b/backend/sensor/main.mo
@@ -45,6 +45,7 @@ persistent actor Sensor {
     #EmporiaVue; #Rachio; #SmartThings; #HomeAssistant;
     #EnphaseEnvoy; #TeslaPowerwall;
     #LGThinQ; #GESmartHQ;
+    #SolarEdge;
   };
 
   public type SensorEventType = {

--- a/frontend/src/__tests__/contracts/__snapshots__/candid.contract.test.ts.snap
+++ b/frontend/src/__tests__/contracts/__snapshots__/candid.contract.test.ts.snap
@@ -1507,7 +1507,7 @@ exports[`sensor IDL factory > full signature snapshot 1`] = `
       "query",
     ],
     "rets": [
-      "vec record {id:text; externalDeviceId:text; source:variant {Sense; Nest; HomeAssistant; MoenFlo; HoneywellHome; SmartThings; RheemEcoNet; RingAlarm; Ecobee; Rachio; Manual; EmporiaVue}; name:text; propertyId:text; isActive:bool; homeowner:principal; registeredAt:int}",
+      "vec record {id:text; externalDeviceId:text; source:variant {Sense; GESmartHQ; Nest; HomeAssistant; MoenFlo; SolarEdge; LGThinQ; TeslaPowerwall; HoneywellHome; SmartThings; EnphaseEnvoy; RheemEcoNet; RingAlarm; Ecobee; Rachio; Manual; EmporiaVue}; name:text; propertyId:text; isActive:bool; homeowner:principal; registeredAt:int}",
     ],
   },
   "getEventsForProperty": {
@@ -1519,7 +1519,7 @@ exports[`sensor IDL factory > full signature snapshot 1`] = `
       "query",
     ],
     "rets": [
-      "vec record {id:text; value:float64; unit:text; jobId:opt text; propertyId:text; deviceId:text; timestamp:int; severity:variant {Info; Critical; Warning}; homeowner:principal; rawPayload:text; eventType:variant {FloodRisk; WaterLeak; HvacFilterDue; HighTemperature; LowTemperature; HvacAlert; LeakDetected; HighHumidity}}",
+      "vec record {id:text; value:float64; unit:text; jobId:opt text; propertyId:text; deviceId:text; timestamp:int; severity:variant {Info; Critical; Warning}; homeowner:principal; rawPayload:text; eventType:variant {FloodRisk; GridOutage; LowProduction; WaterLeak; ApplianceFault; BatteryLow; HvacFilterDue; HighTemperature; LowTemperature; HvacAlert; ApplianceMaintenance; LeakDetected; HighHumidity; SolarFault}}",
     ],
   },
   "getPendingAlerts": {
@@ -1530,32 +1530,32 @@ exports[`sensor IDL factory > full signature snapshot 1`] = `
       "query",
     ],
     "rets": [
-      "vec record {id:text; value:float64; unit:text; jobId:opt text; propertyId:text; deviceId:text; timestamp:int; severity:variant {Info; Critical; Warning}; homeowner:principal; rawPayload:text; eventType:variant {FloodRisk; WaterLeak; HvacFilterDue; HighTemperature; LowTemperature; HvacAlert; LeakDetected; HighHumidity}}",
+      "vec record {id:text; value:float64; unit:text; jobId:opt text; propertyId:text; deviceId:text; timestamp:int; severity:variant {Info; Critical; Warning}; homeowner:principal; rawPayload:text; eventType:variant {FloodRisk; GridOutage; LowProduction; WaterLeak; ApplianceFault; BatteryLow; HvacFilterDue; HighTemperature; LowTemperature; HvacAlert; ApplianceMaintenance; LeakDetected; HighHumidity; SolarFault}}",
     ],
   },
   "recordEvent": {
     "args": [
       "text",
-      "variant {FloodRisk; WaterLeak; HvacFilterDue; HighTemperature; LowTemperature; HvacAlert; LeakDetected; HighHumidity}",
+      "variant {FloodRisk; GridOutage; LowProduction; WaterLeak; ApplianceFault; BatteryLow; HvacFilterDue; HighTemperature; LowTemperature; HvacAlert; ApplianceMaintenance; LeakDetected; HighHumidity; SolarFault}",
       "float64",
       "text",
       "text",
     ],
     "mode": [],
     "rets": [
-      "variant {ok:record {id:text; value:float64; unit:text; jobId:opt text; propertyId:text; deviceId:text; timestamp:int; severity:variant {Info; Critical; Warning}; homeowner:principal; rawPayload:text; eventType:variant {FloodRisk; WaterLeak; HvacFilterDue; HighTemperature; LowTemperature; HvacAlert; LeakDetected; HighHumidity}}; err:variant {InvalidInput:text; NotFound; Unauthorized; AlreadyExists}}",
+      "variant {ok:record {id:text; value:float64; unit:text; jobId:opt text; propertyId:text; deviceId:text; timestamp:int; severity:variant {Info; Critical; Warning}; homeowner:principal; rawPayload:text; eventType:variant {FloodRisk; GridOutage; LowProduction; WaterLeak; ApplianceFault; BatteryLow; HvacFilterDue; HighTemperature; LowTemperature; HvacAlert; ApplianceMaintenance; LeakDetected; HighHumidity; SolarFault}}; err:variant {InvalidInput:text; NotFound; Unauthorized; AlreadyExists}}",
     ],
   },
   "registerDevice": {
     "args": [
       "text",
       "text",
-      "variant {Sense; Nest; HomeAssistant; MoenFlo; HoneywellHome; SmartThings; RheemEcoNet; RingAlarm; Ecobee; Rachio; Manual; EmporiaVue}",
+      "variant {Sense; GESmartHQ; Nest; HomeAssistant; MoenFlo; SolarEdge; LGThinQ; TeslaPowerwall; HoneywellHome; SmartThings; EnphaseEnvoy; RheemEcoNet; RingAlarm; Ecobee; Rachio; Manual; EmporiaVue}",
       "text",
     ],
     "mode": [],
     "rets": [
-      "variant {ok:record {id:text; externalDeviceId:text; source:variant {Sense; Nest; HomeAssistant; MoenFlo; HoneywellHome; SmartThings; RheemEcoNet; RingAlarm; Ecobee; Rachio; Manual; EmporiaVue}; name:text; propertyId:text; isActive:bool; homeowner:principal; registeredAt:int}; err:variant {InvalidInput:text; NotFound; Unauthorized; AlreadyExists}}",
+      "variant {ok:record {id:text; externalDeviceId:text; source:variant {Sense; GESmartHQ; Nest; HomeAssistant; MoenFlo; SolarEdge; LGThinQ; TeslaPowerwall; HoneywellHome; SmartThings; EnphaseEnvoy; RheemEcoNet; RingAlarm; Ecobee; Rachio; Manual; EmporiaVue}; name:text; propertyId:text; isActive:bool; homeowner:principal; registeredAt:int}; err:variant {InvalidInput:text; NotFound; Unauthorized; AlreadyExists}}",
     ],
   },
 }

--- a/frontend/src/components/RegisterDeviceModal.tsx
+++ b/frontend/src/components/RegisterDeviceModal.tsx
@@ -1,7 +1,8 @@
 import React, { useState } from "react";
-import { X } from "lucide-react";
+import { X, ChevronDown, ChevronUp, ExternalLink } from "lucide-react";
 import { Button } from "@/components/Button";
 import { sensorService, type SensorDevice, type DeviceSource } from "@/services/sensor";
+import { useOAuthDevicePicker, type OAuthPickedDevice } from "@/hooks/useOAuthDevicePicker";
 import toast from "react-hot-toast";
 import { COLORS, FONTS, RADIUS } from "@/theme";
 
@@ -15,26 +16,77 @@ const UI = {
   sans:     FONTS.sans,
 };
 
+// ─── Tier classification ──────────────────────────────────────────────────────
+
+const TIER_B: DeviceSource[] = ["Ecobee", "HoneywellHome", "LGThinQ", "GESmartHQ"];
+const TIER_C: DeviceSource[] = ["EnphaseEnvoy", "TeslaPowerwall"];
+
+const TIER_B_PLATFORM: Record<string, string> = {
+  Ecobee:        "ecobee",
+  HoneywellHome: "honeywell",
+  LGThinQ:       "lgthinq",
+  GESmartHQ:     "ge",
+};
+
+// ─── Tier A help text ─────────────────────────────────────────────────────────
+
+interface DeviceHelp { format: string; instructions: string }
+
+const DEVICE_ID_HELP: Partial<Record<DeviceSource, DeviceHelp>> = {
+  Nest: {
+    format:       "projects/{project-id}/devices/{device-id}",
+    instructions: "Find your device ID in the Google Home app → Device Settings → Linked Accounts, or in the Google SDM console at console.nest.google.com.",
+  },
+  MoenFlo: {
+    format:       "00000000-0000-0000-0000-000000000000 (UUID)",
+    instructions: "Open the Moen Flo app → Settings → Device → copy the Device ID field.",
+  },
+  RingAlarm: {
+    format:       "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx (hex string)",
+    instructions: "Run `npx ring-client-api ding` and copy the device ID from the console output.",
+  },
+  Rachio: {
+    format:       "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx (UUID)",
+    instructions: "Log into app.rach.io → Account → Devices → click your controller → copy the UUID from the URL bar.",
+  },
+  SmartThings: {
+    format:       "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx (UUID)",
+    instructions: "SmartThings app → … (more) → Settings → API Access → copy the Device ID, or from the SmartThings Developer Workspace.",
+  },
+  HomeAssistant: {
+    format:       "entity_id (e.g. sensor.living_room_temp)",
+    instructions: "Home Assistant → Settings → Devices & Services → click your device → copy the Entity ID.",
+  },
+  SolarEdge: {
+    format:       "123456 (numeric site ID)",
+    instructions: "Log into monitoring.solaredge.com. Your site ID appears in the URL: /p/site/123456/dashboard.",
+  },
+  Manual: {
+    format:       "Any unique identifier you choose",
+    instructions: "Enter any code you want to use to track this device, e.g. HOME-SENSOR-01.",
+  },
+};
+
+// ─── Sources (Tier D removed from this list) ─────────────────────────────────
+
 const SOURCES: { value: DeviceSource; label: string }[] = [
-  { value: "Nest",          label: "Google Nest"             },
-  { value: "Ecobee",        label: "Ecobee"                  },
-  { value: "MoenFlo",       label: "Moen Flo"                },
-  { value: "RingAlarm",     label: "Ring Alarm"              },
-  { value: "HoneywellHome", label: "Honeywell Home"          },
-  { value: "RheemEcoNet",   label: "Rheem EcoNet"            },
-  { value: "Sense",         label: "Sense Energy Monitor"    },
-  { value: "EmporiaVue",    label: "Emporia Vue"             },
-  { value: "Rachio",        label: "Rachio Smart Sprinkler"  },
-  { value: "SmartThings",   label: "Samsung SmartThings"     },
-  { value: "HomeAssistant", label: "Home Assistant"          },
-  { value: "Manual",        label: "Manual Entry"            },
+  { value: "Nest",           label: "Google Nest"            },
+  { value: "Ecobee",         label: "Ecobee"                 },
+  { value: "MoenFlo",        label: "Moen Flo"               },
+  { value: "RingAlarm",      label: "Ring Alarm"             },
+  { value: "HoneywellHome",  label: "Honeywell Home"         },
+  { value: "Rachio",         label: "Rachio Smart Sprinkler" },
+  { value: "SmartThings",    label: "Samsung SmartThings"    },
+  { value: "HomeAssistant",  label: "Home Assistant"         },
+  { value: "SolarEdge",      label: "SolarEdge Solar"        },
+  { value: "EnphaseEnvoy",   label: "Enphase IQ Gateway"     },
+  { value: "TeslaPowerwall", label: "Tesla Powerwall"        },
+  { value: "LGThinQ",        label: "LG ThinQ"               },
+  { value: "GESmartHQ",      label: "GE SmartHQ"             },
+  { value: "Manual",         label: "Manual Entry"           },
 ];
 
-const BLANK = {
-  name:             "",
-  externalDeviceId: "",
-  source:           "Nest" as DeviceSource,
-};
+const BLANK = { name: "", externalDeviceId: "", source: "Nest" as DeviceSource };
 
 interface Props {
   isOpen:     boolean;
@@ -44,18 +96,44 @@ interface Props {
 }
 
 export function RegisterDeviceModal({ isOpen, onClose, onSuccess, propertyId }: Props) {
-  const [form,    setForm]    = useState({ ...BLANK });
-  const [loading, setLoading] = useState(false);
+  const [form,        setForm]        = useState({ ...BLANK });
+  const [loading,     setLoading]     = useState(false);
+  const [showHelp,    setShowHelp]    = useState(false);
+  const [lanIp,       setLanIp]       = useState("");
+  const [pickedDevice, setPickedDevice] = useState<OAuthPickedDevice | null>(null);
+
+  const oAuth = useOAuthDevicePicker();
 
   if (!isOpen) return null;
 
-  const set = (k: keyof typeof BLANK) => (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) =>
-    setForm((prev) => ({ ...prev, [k]: e.target.value }));
+  const source = form.source;
+  const isTierB = (TIER_B as string[]).includes(source);
+  const isTierC = (TIER_C as string[]).includes(source);
+  const help    = DEVICE_ID_HELP[source];
+
+  const set = (k: keyof typeof BLANK) =>
+    (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
+      setForm((prev) => ({ ...prev, [k]: e.target.value }));
+      setPickedDevice(null);
+      oAuth.reset();
+      setShowHelp(false);
+    };
+
+  const handlePickDevice = (device: OAuthPickedDevice) => {
+    setPickedDevice(device);
+    setForm((prev) => ({ ...prev, name: device.name, externalDeviceId: device.id }));
+  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    const deviceId = isTierC ? lanIp.trim() + ":" + form.externalDeviceId.trim()
+                              : form.externalDeviceId.trim();
     if (!form.name.trim() || !form.externalDeviceId.trim()) {
       toast.error("Device name and ID are required");
+      return;
+    }
+    if (isTierC && !lanIp.trim()) {
+      toast.error("Local IP address is required");
       return;
     }
     if (!propertyId) {
@@ -65,14 +143,14 @@ export function RegisterDeviceModal({ isOpen, onClose, onSuccess, propertyId }: 
     setLoading(true);
     try {
       const device = await sensorService.registerDevice(
-        propertyId,
-        form.externalDeviceId.trim(),
-        form.source,
-        form.name.trim(),
+        propertyId, deviceId, form.source, form.name.trim(),
       );
       toast.success("Device registered");
       onSuccess(device);
       setForm({ ...BLANK });
+      setLanIp("");
+      setPickedDevice(null);
+      oAuth.reset();
       onClose();
     } catch (err: any) {
       toast.error(err?.message ?? "Failed to register device");
@@ -102,28 +180,24 @@ export function RegisterDeviceModal({ isOpen, onClose, onSuccess, propertyId }: 
       }}
       onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
     >
-      <div
-        style={{
-          background: COLORS.white, width: "100%", maxWidth: "28rem",
-          borderRadius: RADIUS.card, padding: "1.75rem",
-          boxShadow: "0 8px 32px rgba(0,0,0,0.18)",
-        }}
-      >
+      <div style={{
+        background: COLORS.white, width: "100%", maxWidth: "30rem",
+        borderRadius: RADIUS.card, padding: "1.75rem",
+        boxShadow: "0 8px 32px rgba(0,0,0,0.18)",
+        maxHeight: "90vh", overflowY: "auto",
+      }}>
         {/* Header */}
         <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: "1.5rem" }}>
           <h2 style={{ fontFamily: UI.serif, fontWeight: 700, fontSize: "1.1rem", color: UI.ink }}>
             Register Device
           </h2>
-          <button
-            onClick={onClose}
-            style={{ background: "none", border: "none", cursor: "pointer", color: UI.inkLight, padding: "0.25rem" }}
-          >
+          <button onClick={onClose} style={{ background: "none", border: "none", cursor: "pointer", color: UI.inkLight, padding: "0.25rem" }}>
             <X size={16} />
           </button>
         </div>
 
         <form onSubmit={handleSubmit} style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
-          {/* Source */}
+          {/* Device type */}
           <div>
             <label htmlFor="register-device-source" style={labelStyle}>Device Type</label>
             <select id="register-device-source" value={form.source} onChange={set("source")} style={inputStyle}>
@@ -133,35 +207,160 @@ export function RegisterDeviceModal({ isOpen, onClose, onSuccess, propertyId }: 
             </select>
           </div>
 
-          {/* Name */}
+          {/* Device name */}
           <div>
             <label style={labelStyle}>Device Name</label>
             <input
-              type="text"
-              value={form.name}
-              onChange={set("name")}
-              placeholder="e.g. Basement Water Sensor"
+              type="text" value={form.name} onChange={set("name")}
+              placeholder={isTierB && pickedDevice ? pickedDevice.name : "e.g. Basement Water Sensor"}
               style={inputStyle}
             />
           </div>
 
-          {/* External ID */}
-          <div>
-            <label style={labelStyle}>Device / Serial ID</label>
-            <input
-              type="text"
-              value={form.externalDeviceId}
-              onChange={set("externalDeviceId")}
-              placeholder="e.g. NEST-ABC-12345"
-              style={inputStyle}
-            />
-          </div>
+          {/* ── Tier B: OAuth button + device picker ── */}
+          {isTierB && (
+            <div>
+              {!oAuth.devices.length && !pickedDevice && (
+                <>
+                  <button
+                    type="button"
+                    onClick={() => oAuth.start(TIER_B_PLATFORM[source])}
+                    disabled={oAuth.loading}
+                    style={{
+                      display: "flex", alignItems: "center", gap: "0.5rem",
+                      padding: "0.5rem 1rem", fontFamily: UI.mono, fontSize: "0.72rem",
+                      letterSpacing: "0.08em", textTransform: "uppercase",
+                      background: UI.ink, color: COLORS.white, border: "none", cursor: "pointer",
+                    }}
+                  >
+                    <ExternalLink size={13} />
+                    {oAuth.loading ? "Connecting…" : `Connect ${SOURCES.find((s) => s.value === source)?.label} Account`}
+                  </button>
+                  {oAuth.error && (
+                    <p style={{ fontFamily: UI.mono, fontSize: "0.65rem", color: "#c94c2e", marginTop: "0.4rem" }}>
+                      {oAuth.error}
+                    </p>
+                  )}
+                  <p style={{ fontFamily: UI.mono, fontSize: "0.6rem", color: UI.inkLight, marginTop: "0.4rem" }}>
+                    A popup will open to authorize HomeGentic to read your device list. No data is stored.
+                  </p>
+                </>
+              )}
+
+              {oAuth.devices.length > 0 && !pickedDevice && (
+                <div>
+                  <label style={labelStyle}>Select Device</label>
+                  <div style={{ display: "flex", flexDirection: "column", gap: "0.5rem", maxHeight: "180px", overflowY: "auto" }}>
+                    {oAuth.devices.map((d) => (
+                      <button
+                        key={d.id} type="button" onClick={() => handlePickDevice(d)}
+                        style={{
+                          textAlign: "left", padding: "0.6rem 0.75rem",
+                          border: `1px solid ${UI.rule}`, background: "transparent",
+                          cursor: "pointer", fontFamily: UI.sans, fontSize: "0.825rem",
+                        }}
+                      >
+                        <span style={{ fontWeight: 500 }}>{d.name}</span>
+                        <span style={{ fontFamily: UI.mono, fontSize: "0.6rem", color: UI.inkLight, marginLeft: "0.5rem" }}>
+                          {d.type} · {d.id}
+                        </span>
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {pickedDevice && (
+                <div style={{ border: `1px solid ${UI.rule}`, padding: "0.6rem 0.75rem", background: "#f9f7f3" }}>
+                  <p style={{ fontFamily: UI.mono, fontSize: "0.6rem", textTransform: "uppercase", letterSpacing: "0.08em", color: UI.inkLight, marginBottom: "0.2rem" }}>
+                    Selected
+                  </p>
+                  <p style={{ fontFamily: UI.sans, fontSize: "0.825rem", fontWeight: 500, color: UI.ink }}>
+                    {pickedDevice.name}
+                  </p>
+                  <p style={{ fontFamily: UI.mono, fontSize: "0.6rem", color: UI.inkLight }}>
+                    {pickedDevice.type} · {pickedDevice.id}
+                  </p>
+                  <button
+                    type="button"
+                    onClick={() => { setPickedDevice(null); oAuth.reset(); setForm((p) => ({ ...p, name: "", externalDeviceId: "" })); }}
+                    style={{ fontFamily: UI.mono, fontSize: "0.6rem", color: UI.inkLight, background: "none", border: "none", cursor: "pointer", marginTop: "0.4rem", padding: 0 }}
+                  >
+                    Choose a different device
+                  </button>
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* ── Tier C: LAN IP + serial ── */}
+          {isTierC && (
+            <>
+              <div>
+                <label style={labelStyle}>Local IP Address</label>
+                <input
+                  type="text" value={lanIp} onChange={(e) => setLanIp(e.target.value)}
+                  placeholder="192.168.1.42"
+                  style={inputStyle}
+                />
+                <p style={{ fontFamily: UI.mono, fontSize: "0.6rem", color: UI.inkLight, marginTop: "0.3rem" }}>
+                  Check your router's device list for the gateway's LAN IP.
+                </p>
+              </div>
+              <div>
+                <label style={labelStyle}>Serial Number</label>
+                <input
+                  type="text" value={form.externalDeviceId} onChange={set("externalDeviceId")}
+                  placeholder={source === "TeslaPowerwall" ? "e.g. 1232100-00-J--T..." : "e.g. 202201..."}
+                  style={inputStyle}
+                />
+                <p style={{ fontFamily: UI.mono, fontSize: "0.6rem", color: UI.inkLight, marginTop: "0.3rem" }}>
+                  Found on the hardware sticker on the device.
+                </p>
+              </div>
+            </>
+          )}
+
+          {/* ── Tier A: ID field with optional help text ── */}
+          {!isTierB && !isTierC && (
+            <div>
+              <label style={labelStyle}>Device / Site ID</label>
+              <input
+                type="text" value={form.externalDeviceId} onChange={set("externalDeviceId")}
+                placeholder={help?.format ?? "e.g. DEVICE-ABC-12345"}
+                style={inputStyle}
+              />
+              {help && (
+                <button
+                  type="button"
+                  onClick={() => setShowHelp((v) => !v)}
+                  style={{
+                    display: "flex", alignItems: "center", gap: "0.3rem",
+                    fontFamily: UI.mono, fontSize: "0.6rem", color: UI.inkLight,
+                    background: "none", border: "none", cursor: "pointer", padding: "0.3rem 0", marginTop: "0.2rem",
+                  }}
+                >
+                  {showHelp ? <ChevronUp size={11} /> : <ChevronDown size={11} />}
+                  Where do I find this?
+                </button>
+              )}
+              {showHelp && help && (
+                <div style={{
+                  background: "#f9f7f3", border: `1px solid ${UI.rule}`,
+                  padding: "0.6rem 0.75rem", marginTop: "0.25rem",
+                  fontFamily: UI.mono, fontSize: "0.65rem", lineHeight: 1.6, color: UI.inkLight,
+                }}>
+                  <p style={{ marginBottom: "0.3rem" }}><strong>Format:</strong> {help.format}</p>
+                  <p>{help.instructions}</p>
+                </div>
+              )}
+            </div>
+          )}
 
           {/* Actions */}
           <div style={{ display: "flex", justifyContent: "flex-end", gap: "0.75rem", marginTop: "0.5rem" }}>
             <button
-              type="button"
-              onClick={onClose}
+              type="button" onClick={onClose}
               style={{
                 fontFamily: UI.mono, fontSize: "0.7rem", letterSpacing: "0.08em",
                 textTransform: "uppercase", padding: "0.5rem 1rem",
@@ -170,7 +369,10 @@ export function RegisterDeviceModal({ isOpen, onClose, onSuccess, propertyId }: 
             >
               Cancel
             </button>
-            <Button type="submit" disabled={loading}>
+            <Button
+              type="submit"
+              disabled={loading || (isTierB && !pickedDevice) || (isTierC && (!lanIp.trim() || !form.externalDeviceId.trim()))}
+            >
               {loading ? "Registering…" : "Register Device"}
             </Button>
           </div>

--- a/frontend/src/hooks/useOAuthDevicePicker.ts
+++ b/frontend/src/hooks/useOAuthDevicePicker.ts
@@ -1,0 +1,85 @@
+import { useState, useEffect, useRef } from "react";
+
+export interface OAuthPickedDevice {
+  id:   string;
+  name: string;
+  type: string;
+}
+
+interface OAuthMessage {
+  type:    "oauth-devices";
+  devices?: OAuthPickedDevice[];
+  error?:  string;
+}
+
+const GATEWAY_URL = (import.meta as any).env?.VITE_IOT_GATEWAY_URL ?? "http://localhost:3002";
+
+/**
+ * Opens an OAuth popup pointing at the gateway's /oauth/device/start/:platform
+ * route. Listens for the postMessage the callback page sends with the device list.
+ * Returns a { start, devices, loading, error, reset } API.
+ */
+export function useOAuthDevicePicker() {
+  const [devices, setDevices] = useState<OAuthPickedDevice[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error,   setError]   = useState<string | null>(null);
+  const popupRef = useRef<Window | null>(null);
+  const pollRef  = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (pollRef.current) clearInterval(pollRef.current);
+    };
+  }, []);
+
+  function start(platform: string) {
+    if (popupRef.current && !popupRef.current.closed) popupRef.current.close();
+    if (pollRef.current) clearInterval(pollRef.current);
+
+    setLoading(true);
+    setError(null);
+    setDevices([]);
+
+    const url    = `${GATEWAY_URL}/oauth/device/start/${platform}`;
+    const popup  = window.open(url, `oauth-${platform}`, "width=640,height=720,popup=yes");
+    popupRef.current = popup;
+
+    function onMessage(event: MessageEvent) {
+      const gatewayOrigin = new URL(GATEWAY_URL).origin;
+      // Gateway sends from its own origin; allow wildcard because popup may not
+      // share origin after auth-provider redirects.
+      const msg = event.data as OAuthMessage;
+      if (msg?.type !== "oauth-devices") return;
+
+      window.removeEventListener("message", onMessage);
+      if (pollRef.current) clearInterval(pollRef.current);
+      setLoading(false);
+
+      if (msg.error) {
+        setError(msg.error);
+      } else {
+        setDevices(msg.devices ?? []);
+      }
+      popup?.close();
+    }
+
+    window.addEventListener("message", onMessage);
+
+    // Fallback: if user closes popup without completing OAuth
+    pollRef.current = setInterval(() => {
+      if (popup?.closed) {
+        clearInterval(pollRef.current!);
+        window.removeEventListener("message", onMessage);
+        setLoading(false);
+      }
+    }, 500);
+  }
+
+  function reset() {
+    setDevices([]);
+    setError(null);
+    setLoading(false);
+  }
+
+  return { start, devices, loading, error, reset };
+}

--- a/frontend/src/pages/SensorPage.tsx
+++ b/frontend/src/pages/SensorPage.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { Wifi, WifiOff, AlertTriangle, Plus, Trash2, Wrench } from "lucide-react";
+import { Wifi, WifiOff, AlertTriangle, Plus, Trash2, Wrench, Key } from "lucide-react";
 import { Layout } from "@/components/Layout";
 import { Button } from "@/components/Button";
 import { Badge } from "@/components/Badge";
@@ -28,18 +28,24 @@ const UI = {
 };
 
 const SOURCES: { value: string; label: string }[] = [
-  { value: "Nest",          label: "Google Nest"             },
-  { value: "Ecobee",        label: "Ecobee"                  },
-  { value: "MoenFlo",       label: "Moen Flo"                },
-  { value: "RingAlarm",     label: "Ring Alarm"              },
-  { value: "HoneywellHome", label: "Honeywell Home"          },
-  { value: "RheemEcoNet",   label: "Rheem EcoNet"            },
-  { value: "Sense",         label: "Sense Energy Monitor"    },
-  { value: "EmporiaVue",    label: "Emporia Vue"             },
-  { value: "Rachio",        label: "Rachio Smart Sprinkler"  },
-  { value: "SmartThings",   label: "Samsung SmartThings"     },
-  { value: "HomeAssistant", label: "Home Assistant"          },
-  { value: "Manual",        label: "Manual Entry"            },
+  { value: "Nest",           label: "Google Nest"            },
+  { value: "Ecobee",         label: "Ecobee"                 },
+  { value: "MoenFlo",        label: "Moen Flo"               },
+  { value: "RingAlarm",      label: "Ring Alarm"             },
+  { value: "HoneywellHome",  label: "Honeywell Home"         },
+  { value: "Rachio",         label: "Rachio Smart Sprinkler" },
+  { value: "SmartThings",    label: "Samsung SmartThings"    },
+  { value: "HomeAssistant",  label: "Home Assistant"         },
+  { value: "SolarEdge",      label: "SolarEdge Solar"        },
+  { value: "EnphaseEnvoy",   label: "Enphase IQ Gateway"     },
+  { value: "TeslaPowerwall", label: "Tesla Powerwall"        },
+  { value: "LGThinQ",        label: "LG ThinQ"               },
+  { value: "GESmartHQ",      label: "GE SmartHQ"             },
+  { value: "Manual",         label: "Manual Entry"           },
+  // Tier D — credential-only (Rheem, Sense, Emporia) shown in Connected Accounts below
+  { value: "RheemEcoNet",    label: "Rheem EcoNet"           },
+  { value: "Sense",          label: "Sense Energy Monitor"   },
+  { value: "EmporiaVue",     label: "Emporia Vue"            },
 ];
 
 export default function SensorPage() {
@@ -48,8 +54,12 @@ export default function SensorPage() {
   const [selectedPropertyId, setSelectedPropertyId] = useState<string>("");
   const [devices,       setDevices]       = useState<SensorDevice[]>([]);
   const [alerts,        setAlerts]        = useState<SensorEvent[]>([]);
-  const [loading,       setLoading]       = useState(false);
-  const [modalOpen,     setModalOpen]     = useState(false);
+  const [loading,           setLoading]           = useState(false);
+  const [modalOpen,         setModalOpen]         = useState(false);
+  const [connectingAccount, setConnectingAccount] = useState<string | null>(null);
+  const [accountEmail,      setAccountEmail]      = useState("");
+  const [accountPassword,   setAccountPassword]   = useState("");
+  const [accountLoading,    setAccountLoading]    = useState(false);
 
   // Seed the property store when navigating directly to this page
   useEffect(() => {
@@ -86,6 +96,52 @@ export default function SensorPage() {
       toast.success("Device removed");
     } catch {
       toast.error("Could not remove device");
+    }
+  };
+
+  const GATEWAY_URL = (import.meta as any).env?.VITE_IOT_GATEWAY_URL ?? "http://localhost:3002";
+
+  const handleConnectAccount = async (platform: string) => {
+    if (!accountEmail.trim() || !accountPassword.trim()) {
+      toast.error("Email and password are required");
+      return;
+    }
+    if (!selectedPropertyId) {
+      toast.error("Select a property first");
+      return;
+    }
+    setAccountLoading(true);
+    try {
+      const resp = await fetch(`${GATEWAY_URL}/accounts/${platform}`, {
+        method:  "POST",
+        headers: { "Content-Type": "application/json" },
+        body:    JSON.stringify({ email: accountEmail.trim(), password: accountPassword }),
+      });
+      if (!resp.ok) {
+        const err = await resp.json() as { error?: string };
+        throw new Error(err.error ?? `Request failed (${resp.status})`);
+      }
+      const data = await resp.json() as { devices: Array<{ id: string; name: string; type: string }> };
+      const sourceMap: Record<string, string> = { rheem: "RheemEcoNet", sense: "Sense", emporia: "EmporiaVue" };
+      const source = sourceMap[platform] ?? "Manual";
+      let registered = 0;
+      for (const d of data.devices) {
+        try {
+          const device = await sensorService.registerDevice(selectedPropertyId, d.id, source as any, d.name);
+          setDevices((prev) => [...prev, device]);
+          registered++;
+        } catch {
+          // skip duplicates
+        }
+      }
+      toast.success(`${registered} device${registered !== 1 ? "s" : ""} connected`);
+      setConnectingAccount(null);
+      setAccountEmail("");
+      setAccountPassword("");
+    } catch (err: any) {
+      toast.error(err?.message ?? "Connection failed");
+    } finally {
+      setAccountLoading(false);
     }
   };
 
@@ -240,6 +296,61 @@ export default function SensorPage() {
           )}
         </div>
 
+        {/* Connected Accounts — Tier D (credential-based platforms) */}
+        <div style={{ marginTop: "2rem" }}>
+          <h2 style={{ fontFamily: UI.mono, fontSize: "0.65rem", letterSpacing: "0.12em", textTransform: "uppercase", color: UI.inkLight, marginBottom: "0.75rem" }}>
+            Connected Accounts
+          </h2>
+          <p style={{ fontFamily: UI.mono, fontSize: "0.65rem", color: UI.inkLight, marginBottom: "1rem", lineHeight: 1.5 }}>
+            These platforms use email/password credentials. Credentials are stored only in the IoT gateway and are never sent to HomeGentic.
+          </p>
+          <div style={{ display: "flex", flexDirection: "column", gap: "0.75rem" }}>
+            {[
+              { platform: "rheem",   label: "Rheem EcoNet",       desc: "Water heaters and HVAC"    },
+              { platform: "sense",   label: "Sense Energy Monitor", desc: "Whole-home energy usage" },
+              { platform: "emporia", label: "Emporia Vue",         desc: "Circuit-level energy data" },
+            ].map(({ platform, label, desc }) => (
+              <div key={platform} style={{ border: `1px solid ${UI.rule}`, background: COLORS.white }}>
+                <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", padding: "0.875rem 1.25rem" }}>
+                  <div>
+                    <p style={{ fontWeight: 500, fontSize: "0.875rem", marginBottom: "0.1rem" }}>{label}</p>
+                    <p style={{ fontFamily: UI.mono, fontSize: "0.6rem", color: UI.inkLight }}>{desc}</p>
+                  </div>
+                  <button
+                    onClick={() => setConnectingAccount(connectingAccount === platform ? null : platform)}
+                    style={{
+                      display: "flex", alignItems: "center", gap: "0.35rem",
+                      padding: "0.4rem 0.85rem", fontFamily: UI.mono, fontSize: "0.6rem",
+                      letterSpacing: "0.08em", textTransform: "uppercase",
+                      background: "none", border: `1px solid ${UI.rule}`, cursor: "pointer", color: UI.ink,
+                    }}
+                  >
+                    <Key size={11} />
+                    {connectingAccount === platform ? "Cancel" : "Connect"}
+                  </button>
+                </div>
+                {connectingAccount === platform && (
+                  <div style={{ borderTop: `1px solid ${UI.rule}`, padding: "1rem 1.25rem", display: "flex", flexDirection: "column", gap: "0.75rem" }}>
+                    <input
+                      type="email" value={accountEmail} onChange={(e) => setAccountEmail(e.target.value)}
+                      placeholder="Email address"
+                      style={{ fontFamily: UI.mono, fontSize: "0.875rem", fontWeight: 300, padding: "0.45rem 0.75rem", border: `1px solid ${UI.rule}`, outline: "none" }}
+                    />
+                    <input
+                      type="password" value={accountPassword} onChange={(e) => setAccountPassword(e.target.value)}
+                      placeholder="Password"
+                      style={{ fontFamily: UI.mono, fontSize: "0.875rem", fontWeight: 300, padding: "0.45rem 0.75rem", border: `1px solid ${UI.rule}`, outline: "none" }}
+                    />
+                    <Button onClick={() => handleConnectAccount(platform)} disabled={accountLoading} style={{ alignSelf: "flex-start" }}>
+                      {accountLoading ? "Connecting…" : `Connect ${label}`}
+                    </Button>
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+
         {/* Info callout */}
         <div style={{ marginTop: "2rem", border: `1px solid ${UI.rule}`, padding: "1rem 1.25rem", background: COLORS.white }}>
           <p style={{ fontFamily: UI.mono, fontSize: "0.65rem", letterSpacing: "0.08em", textTransform: "uppercase", marginBottom: "0.5rem", color: UI.inkLight }}>
@@ -247,8 +358,9 @@ export default function SensorPage() {
           </p>
           <p style={{ fontSize: "0.8rem", fontWeight: 300, lineHeight: 1.6, color: UI.inkLight }}>
             Your IoT gateway forwards events from Nest, Ecobee, Moen Flo, Ring Alarm, Honeywell Home,
-            Rheem EcoNet, Sense, Emporia Vue, Rachio, Samsung SmartThings, Home Assistant, and manually
-            entered devices to HomeGentic. Critical events — water leaks, HVAC faults, pipe-freeze risk —
+            Rachio, Samsung SmartThings, Home Assistant, SolarEdge, Enphase, Tesla Powerwall, LG ThinQ,
+            GE SmartHQ, Rheem EcoNet, Sense, Emporia Vue, and manually entered devices to HomeGentic.
+            Critical events — water leaks, HVAC faults, solar outages, pipe-freeze risk —
             automatically open a pending job on your property record so nothing falls through the cracks.
           </p>
         </div>

--- a/frontend/src/pages/SensorPage.tsx
+++ b/frontend/src/pages/SensorPage.tsx
@@ -297,7 +297,7 @@ export default function SensorPage() {
         </div>
 
         {/* Connected Accounts — Tier D (credential-based platforms) */}
-        <div style={{ marginTop: "2rem" }}>
+        <div data-testid="connected-accounts" style={{ marginTop: "2rem" }}>
           <h2 style={{ fontFamily: UI.mono, fontSize: "0.65rem", letterSpacing: "0.12em", textTransform: "uppercase", color: UI.inkLight, marginBottom: "0.75rem" }}>
             Connected Accounts
           </h2>

--- a/frontend/src/services/sensor.ts
+++ b/frontend/src/services/sensor.ts
@@ -7,22 +7,31 @@ const SENSOR_CANISTER_ID = (process.env as any).SENSOR_CANISTER_ID || "";
 
 export const idlFactory = ({ IDL }: any) => {
   const DeviceSource = IDL.Variant({
-    Nest:          IDL.Null, Ecobee:        IDL.Null,
-    MoenFlo:       IDL.Null, Manual:        IDL.Null,
-    RingAlarm:     IDL.Null, HoneywellHome: IDL.Null,
-    RheemEcoNet:   IDL.Null, Sense:         IDL.Null,
-    EmporiaVue:    IDL.Null, Rachio:        IDL.Null,
-    SmartThings:   IDL.Null, HomeAssistant: IDL.Null,
+    Nest:           IDL.Null, Ecobee:        IDL.Null,
+    MoenFlo:        IDL.Null, Manual:        IDL.Null,
+    RingAlarm:      IDL.Null, HoneywellHome: IDL.Null,
+    RheemEcoNet:    IDL.Null, Sense:         IDL.Null,
+    EmporiaVue:     IDL.Null, Rachio:        IDL.Null,
+    SmartThings:    IDL.Null, HomeAssistant: IDL.Null,
+    EnphaseEnvoy:   IDL.Null, TeslaPowerwall: IDL.Null,
+    LGThinQ:        IDL.Null, GESmartHQ:     IDL.Null,
+    SolarEdge:      IDL.Null,
   });
   const SensorEventType = IDL.Variant({
-    WaterLeak:       IDL.Null,
-    LeakDetected:    IDL.Null,
-    FloodRisk:       IDL.Null,
-    LowTemperature:  IDL.Null,
-    HvacAlert:       IDL.Null,
-    HvacFilterDue:   IDL.Null,
-    HighHumidity:    IDL.Null,
-    HighTemperature: IDL.Null,
+    WaterLeak:            IDL.Null,
+    LeakDetected:         IDL.Null,
+    FloodRisk:            IDL.Null,
+    LowTemperature:       IDL.Null,
+    HvacAlert:            IDL.Null,
+    HvacFilterDue:        IDL.Null,
+    HighHumidity:         IDL.Null,
+    HighTemperature:      IDL.Null,
+    SolarFault:           IDL.Null,
+    LowProduction:        IDL.Null,
+    BatteryLow:           IDL.Null,
+    GridOutage:           IDL.Null,
+    ApplianceFault:       IDL.Null,
+    ApplianceMaintenance: IDL.Null,
   });
   const Severity = IDL.Variant({ Info: IDL.Null, Warning: IDL.Null, Critical: IDL.Null });
   const SensorDevice = IDL.Record({
@@ -81,11 +90,15 @@ export const idlFactory = ({ IDL }: any) => {
 export type DeviceSource =
   | "Nest" | "Ecobee" | "MoenFlo" | "Manual"
   | "RingAlarm" | "HoneywellHome" | "RheemEcoNet" | "Sense"
-  | "EmporiaVue" | "Rachio" | "SmartThings" | "HomeAssistant";
+  | "EmporiaVue" | "Rachio" | "SmartThings" | "HomeAssistant"
+  | "EnphaseEnvoy" | "TeslaPowerwall" | "LGThinQ" | "GESmartHQ"
+  | "SolarEdge";
 export type SensorEventType =
   | "WaterLeak" | "LeakDetected" | "FloodRisk"
   | "LowTemperature" | "HvacAlert" | "HvacFilterDue"
-  | "HighHumidity" | "HighTemperature";
+  | "HighHumidity" | "HighTemperature"
+  | "SolarFault" | "LowProduction" | "BatteryLow" | "GridOutage"
+  | "ApplianceFault" | "ApplianceMaintenance";
 export type Severity = "Info" | "Warning" | "Critical";
 
 export interface SensorDevice {
@@ -279,14 +292,20 @@ function createSensorService() {
   /** Human-readable label for an event type. */
   eventLabel(type: SensorEventType): string {
     const labels: Record<SensorEventType, string> = {
-      WaterLeak:       "Water Leak Detected",
-      LeakDetected:    "Possible Leak",
-      FloodRisk:       "Flood Risk Alert",
-      LowTemperature:  "Low Temperature — Pipe Freeze Risk",
-      HvacAlert:       "HVAC System Fault",
-      HvacFilterDue:   "HVAC Filter Due",
-      HighHumidity:    "High Humidity",
-      HighTemperature: "High Temperature",
+      WaterLeak:            "Water Leak Detected",
+      LeakDetected:         "Possible Leak",
+      FloodRisk:            "Flood Risk Alert",
+      LowTemperature:       "Low Temperature — Pipe Freeze Risk",
+      HvacAlert:            "HVAC System Fault",
+      HvacFilterDue:        "HVAC Filter Due",
+      HighHumidity:         "High Humidity",
+      HighTemperature:      "High Temperature",
+      SolarFault:           "Solar Inverter Fault",
+      LowProduction:        "Solar Low Production",
+      BatteryLow:           "Battery Critically Low",
+      GridOutage:           "Grid Outage — Battery Islanded",
+      ApplianceFault:       "Appliance Fault",
+      ApplianceMaintenance: "Appliance Maintenance Due",
     };
     return labels[type] ?? type;
   },

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-DEPLOY_SCRIPT_VERSION="1.5.2"
+DEPLOY_SCRIPT_VERSION="1.6.0"
 ENV=${1:-local}
 
 echo "============================================"

--- a/tests/e2e/sensor.spec.ts
+++ b/tests/e2e/sensor.spec.ts
@@ -72,16 +72,37 @@ test.describe("SensorPage — /sensor", () => {
       await expect(page.getByLabel(/device type/i).locator("option", { hasText: /honeywell home/i })).toHaveCount(1);
     });
 
-    test("dropdown includes Rheem EcoNet", async ({ page }) => {
-      await expect(page.getByLabel(/device type/i).locator("option", { hasText: /rheem econet/i })).toHaveCount(1);
+    // Tier D sources are in Connected Accounts, not the modal dropdown
+    test("dropdown does NOT include Rheem EcoNet (moved to Connected Accounts)", async ({ page }) => {
+      await expect(page.getByLabel(/device type/i).locator("option", { hasText: /rheem econet/i })).toHaveCount(0);
     });
 
-    test("dropdown includes Sense Energy Monitor", async ({ page }) => {
-      await expect(page.getByLabel(/device type/i).locator("option", { hasText: /sense energy/i })).toHaveCount(1);
+    test("dropdown does NOT include Sense Energy Monitor (moved to Connected Accounts)", async ({ page }) => {
+      await expect(page.getByLabel(/device type/i).locator("option", { hasText: /sense energy/i })).toHaveCount(0);
     });
 
-    test("dropdown includes Emporia Vue", async ({ page }) => {
-      await expect(page.getByLabel(/device type/i).locator("option", { hasText: /emporia vue/i })).toHaveCount(1);
+    test("dropdown does NOT include Emporia Vue (moved to Connected Accounts)", async ({ page }) => {
+      await expect(page.getByLabel(/device type/i).locator("option", { hasText: /emporia vue/i })).toHaveCount(0);
+    });
+
+    test("dropdown includes SolarEdge Solar", async ({ page }) => {
+      await expect(page.getByLabel(/device type/i).locator("option", { hasText: /solaredge/i })).toHaveCount(1);
+    });
+
+    test("dropdown includes Enphase IQ Gateway", async ({ page }) => {
+      await expect(page.getByLabel(/device type/i).locator("option", { hasText: /enphase/i })).toHaveCount(1);
+    });
+
+    test("dropdown includes Tesla Powerwall", async ({ page }) => {
+      await expect(page.getByLabel(/device type/i).locator("option", { hasText: /tesla powerwall/i })).toHaveCount(1);
+    });
+
+    test("dropdown includes LG ThinQ", async ({ page }) => {
+      await expect(page.getByLabel(/device type/i).locator("option", { hasText: /lg thinq/i })).toHaveCount(1);
+    });
+
+    test("dropdown includes GE SmartHQ", async ({ page }) => {
+      await expect(page.getByLabel(/device type/i).locator("option", { hasText: /ge smarthq/i })).toHaveCount(1);
     });
 
     test("dropdown includes Rachio Smart Sprinkler", async ({ page }) => {
@@ -100,14 +121,38 @@ test.describe("SensorPage — /sensor", () => {
       await expect(page.getByLabel(/device type/i).locator("option", { hasText: /manual entry/i })).toHaveCount(1);
     });
 
-    test("dropdown has 12 source options in total", async ({ page }) => {
+    test("dropdown has 14 source options in total", async ({ page }) => {
       const options = page.getByLabel(/device type/i).locator("option");
-      await expect(options).toHaveCount(12);
+      await expect(options).toHaveCount(14);
     });
 
     test("Cancel button closes the modal", async ({ page }) => {
       await page.getByRole("button", { name: /cancel/i }).click();
       await expect(page.getByRole("heading", { name: /register device/i })).not.toBeVisible();
+    });
+  });
+
+  // ── Connected Accounts section (Tier D — credential-based platforms) ─────────
+
+  test.describe("Connected Accounts section", () => {
+    test("shows 'Connected Accounts' heading", async ({ page }) => {
+      const section = page.locator("[data-testid='connected-accounts']");
+      await expect(section.getByText(/connected accounts/i)).toBeVisible();
+    });
+
+    test("shows Rheem EcoNet entry", async ({ page }) => {
+      const section = page.locator("[data-testid='connected-accounts']");
+      await expect(section.getByText(/rheem econet/i)).toBeVisible();
+    });
+
+    test("shows Sense Energy Monitor entry", async ({ page }) => {
+      const section = page.locator("[data-testid='connected-accounts']");
+      await expect(section.getByText(/sense energy monitor/i)).toBeVisible();
+    });
+
+    test("shows Emporia Vue entry", async ({ page }) => {
+      const section = page.locator("[data-testid='connected-accounts']");
+      await expect(section.getByText(/emporia vue/i)).toBeVisible();
     });
   });
 


### PR DESCRIPTION
…#275)

#272 — SolarEdge inverter integration
- Add #SolarEdge to Motoko DeviceSource variant
- Add SolarEdgeEvent type and handleSolarEdgeEvent handler (SolarFault / LowProduction)
- New agents/iot-gateway/pollers/solarEdge.ts — polls overview + alerts every 15 min
- Wire startSolarEdgePoller in server.ts; add SOLAREDGE_API_KEY/SITE_ID to .env.example

#275 — Tiered device registration UX
- Tier A: DEVICE_ID_HELP map in RegisterDeviceModal with format + inline instructions per source
- Tier B: OAuth popup device picker for Ecobee, Honeywell, LG ThinQ, GE SmartHQ
  - New oauth/ecobee.ts, honeywellHome.ts, lgThinQ.ts, geSmartHQ.ts device-picker helpers
  - New GET /oauth/device/start/:platform and GET /oauth/device/callback/:platform gateway routes
  - New useOAuthDevicePicker hook (popup + postMessage listener)
- Tier C: Dual IP + serial form for EnphaseEnvoy and TeslaPowerwall
- Tier D: Remove Rheem EcoNet, Sense, Emporia Vue from RegisterDeviceModal; add ConnectedAccountsCard on SensorPage with email/password credential form per platform and POST /accounts/:platform gateway endpoint
- Add SolarEdge, EnphaseEnvoy, TeslaPowerwall, LGThinQ, GESmartHQ to frontend DeviceSource and SensorEventType IDL variants and TS type unions
- Add eventLabel entries for all new SensorEventType variants
- Add VITE_IOT_GATEWAY_URL and LG_THINQ_CLIENT_ID/SECRET to .env.example
- Update Candid contract snapshots; deploy.sh bumped to 1.6.0

## Summary
<!-- What does this PR do? -->

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [ ] Backend tests pass (`make test`)
- [ ] Frontend builds (`cd frontend && npm run build`)
- [ ] Tested locally with dfx

## Checklist
- [ ] Code follows project conventions
- [ ] Self-review completed
- [ ] No sensitive data committed
