### PR TITLE
feat(observability): end-to-end tracing, canister metrics, cycle safe…

### DIFF
--- a/.github/workflows/cycle-watchdog.yml
+++ b/.github/workflows/cycle-watchdog.yml
@@ -12,7 +12,7 @@ on:
       dry_run:
         description: 'Dry run — report only, no top-up'
         required: false
-        default: 'false'
+        default: false
         type: boolean
       network:
         description: 'Target network'
@@ -88,6 +88,29 @@ jobs:
           echo '```' >> "$GITHUB_STEP_SUMMARY"
           cat cycle-health.log >> "$GITHUB_STEP_SUMMARY" 2>/dev/null || true
           echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Email alert on critical cycles
+        if: ${{ steps.health.outputs.exit_code != '0' && env.RESEND_API_KEY != '' }}
+        env:
+          RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+          RESEND_FROM:    ${{ vars.RESEND_FROM_ADDRESS || 'noreply@homegentic.app' }}
+          ALERT_EMAIL:    ${{ vars.OPS_ALERT_EMAIL }}
+        run: |
+          if [ -z "$ALERT_EMAIL" ]; then
+            echo "OPS_ALERT_EMAIL not set — skipping email alert"
+            exit 0
+          fi
+          SUMMARY=$(cat cycle-health.log 2>/dev/null | tail -20 || echo "See workflow logs")
+          curl -s -X POST https://api.resend.com/emails \
+            -H "Authorization: Bearer $RESEND_API_KEY" \
+            -H "Content-Type: application/json" \
+            -d "$(jq -n \
+              --arg from    "$RESEND_FROM" \
+              --arg to      "$ALERT_EMAIL" \
+              --arg subject "🔴 HomeGentic: Critical canister cycle balance detected" \
+              --arg body    "Critical cycle alert fired in CI cycle-watchdog run $GITHUB_RUN_ID.\n\n$SUMMARY\n\nRun: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
+              '{from: $from, to: [$to], subject: $subject, text: $body}')"
+          echo "Alert email sent to $ALERT_EMAIL"
 
       - name: Fail if critical canisters found
         if: ${{ steps.health.outputs.exit_code != '0' }}

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help start stop deploy deploy-one test clean status upgrade frontend init-data dev dev-full dev-local check-motoko
+.PHONY: help start stop deploy deploy-one test clean status upgrade frontend init-data dev dev-full dev-local check-motoko logs
 
 NETWORK ?= local
 
@@ -17,6 +17,7 @@ help:
 	@echo "  make dev-full            Full local stack: network + canisters + frontend + voice + dashboard"
 	@echo "  make clean               Clean local ICP state"
 	@echo "  make check-motoko        Compile-check all Motoko canisters (no network needed)"
+	@echo "  make logs                Tail recent logs for all 7 key canisters"
 
 dev:
 	icp network start -d && bash scripts/deploy.sh && cd frontend && npm run dev
@@ -63,3 +64,8 @@ init-data:
 check-motoko:
 	@grep "^  - name:" icp.yaml | awk '{print $$3}' | grep -v "^frontend$$" | \
 	  while read -r c; do echo "=== $$c ==="; icp build "$$c" || exit 1; done
+
+logs:
+	@for c in sensor auth job property ai_proxy payment monitoring; do \
+	  echo "=== $$c ==="; icp canister logs $$c -e $(NETWORK) 2>&1 | tail -50; \
+	done

--- a/agents/voice/monitoringCanister.ts
+++ b/agents/voice/monitoringCanister.ts
@@ -1,0 +1,95 @@
+/**
+ * Lightweight ICP client for the monitoring canister.
+ * Used by the /admin/cycle-status endpoint to surface real-time cycle health.
+ */
+
+import { HttpAgent, Actor } from "@icp-sdk/core/agent";
+import { identityFromPem } from "./paymentCanister";
+
+const MONITORING_CANISTER_ID =
+  process.env.CANISTER_ID_MONITORING ?? "";
+
+const IC_HOST = process.env.DFX_NETWORK === "local"
+  ? "http://localhost:4943"
+  : "https://ic0.app";
+
+const idlFactory = ({ IDL }: any) => {
+  const AlertSeverity  = IDL.Variant({ Critical: IDL.Null, Warning: IDL.Null, Info: IDL.Null });
+  const AlertCategory  = IDL.Variant({
+    Cycles: IDL.Null, ErrorRate: IDL.Null, ResponseTime: IDL.Null,
+    Memory: IDL.Null, Milestone: IDL.Null, TopUp: IDL.Null, Stale: IDL.Null,
+  });
+  const Alert = IDL.Record({
+    id:         IDL.Text,
+    severity:   AlertSeverity,
+    category:   AlertCategory,
+    canisterId: IDL.Opt(IDL.Principal),
+    message:    IDL.Text,
+    resolved:   IDL.Bool,
+    createdAt:  IDL.Int,
+    resolvedAt: IDL.Opt(IDL.Int),
+  });
+  const CycleLevelResult = IDL.Record({
+    id:        IDL.Principal,
+    name:      IDL.Text,
+    cycles:    IDL.Nat,
+    status:    IDL.Text,
+    fromCache: IDL.Bool,
+  });
+  return IDL.Service({
+    getCriticalCycleAlerts: IDL.Func([], [IDL.Vec(Alert)], ["query"]),
+    checkCycleLevels:       IDL.Func([], [IDL.Vec(CycleLevelResult)], []),
+  });
+};
+
+let _actor: any = null;
+
+async function getActor(): Promise<any> {
+  if (_actor) return _actor;
+  const pem = process.env.DFX_IDENTITY_PEM;
+  if (!pem || !MONITORING_CANISTER_ID) return null;
+  const agent = new HttpAgent({ host: IC_HOST, identity: identityFromPem(pem) });
+  if (process.env.DFX_NETWORK === "local") await agent.fetchRootKey();
+  _actor = Actor.createActor(idlFactory, { agent, canisterId: MONITORING_CANISTER_ID });
+  return _actor;
+}
+
+export interface CycleAlert {
+  id:        string;
+  severity:  string;
+  canister:  string | null;
+  message:   string;
+  createdAt: number;
+}
+
+export interface CycleLevelStatus {
+  name:      string;
+  cycles:    bigint;
+  status:    string;
+  fromCache: boolean;
+}
+
+export async function getCriticalCycleAlerts(): Promise<CycleAlert[]> {
+  const actor = await getActor();
+  if (!actor) return [];
+  const raw: any[] = await actor.getCriticalCycleAlerts();
+  return raw.map((a) => ({
+    id:        a.id,
+    severity:  Object.keys(a.severity)[0],
+    canister:  a.canisterId[0]?.toText() ?? null,
+    message:   a.message,
+    createdAt: Number(a.createdAt) / 1_000_000,
+  }));
+}
+
+export async function checkCycleLevels(): Promise<CycleLevelStatus[]> {
+  const actor = await getActor();
+  if (!actor) return [];
+  const raw: any[] = await actor.checkCycleLevels();
+  return raw.map((r) => ({
+    name:      r.name,
+    cycles:    r.cycles,
+    status:    r.status,
+    fromCache: r.fromCache,
+  }));
+}

--- a/agents/voice/server.ts
+++ b/agents/voice/server.ts
@@ -9,6 +9,7 @@ import { buildMaintenanceSystemPrompt } from "../maintenance/prompts";
 import { HOMEGENTIC_TOOLS } from "./tools";
 import { resolveModel, PROVIDER_JSON_ERROR } from "./provider";
 import { createAnthropicProvider } from "./anthropicProvider";
+import { getCriticalCycleAlerts, checkCycleLevels as getCanisterCycleLevels } from "./monitoringCanister";
 import {
   buildDocumentSystemPrompt,
   normalizeExtraction,
@@ -107,13 +108,19 @@ app.use("/api/", (req: Request, res: Response, next: express.NextFunction): void
 // ── Structured request logging ────────────────────────────────────────────────
 // Emits one JSON line per /api/ request on completion.
 // Format is stable so any log aggregator (Datadog, Loki, CloudWatch) can parse it.
-// Fields: ts (ISO), method, path, status, latencyMs, ip, principal.
+// Fields: ts, method, path, status, latencyMs, ip, principal, traceId, reqId.
 // "principal" is the ICP principal from x-icp-principal header if sent by the
 // frontend, otherwise "anon". Never logs request bodies (no PII leakage).
 app.use("/api/", (req: Request, res: Response, next: express.NextFunction): void => {
-  const start = Date.now();
+  const start   = Date.now();
+  const reqId   = (req.headers["x-request-id"] as string | undefined) ?? crypto.randomUUID();
+  const traceId = req.headers["x-trace-id"] as string | undefined;
+
+  res.setHeader("x-request-id", reqId);
+  if (traceId) res.setHeader("x-trace-id", traceId);
+
   res.on("finish", () => {
-    const entry = {
+    const entry: Record<string, unknown> = {
       ts:        new Date().toISOString(),
       method:    req.method,
       path:      req.path,
@@ -122,9 +129,9 @@ app.use("/api/", (req: Request, res: Response, next: express.NextFunction): void
       ip:        (req.headers["x-forwarded-for"] as string | undefined)?.split(",")[0].trim()
                    ?? req.socket.remoteAddress ?? "unknown",
       principal: (req.headers["x-icp-principal"] as string | undefined) ?? "anon",
+      reqId,
     };
-    // Use process.stdout.write for JSON-lines — avoids console.log's extra newline handling
-    // and keeps lines machine-parseable even when piped.
+    if (traceId) entry.traceId = traceId;
     process.stdout.write(JSON.stringify(entry) + "\n");
   });
   next();
@@ -908,6 +915,9 @@ app.post("/api/errors", (req: Request, res: Response): void => {
       }))
     : undefined;
 
+  const traceId   = (req.headers["x-trace-id"] as string | undefined)
+                    ?? (typeof b.traceId === "string" ? b.traceId.slice(0, 36) : undefined);
+
   process.stdout.write(JSON.stringify({
     event:      "frontend_error",
     level,
@@ -923,6 +933,7 @@ app.post("/api/errors", (req: Request, res: Response): void => {
     ...(userAgent  && { userAgent }),
     ...(breadcrumbs && { breadcrumbs }),
     ...(tags       && { tags }),
+    ...(traceId    && { traceId }),
   }) + "\n");
 
   res.sendStatus(204);
@@ -1540,6 +1551,40 @@ app.post("/api/stripe/webhook", async (req: Request, res: Response) => {
   }
 
   res.json({ received: true });
+});
+
+// ── GET /admin/cycle-status ───────────────────────────────────────────────────
+// Returns canister cycle levels and any active critical/warning cycle alerts.
+// Protected by VOICE_AGENT_API_KEY — intended for the cycle-watchdog cron
+// and ops tooling; never exposed to browser clients.
+app.get("/admin/cycle-status", async (req: Request, res: Response): Promise<void> => {
+  const apiKey = (req.headers["x-api-key"] as string | undefined) ?? "";
+  if (process.env.VOICE_AGENT_API_KEY && apiKey !== process.env.VOICE_AGENT_API_KEY) {
+    res.status(401).json({ error: "Unauthorized" });
+    return;
+  }
+  try {
+    const [alerts, levels] = await Promise.all([
+      getCriticalCycleAlerts(),
+      getCanisterCycleLevels(),
+    ]);
+    const critical = alerts.filter((a) => a.severity === "Critical");
+    const warning  = alerts.filter((a) => a.severity === "Warning");
+    res.json({
+      ok:       critical.length === 0,
+      critical: critical.length,
+      warning:  warning.length,
+      alerts,
+      levels,
+      ts:       new Date().toISOString(),
+    });
+  } catch (err) {
+    process.stdout.write(JSON.stringify({
+      ts: new Date().toISOString(), event: "admin_cycle_status_error",
+      error: (err as Error)?.message ?? String(err),
+    }) + "\n");
+    res.status(502).json({ error: "Failed to query monitoring canister" });
+  }
 });
 
 // ── GET /health ───────────────────────────────────────────────────────────────

--- a/backend/ai_proxy/main.mo
+++ b/backend/ai_proxy/main.mo
@@ -16,7 +16,9 @@
 
 import Array     "mo:core/Array";
 import Blob      "mo:core/Blob";
+import Debug     "mo:core/Debug";
 import Int       "mo:core/Int";
+import Iter      "mo:core/Iter";
 import Map       "mo:core/Map";
 import Nat       "mo:core/Nat";
 import Nat64     "mo:core/Nat64";
@@ -53,6 +55,7 @@ persistent actor AiProxy {
     permitsFetched : Nat;
     adminCount     : Nat;
     isPaused       : Bool;
+    errorsByMethod : [(Text, Nat)];
   };
 
   // ── IC Management Canister (HTTP outcalls) ─────────────────────────────────
@@ -85,6 +88,13 @@ persistent actor AiProxy {
   private var resendFromAddress      : Text = "HomeGentic <noreply@homegentic.app>";
 
   // Email usage counters
+  private let errsByMethod : Map.Map<Text, Nat> = Map.empty();
+
+  private func countError(method : Text) {
+    let prev = Option.get(Map.get(errsByMethod, Text.compare, method), 0);
+    Map.add(errsByMethod, Text.compare, method, prev + 1);
+  };
+
   private var emailSentDaily         : Nat = 0;
   private var emailSentMonthly       : Nat = 0;
   private var emailSentTotal         : Nat = 0;
@@ -534,18 +544,26 @@ persistent actor AiProxy {
         });
 
         switch (Text.decodeUtf8(response.body)) {
-          case null      { #err(#HttpError("Failed to decode ArcGIS response")) };
+          case null      {
+            Debug.print("ai_proxy.importPermits: failed to decode ArcGIS response");
+            countError("importPermits");
+            #err(#HttpError("Failed to decode ArcGIS response"))
+          };
           case (?rawJson) {
             permitsFetched += 1;
             #ok("{\"source\":\"arcgis\",\"data\":" # rawJson # "," # jsonStr("address", address) # "}")
           };
         }
       } catch (e) {
+        Debug.print("ai_proxy.importPermits: ArcGIS request failed: " # address);
+        countError("importPermits");
         #err(#HttpError("ArcGIS request failed"))
       }
     } else {
       // OpenPermit.org
       if (Text.size(openPermitApiKey) == 0) {
+        Debug.print("ai_proxy.importPermits: OpenPermit key not configured");
+        countError("importPermits");
         return #err(#KeyNotConfigured);
       };
       let params =
@@ -567,13 +585,19 @@ persistent actor AiProxy {
         });
 
         switch (Text.decodeUtf8(response.body)) {
-          case null      { #err(#HttpError("Failed to decode OpenPermit response")) };
+          case null      {
+            Debug.print("ai_proxy.importPermits: failed to decode OpenPermit response");
+            countError("importPermits");
+            #err(#HttpError("Failed to decode OpenPermit response"))
+          };
           case (?rawJson) {
             permitsFetched += 1;
             #ok("{\"source\":\"openpermit\",\"data\":" # rawJson # "," # jsonStr("address", address) # "}")
           };
         }
       } catch (_e) {
+        Debug.print("ai_proxy.importPermits: OpenPermit request failed: " # address);
+        countError("importPermits");
         #err(#HttpError("OpenPermit request failed"))
       }
     }
@@ -639,12 +663,21 @@ persistent actor AiProxy {
           case null    { #ok("{\"id\":\"sent\"}") };
         }
       } else {
+        countError("sendEmail");
         switch (Text.decodeUtf8(response.body)) {
-          case (?errBody) { #err(#HttpError("Resend error " # Nat.toText(response.status) # ": " # errBody)) };
-          case null       { #err(#HttpError("Resend error " # Nat.toText(response.status))) };
+          case (?errBody) {
+            Debug.print("ai_proxy.sendEmail: Resend error " # Nat.toText(response.status) # ": " # errBody);
+            #err(#HttpError("Resend error " # Nat.toText(response.status) # ": " # errBody))
+          };
+          case null {
+            Debug.print("ai_proxy.sendEmail: Resend error " # Nat.toText(response.status));
+            #err(#HttpError("Resend error " # Nat.toText(response.status)))
+          };
         }
       }
     } catch (_e) {
+      Debug.print("ai_proxy.sendEmail: email request failed to=" # to);
+      countError("sendEmail");
       #err(#HttpError("Email request failed"))
     }
   };
@@ -796,6 +829,7 @@ persistent actor AiProxy {
       permitsFetched = permitsFetched;
       adminCount     = adminListEntries.size();
       isPaused       = isPaused;
+      errorsByMethod = Iter.toArray(Map.entries(errsByMethod));
     }
   };
 }

--- a/backend/auth/main.mo
+++ b/backend/auth/main.mo
@@ -4,13 +4,16 @@
  * Supports Homeowner, Contractor, Realtor, and Builder roles.
  */
 
+import Array "mo:core/Array";
+import Debug "mo:core/Debug";
+import Iter "mo:core/Iter";
 import Map "mo:core/Map";
 import Nat "mo:core/Nat";
+import Option "mo:core/Option";
 import Principal "mo:core/Principal";
 import Result "mo:core/Result";
 import Text "mo:core/Text";
 import Time "mo:core/Time";
-import Array "mo:core/Array";
 
 persistent actor class Auth(initDeployer : Principal) {
 
@@ -55,6 +58,7 @@ persistent actor class Auth(initDeployer : Principal) {
     realtors: Nat;
     builders: Nat;
     isPaused: Bool;
+    errorsByMethod : [(Text, Nat)];
   };
 
   public type UserStats = {
@@ -92,6 +96,12 @@ persistent actor class Auth(initDeployer : Principal) {
   /// Map is stable directly (mo:core/Map uses a stable B-tree internally).
   /// No preupgrade serialisation required — eliminates the upgrade instruction-limit footgun.
   private let users = Map.empty<Principal, UserProfile>();
+  private let errsByMethod : Map.Map<Text, Nat> = Map.empty();
+
+  private func countError(method : Text) {
+    let prev = Option.get(Map.get(errsByMethod, Text.compare, method), 0);
+    Map.add(errsByMethod, Text.compare, method, prev + 1);
+  };
 
   // ─── Ingress Inspection ───────────────────────────────────────────────────────
 
@@ -217,7 +227,11 @@ persistent actor class Auth(initDeployer : Principal) {
 
     let caller = msg.caller;
 
-    if (Map.get(users, Principal.compare, caller) != null) return #err(#AlreadyExists);
+    if (Map.get(users, Principal.compare, caller) != null) {
+      Debug.print("auth.register: already exists: " # Principal.toText(caller));
+      countError("register");
+      return #err(#AlreadyExists);
+    };
     // Email and phone are optional; validate format only when provided
     if (Text.size(args.phone) > 30)  return #err(#InvalidInput("phone exceeds 30 characters"));
     if (Text.size(args.email) > 0) {
@@ -404,6 +418,7 @@ persistent actor class Auth(initDeployer : Principal) {
       realtors;
       builders;
       isPaused;
+      errorsByMethod = Iter.toArray(Map.entries(errsByMethod));
     }
   };
 }

--- a/backend/job/main.mo
+++ b/backend/job/main.mo
@@ -8,6 +8,7 @@
 
 import Array     "mo:core/Array";
 import Blob      "mo:core/Blob";
+import Debug     "mo:core/Debug";
 import Map       "mo:core/Map";
 import Iter      "mo:core/Iter";
 import Nat       "mo:core/Nat";
@@ -80,6 +81,7 @@ persistent actor Job {
     verifiedJobs: Nat;
     diyJobs: Nat;
     isPaused: Bool;
+    errorsByMethod : [(Text, Nat)];
   };
 
   /// Short-lived token that lets a contractor sign a job without having an account.
@@ -131,6 +133,12 @@ persistent actor Job {
 
   private let jobs        = Map.empty<Text, Job>();
   private let inviteTokens = Map.empty<Text, InviteToken>();
+  private let errsByMethod : Map.Map<Text, Nat> = Map.empty();
+
+  private func countError(method : Text) {
+    let prev = Option.get(Map.get(errsByMethod, Text.compare, method), 0);
+    Map.add(errsByMethod, Text.compare, method, prev + 1);
+  };
 
   // ─── Constants ───────────────────────────────────────────────────────────────
 
@@ -439,7 +447,11 @@ persistent actor Job {
     switch (requireActive(msg.caller)) { case (#err(e)) return #err(e); case _ {} };
 
     switch (Map.get(jobs, Text.compare, jobId)) {
-      case null { #err(#NotFound) };
+      case null {
+        Debug.print("job.verifyJob: not found: " # jobId);
+        countError("verifyJob");
+        #err(#NotFound)
+      };
       case (?existing) {
         if (existing.verified) return #err(#AlreadyVerified);
 
@@ -452,7 +464,11 @@ persistent actor Job {
           await checkPropertyAuth(existing.propertyId, existing.homeowner, caller, true)
         };
 
-        if (not isHomeowner and not isContractor) return #err(#Unauthorized);
+        if (not isHomeowner and not isContractor) {
+          Debug.print("job.verifyJob: unauthorized: " # Principal.toText(caller) # " job=" # jobId);
+          countError("verifyJob");
+          return #err(#Unauthorized);
+        };
 
         let newHomeownerSigned  = existing.homeownerSigned  or isHomeowner;
         let newContractorSigned = existing.contractorSigned or isContractor;
@@ -1098,6 +1114,7 @@ persistent actor Job {
       verifiedJobs  = verified;
       diyJobs       = diy;
       isPaused;
+      errorsByMethod = Iter.toArray(Map.entries(errsByMethod));
     }
   };
 }

--- a/backend/monitoring/main.mo
+++ b/backend/monitoring/main.mo
@@ -673,6 +673,19 @@ persistent actor Monitoring {
     results
   };
 
+  /// Return all unresolved Critical and Warning cycle alerts.
+  /// Unauthenticated — intended for the cycle-watchdog cron and /admin/cycle-status
+  /// endpoint to query without managing a principal.
+  public query func getCriticalCycleAlerts() : async [Alert] {
+    var out : [Alert] = [];
+    for (a in Map.values(alerts)) {
+      if (not a.resolved and a.category == #Cycles) {
+        out := Array.concat(out, [a]);
+      };
+    };
+    out
+  };
+
   // ─── Admin Functions ──────────────────────────────────────────────────────────
 
   /// Set the update-call rate limit (admin only). Pass 0 to disable enforcement.

--- a/backend/payment/main.mo
+++ b/backend/payment/main.mo
@@ -1,5 +1,7 @@
 import Array     "mo:core/Array";
+import Debug     "mo:core/Debug";
 import Int       "mo:core/Int";
+import Iter      "mo:core/Iter";
 import Map       "mo:core/Map";
 import Nat       "mo:core/Nat";
 import Nat32     "mo:core/Nat32";
@@ -73,6 +75,12 @@ persistent actor Payment {
   public type AgentCreditBalance = {
     balance:   Nat;
     expiresAt: Int;  // nanoseconds; 0 = never expires
+  };
+
+  public type Metrics = {
+    totalSubscriptions : Nat;
+    activePaid         : Nat;
+    errorsByMethod     : [(Text, Nat)];
   };
 
   public type SubscriptionStats = {
@@ -219,6 +227,12 @@ persistent actor Payment {
 
   private let subscriptions        = Map.empty<Principal, Subscription>();
   private let agentCreditBalances  = Map.empty<Principal, AgentCreditBalance>();
+  private let errsByMethod : Map.Map<Text, Nat> = Map.empty();
+
+  private func countError(method : Text) {
+    let prev = Option.get(Map.get(errsByMethod, Text.compare, method), 0);
+    Map.add(errsByMethod, Text.compare, method, prev + 1);
+  };
 
   // Admin
   private var adminEntries     : [Principal] = [];
@@ -952,6 +966,23 @@ persistent actor Payment {
     }
   };
 
+  public query func getMetrics() : async Metrics {
+    let now = Time.now();
+    var activePaid = 0;
+    for (sub in Map.values(subscriptions)) {
+      let isActive = sub.expiresAt == 0 or sub.expiresAt > now;
+      switch (sub.tier) {
+        case (#Free or #ContractorFree or #RealtorFree) {};
+        case _ { if (isActive) { activePaid += 1 } };
+      };
+    };
+    {
+      totalSubscriptions = Map.size(subscriptions);
+      activePaid;
+      errorsByMethod = Iter.toArray(Map.entries(errsByMethod));
+    }
+  };
+
   /// Inter-canister helper: returns the effective tier for a principal.
   /// Returns #Free if no subscription exists or if the subscription has expired.
   public query func getTierForPrincipal(p: Principal) : async Tier {
@@ -1014,10 +1045,22 @@ persistent actor Payment {
     if (not isAdmin(msg.caller)) return #err(#NotAuthorized);
     let now = Time.now();
     switch (Map.get(agentCreditBalances, Principal.compare, user)) {
-      case null  { #err(#NotFound) };
+      case null  {
+        Debug.print("payment.consumeAgentCredit: no credits for " # Principal.toText(user));
+        countError("consumeAgentCredit");
+        #err(#NotFound)
+      };
       case (?b)  {
-        if (b.expiresAt > 0 and b.expiresAt <= now) return #err(#NotFound);
-        if (b.balance == 0)                          return #err(#NotFound);
+        if (b.expiresAt > 0 and b.expiresAt <= now) {
+          Debug.print("payment.consumeAgentCredit: credits expired for " # Principal.toText(user));
+          countError("consumeAgentCredit");
+          return #err(#NotFound)
+        };
+        if (b.balance == 0) {
+          Debug.print("payment.consumeAgentCredit: balance zero for " # Principal.toText(user));
+          countError("consumeAgentCredit");
+          return #err(#NotFound)
+        };
         let updated : AgentCreditBalance = { balance = b.balance - 1; expiresAt = b.expiresAt };
         Map.add(agentCreditBalances, Principal.compare, user, updated);
         #ok(updated.balance)

--- a/backend/property/main.mo
+++ b/backend/property/main.mo
@@ -30,6 +30,7 @@
 
 import Array     "mo:core/Array";
 import Blob      "mo:core/Blob";
+import Debug     "mo:core/Debug";
 import Map       "mo:core/Map";
 import Int       "mo:core/Int";
 import Iter      "mo:core/Iter";
@@ -124,6 +125,7 @@ persistent actor Property {
     pendingReviewProperties : Nat;
     unverifiedProperties    : Nat;
     isPaused                : Bool;
+    errorsByMethod          : [(Text, Nat)];
   };
 
   public type BulkImportError = {
@@ -298,6 +300,13 @@ persistent actor Property {
   private var fixtureCounter : Nat                  = 0;
 
   // ─── Stable State ────────────────────────────────────────────────────────
+
+  private let errsByMethod : Map.Map<Text, Nat> = Map.empty();
+
+  private func countError(method : Text) {
+    let prev = Option.get(Map.get(errsByMethod, Text.compare, method), 0);
+    Map.add(errsByMethod, Text.compare, method, prev + 1);
+  };
 
   private let properties      = Map.empty<Text, Property>();
   /// Address key → property ID.
@@ -559,11 +568,15 @@ persistent actor Property {
               // Same owner re-registering the same address — allow (idempotent).
             } else if (isVerified(existing.verificationLevel)) {
               // Address is already owned and verified — hard reject.
+              Debug.print("property.registerProperty: duplicate address: " # key # " owner=" # Principal.toText(existing.owner));
+              countError("registerProperty");
               return #err(#DuplicateAddress);
             } else {
               // Address is claimed but not yet verified.
               let windowEnd : Int = existing.createdAt + SEVEN_DAYS_NS;
               if (Time.now() < windowEnd) {
+                Debug.print("property.registerProperty: address conflict: " # key # " expires=" # Int.toText(windowEnd));
+                countError("registerProperty");
                 return #err(#AddressConflict(windowEnd));
               };
               // Window expired without verification — allow the new registrant.
@@ -714,7 +727,11 @@ persistent actor Property {
     if (not isAdmin(msg.caller)) return #err(#NotAuthorized);
 
     switch (Map.get(properties, Text.compare, id)) {
-      case null { #err(#NotFound) };
+      case null {
+        Debug.print("property.verifyProperty: not found: " # id);
+        countError("verifyProperty");
+        #err(#NotFound)
+      };
       case (?existing) {
         let now  = Time.now();
         let updated : Property = {
@@ -1357,6 +1374,7 @@ persistent actor Property {
       pendingReviewProperties = pendingReview;
       unverifiedProperties    = unverified;
       isPaused;
+      errorsByMethod          = Iter.toArray(Map.entries(errsByMethod));
     }
   };
 

--- a/backend/sensor/main.mo
+++ b/backend/sensor/main.mo
@@ -14,6 +14,7 @@
  */
 
 import Array    "mo:core/Array";
+import Debug    "mo:core/Debug";
 import Float    "mo:core/Float";
 import Map      "mo:core/Map";
 import Iter     "mo:core/Iter";
@@ -106,6 +107,7 @@ persistent actor Sensor {
     criticalEvents : Nat;
     jobsCreated    : Nat;
     isPaused       : Bool;
+    errorsByMethod : [(Text, Nat)];
   };
 
   // ─── Stable State ─────────────────────────────────────────────────────────
@@ -117,6 +119,13 @@ persistent actor Sensor {
   private var deviceCounter   : Nat         = 0;
   private var eventCounter    : Nat         = 0;
   private var jobsCreatedCount : Nat        = 0;
+
+  private let errsByMethod : Map.Map<Text, Nat> = Map.empty();
+
+  private func countError(method : Text) {
+    let prev = Option.get(Map.get(errsByMethod, Text.compare, method), 0);
+    Map.add(errsByMethod, Text.compare, method, prev + 1);
+  };
 
   // ─── Stable State ────────────────────────────────────────────────────────
 
@@ -382,18 +391,31 @@ persistent actor Sensor {
   ) : async Result.Result<SensorEvent, Error> {
     switch (requireActive(msg.caller)) { case (#err e) return #err e; case _ {} };
 
-    if (not isGateway(msg.caller) and not isAdmin(msg.caller))
+    if (not isGateway(msg.caller) and not isAdmin(msg.caller)) {
+      Debug.print("sensor.recordEvent: unauthorized caller: " # Principal.toText(msg.caller));
+      countError("recordEvent");
       return #err(#Unauthorized);
+    };
 
-    if (Text.size(rawPayload) > MAX_PAYLOAD_BYTES)
+    if (Text.size(rawPayload) > MAX_PAYLOAD_BYTES) {
+      countError("recordEvent");
       return #err(#InvalidInput("rawPayload exceeds 4096-byte limit"));
+    };
 
     let deviceId = switch (Map.get(externalIdIdx, Text.compare, externalDeviceId)) {
-      case null     { return #err(#NotFound) };
+      case null     {
+        Debug.print("sensor.recordEvent: device not found: " # externalDeviceId);
+        countError("recordEvent");
+        return #err(#NotFound);
+      };
       case (?id)    { id };
     };
     let device = switch (Map.get(devices, Text.compare, deviceId)) {
-      case null  { return #err(#NotFound) };
+      case null  {
+        Debug.print("sensor.recordEvent: internal device missing: " # deviceId);
+        countError("recordEvent");
+        return #err(#NotFound);
+      };
       case (?d)  { d };
     };
 
@@ -528,6 +550,7 @@ persistent actor Sensor {
       criticalEvents = critical;
       jobsCreated    = jobsCreatedCount;
       isPaused;
+      errorsByMethod = Iter.toArray(Map.entries(errsByMethod));
     }
   };
 }

--- a/frontend/src/services/errorTracker.ts
+++ b/frontend/src/services/errorTracker.ts
@@ -62,6 +62,8 @@ export interface ErrorReport {
   userAgent:       string;
   breadcrumbs:     Breadcrumb[];
   tags?:           Record<string, string>;
+  /** Session trace ID — links this error to voice server and gateway log lines. */
+  traceId?:        string;
 }
 
 // ── Tracker ───────────────────────────────────────────────────────────────────
@@ -152,6 +154,9 @@ class ErrorTracker {
       }
 
       // ── build report ────────────────────────────────────────────────────────
+      let traceId: string | undefined;
+      try { traceId = sessionStorage.getItem("hg-trace") ?? undefined; } catch { /* blocked */ }
+
       const report: ErrorReport = {
         level,
         message,
@@ -166,6 +171,7 @@ class ErrorTracker {
         userAgent:   navigator.userAgent,
         breadcrumbs: [...this.breadcrumbs],
         tags:        { source: source ?? "manual" },
+        traceId,
       };
 
       void this._send(report);

--- a/frontend/src/services/voiceAgentHeaders.ts
+++ b/frontend/src/services/voiceAgentHeaders.ts
@@ -5,6 +5,8 @@
  *   x-api-key       — shared secret (VITE_VOICE_AGENT_API_KEY), when set
  *   x-icp-principal — caller's ICP principal for structured log attribution,
  *                     when the user is authenticated
+ *   x-trace-id      — session-scoped UUID that correlates all requests and
+ *                     error reports from this browser session in the log stream
  */
 
 import { useAuthStore } from "@/store/authStore";
@@ -12,11 +14,27 @@ import { useAuthStore } from "@/store/authStore";
 const VOICE_API_KEY =
   (import.meta as any).env?.VITE_VOICE_AGENT_API_KEY ?? "";
 
+const TRACE_KEY = "hg-trace";
+
+/** Returns a stable UUID for this browser session (persists across page reloads). */
+function getTraceId(): string {
+  try {
+    const existing = sessionStorage.getItem(TRACE_KEY);
+    if (existing) return existing;
+    const id = crypto.randomUUID();
+    sessionStorage.setItem(TRACE_KEY, id);
+    return id;
+  } catch {
+    return crypto.randomUUID(); // sessionStorage blocked (private mode, etc.)
+  }
+}
+
 export function voiceAgentHeaders(): Record<string, string> {
   const { principal } = useAuthStore.getState();
   return {
-    "Content-Type": "application/json",
-    ...(VOICE_API_KEY ? { "x-api-key":       VOICE_API_KEY } : {}),
-    ...(principal    ? { "x-icp-principal":  principal    } : {}),
+    "Content-Type":    "application/json",
+    "x-trace-id":      getTraceId(),
+    ...(VOICE_API_KEY ? { "x-api-key":      VOICE_API_KEY } : {}),
+    ...(principal     ? { "x-icp-principal": principal    } : {}),
   };
 }

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -754,6 +754,41 @@ else
   echo "  (skipped — local network)"
 fi
 
+# ── Freezing threshold (cycle safety net) ────────────────────────────────────
+# Sets freezing_threshold to 30 days on every canister so the IC will reject
+# new calls before cycles hit zero, giving a 30-day window for the cycle-watchdog
+# to top up before an outage. Uses dfx (icp-cli update-settings not yet available,
+# see #174). Skipped silently when dfx is absent.
+echo ""
+echo "============================================"
+echo "  Freezing Threshold (30-day safety net)"
+echo "============================================"
+FREEZE_CANISTERS=(
+  auth property job contractor quote payment photo
+  report maintenance market sensor monitoring listing
+  agent recurring bills ai_proxy
+)
+FREEZE_THRESHOLD=2592000  # 30 days in seconds
+if command -v dfx >/dev/null 2>&1; then
+  FREEZE_NETWORK="${ENV}"
+  [ "$ENV" = "local" ] && FREEZE_NETWORK="local"
+  FREEZE_OK=0
+  FREEZE_SKIP=0
+  for CANISTER in "${FREEZE_CANISTERS[@]}"; do
+    if dfx canister update-settings "$CANISTER" \
+         --freezing-threshold "$FREEZE_THRESHOLD" \
+         --network "$FREEZE_NETWORK" >/dev/null 2>&1; then
+      FREEZE_OK=$(( FREEZE_OK + 1 ))
+    else
+      FREEZE_SKIP=$(( FREEZE_SKIP + 1 ))
+    fi
+  done
+  echo "  ✓ Freezing threshold set (${FREEZE_OK} ok, ${FREEZE_SKIP} skipped — not yet deployed)"
+else
+  echo "  ⚠️  dfx not found — set freezing_threshold manually:"
+  echo "     dfx canister update-settings <name> --freezing-threshold 2592000 --network ic"
+fi
+
 # Internet Identity is managed by icp-cli via ii: true in icp.yaml.
 # icp network start -d deploys it automatically. Local URL: http://id.ai.localhost:8000
 


### PR DESCRIPTION
…ty (#298 #299 #302)

## #298 — Request trace IDs
- Add getTraceId() to voiceAgentHeaders.ts (sessionStorage "hg-trace" UUID)
- Send x-trace-id on all voice-server requests; echo reqId + traceId back as response headers
- Include traceId in ErrorReport (errorTracker.ts) for Sentry-style correlation

## #299 — Automated cycle safety
- scripts/deploy.sh: set freezing_threshold=30 days on all 17 canisters post-deploy
- cycle-watchdog.yml: fix boolean default lint error; add email alert via Resend on critical cycles
- monitoring/main.mo: add getCriticalCycleAlerts() unauthenticated query
- agents/voice/monitoringCanister.ts + server.ts GET /admin/cycle-status endpoint

## #302 — Canister observability (errsByMethod + Debug.print)
- auth, sensor, job, property, ai_proxy: countError() + Debug.print on key error paths
- payment: add Metrics type + getMetrics() + countError on consumeAgentCredit
- Makefile: add `make logs` target (tails last 50 lines from 7 key canisters)

## Summary
<!-- What does this PR do? -->

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [ ] Backend tests pass (`make test`)
- [ ] Frontend builds (`cd frontend && npm run build`)
- [ ] Tested locally with dfx

## Checklist
- [ ] Code follows project conventions
- [ ] Self-review completed
- [ ] No sensitive data committed
