### PR TITLE
feat(ops): migrate IoT pollers and voice server to structured logger …

### DIFF
--- a/agents/iot-gateway/pollers/ecobee.ts
+++ b/agents/iot-gateway/pollers/ecobee.ts
@@ -21,6 +21,7 @@ import fs from "fs";
 import path from "path";
 import { handleEcobeeEvent } from "../handlers";
 import { recordSensorEvent } from "../icp";
+import { logger } from "../logger";
 import type { EcobeeWebhookEvent, EcobeeAlert } from "../types";
 
 const ECOBEE_API        = "https://api.ecobee.com";
@@ -46,7 +47,7 @@ export function loadTokenState(): TokenState | null {
         return parsed;
       }
     } catch {
-      console.warn("[ecobee-poller] corrupted token file — falling back to env vars");
+      logger.warn("ecobee-poller", "corrupted token file — falling back to env vars");
     }
   }
 
@@ -65,7 +66,7 @@ export function persistTokenState(state: TokenState): void {
   try {
     fs.writeFileSync(TOKENS_FILE, JSON.stringify(state, null, 2), "utf8");
   } catch (err) {
-    console.warn("[ecobee-poller] failed to persist tokens:", err);
+    logger.warn("ecobee-poller", "failed to persist tokens", { error: String(err) });
   }
   // Keep process.env in sync so other callers (e.g. tests) see current values.
   process.env.ECOBEE_ACCESS_TOKEN  = state.accessToken;
@@ -100,7 +101,7 @@ export async function refreshTokens(state: TokenState): Promise<TokenState> {
   };
 
   persistTokenState(newState);
-  console.log(`[ecobee-poller] tokens refreshed — next expiry in ${Math.round(data.expires_in / 60)} min`);
+  logger.info("ecobee-poller", "tokens refreshed", { expiresInMin: Math.round(data.expires_in / 60) });
   return newState;
 }
 
@@ -143,7 +144,7 @@ export async function pollOnce(state: TokenState): Promise<void> {
   });
 
   if (!resp.ok) {
-    console.error(`[ecobee-poller] poll failed (${resp.status}): ${await resp.text()}`);
+    logger.error("ecobee-poller", "poll failed", { status: resp.status, body: await resp.text() });
     return;
   }
 
@@ -161,16 +162,16 @@ export async function pollOnce(state: TokenState): Promise<void> {
     if (!reading) continue;
 
     const eventName = Object.keys(reading.eventType)[0];
-    console.log(`[ecobee-poller] ${eventName} device=${therm.identifier} (${therm.name})`);
+    logger.info("ecobee-poller", eventName, { deviceId: therm.identifier, deviceName: therm.name });
 
     const result = await recordSensorEvent(reading);
     if (result.success) {
-      console.log(
-        `[ecobee-poller] recorded eventId=${result.eventId}` +
-        (result.jobId ? ` jobId=${result.jobId}` : "")
-      );
+      logger.info("ecobee-poller", "recorded", {
+        eventId: result.eventId,
+        ...(result.jobId ? { jobId: result.jobId } : {}),
+      });
     } else {
-      console.error(`[ecobee-poller] canister error: ${result.error}`);
+      logger.error("ecobee-poller", "canister error", { error: result.error });
     }
   }
 }
@@ -186,9 +187,7 @@ export async function pollOnce(state: TokenState): Promise<void> {
 export function startEcobeePoller(intervalMs = 3 * 60 * 1000): () => void {
   const initial = loadTokenState();
   if (!initial) {
-    console.warn(
-      "[ecobee-poller] ECOBEE_ACCESS_TOKEN or ECOBEE_REFRESH_TOKEN not set — poller disabled"
-    );
+    logger.warn("ecobee-poller", "ECOBEE_ACCESS_TOKEN or ECOBEE_REFRESH_TOKEN not set — poller disabled");
     return () => {};
   }
 
@@ -202,7 +201,7 @@ export function startEcobeePoller(intervalMs = 3 * 60 * 1000): () => void {
       currentState = await ensureFreshToken(currentState);
       await pollOnce(currentState);
     } catch (err) {
-      console.error("[ecobee-poller] tick error:", err);
+      logger.error("ecobee-poller", "tick error", { error: String(err) });
     } finally {
       if (!stopped) {
         timer = setTimeout(tick, intervalMs);
@@ -210,12 +209,12 @@ export function startEcobeePoller(intervalMs = 3 * 60 * 1000): () => void {
     }
   }
 
-  console.log(`[ecobee-poller] starting — interval=${intervalMs / 1000}s`);
+  logger.info("ecobee-poller", "starting", { intervalSec: intervalMs / 1000 });
   tick(); // run immediately, then on each interval
 
   return () => {
     stopped = true;
     if (timer) clearTimeout(timer);
-    console.log("[ecobee-poller] stopped");
+    logger.info("ecobee-poller", "stopped");
   };
 }

--- a/agents/iot-gateway/pollers/enphase.ts
+++ b/agents/iot-gateway/pollers/enphase.ts
@@ -18,6 +18,7 @@
 
 import { handleEnphaseEvent } from "../handlers";
 import { recordSensorEvent } from "../icp";
+import { logger } from "../logger";
 import type { EnphaseSystemEvent } from "../types";
 
 const ENVOY_API            = "https"; // scheme prefix — full URL built at call time
@@ -71,7 +72,11 @@ export async function pollOnce(config: EnphaseConfig): Promise<void> {
   });
 
   if (!prodResp.ok) {
-    console.error(`[enphase-poller] production fetch failed (${prodResp.status}): ${await prodResp.text()}`);
+    logger.error("enphase-poller", "production fetch failed", {
+      serial: config.serial,
+      status: prodResp.status,
+      body:   await prodResp.text(),
+    });
     return;
   }
 
@@ -84,7 +89,11 @@ export async function pollOnce(config: EnphaseConfig): Promise<void> {
   });
 
   if (!invResp.ok) {
-    console.error(`[enphase-poller] inverters fetch failed (${invResp.status}): ${await invResp.text()}`);
+    logger.error("enphase-poller", "inverters fetch failed", {
+      serial: config.serial,
+      status: invResp.status,
+      body:   await invResp.text(),
+    });
     return;
   }
 
@@ -109,16 +118,20 @@ export async function pollOnce(config: EnphaseConfig): Promise<void> {
   if (!reading) return;
 
   const eventName = Object.keys(reading.eventType)[0];
-  console.log(`[enphase-poller] ${eventName} serial=${config.serial} wNow=${production.wNow}W faulted=${faultedInverters}`);
+  logger.info("enphase-poller", eventName, {
+    serial:           config.serial,
+    powerW:           production.wNow,
+    faultedInverters,
+  });
 
   const result = await recordSensorEvent(reading);
   if (result.success) {
-    console.log(
-      `[enphase-poller] recorded eventId=${result.eventId}` +
-      (result.jobId ? ` jobId=${result.jobId}` : "")
-    );
+    logger.info("enphase-poller", "recorded", {
+      eventId: result.eventId,
+      ...(result.jobId ? { jobId: result.jobId } : {}),
+    });
   } else {
-    console.error(`[enphase-poller] canister error: ${result.error}`);
+    logger.error("enphase-poller", "canister error", { error: result.error });
   }
 }
 
@@ -131,9 +144,7 @@ export async function pollOnce(config: EnphaseConfig): Promise<void> {
 export function startEnphasePoller(intervalMs = 60_000): () => void {
   const config = loadConfig();
   if (!config) {
-    console.warn(
-      "[enphase-poller] ENPHASE_ENVOY_IP, ENPHASE_ENVOY_TOKEN, or ENPHASE_SERIAL not set — poller disabled"
-    );
+    logger.warn("enphase-poller", "ENPHASE_ENVOY_IP, ENPHASE_ENVOY_TOKEN, or ENPHASE_SERIAL not set — poller disabled");
     return () => {};
   }
 
@@ -145,7 +156,7 @@ export function startEnphasePoller(intervalMs = 60_000): () => void {
     try {
       await pollOnce(config);
     } catch (err) {
-      console.error("[enphase-poller] tick error:", err);
+      logger.error("enphase-poller", "tick error", { error: String(err) });
     } finally {
       if (!stopped) {
         timer = setTimeout(tick, intervalMs);
@@ -153,12 +164,16 @@ export function startEnphasePoller(intervalMs = 60_000): () => void {
     }
   }
 
-  console.log(`[enphase-poller] starting — ip=${config.ip} serial=${config.serial} interval=${intervalMs / 1000}s`);
+  logger.info("enphase-poller", "starting", {
+    ip:          config.ip,
+    serial:      config.serial,
+    intervalSec: intervalMs / 1000,
+  });
   tick();
 
   return () => {
     stopped = true;
     if (timer) clearTimeout(timer);
-    console.log("[enphase-poller] stopped");
+    logger.info("enphase-poller", "stopped");
   };
 }

--- a/agents/iot-gateway/pollers/geSmartHQ.ts
+++ b/agents/iot-gateway/pollers/geSmartHQ.ts
@@ -20,6 +20,7 @@
 import fs from "fs";
 import path from "path";
 import { recordSensorEvent } from "../icp";
+import { logger } from "../logger";
 import type { SensorEventType, SensorReading, GEAppliance, GEApplianceAttributes } from "../types";
 
 const GE_API         = "https://api.whrcloud.com";
@@ -44,7 +45,7 @@ export function loadTokenState(): GETokenState | null {
         return parsed;
       }
     } catch {
-      console.warn("[ge-poller] corrupted token file — falling back to env vars");
+      logger.warn("ge-poller", "corrupted token file — falling back to env vars");
     }
   }
 
@@ -63,7 +64,7 @@ export function persistTokenState(state: GETokenState): void {
   try {
     fs.writeFileSync(TOKENS_FILE, JSON.stringify(state, null, 2), "utf8");
   } catch (err) {
-    console.warn("[ge-poller] failed to persist tokens:", err);
+    logger.warn("ge-poller", "failed to persist tokens", { error: String(err) });
   }
   process.env.GE_ACCESS_TOKEN  = state.accessToken;
   process.env.GE_REFRESH_TOKEN = state.refreshToken;
@@ -108,7 +109,7 @@ export async function refreshTokens(state: GETokenState): Promise<GETokenState> 
   };
 
   persistTokenState(newState);
-  console.log(`[ge-poller] tokens refreshed — next expiry in ${Math.round(data.expires_in / 60)} min`);
+  logger.info("ge-poller", "tokens refreshed", { expiresInMin: Math.round(data.expires_in / 60) });
   return newState;
 }
 
@@ -167,7 +168,10 @@ export async function pollOnce(state: GETokenState): Promise<void> {
   // 1. Fetch appliance list.
   const listResp = await fetch(`${GE_API}/api/v1/appliance`, { headers });
   if (!listResp.ok) {
-    console.error(`[ge-poller] appliance list failed (${listResp.status}): ${await listResp.text()}`);
+    logger.error("ge-poller", "appliance list failed", {
+      status: listResp.status,
+      body:   await listResp.text(),
+    });
     return;
   }
 
@@ -186,10 +190,11 @@ export async function pollOnce(state: GETokenState): Promise<void> {
     if (!attrResp.ok) {
       // 404 is expected for unconfigured appliance types — suppress.
       if (attrResp.status !== 404) {
-        console.error(
-          `[ge-poller] attribute fetch failed for ${applianceId} ` +
-          `(${attrResp.status}): ${await attrResp.text()}`
-        );
+        logger.error("ge-poller", "attribute fetch failed", {
+          applianceId,
+          status: attrResp.status,
+          body:   await attrResp.text(),
+        });
       }
       continue;
     }
@@ -203,16 +208,16 @@ export async function pollOnce(state: GETokenState): Promise<void> {
 
     const eventName = Object.keys(reading.eventType)[0];
     const label     = appliance.nickName ?? applianceId;
-    console.log(`[ge-poller] ${eventName} appliance=${applianceId} (${label})`);
+    logger.info("ge-poller", eventName, { applianceId, applianceName: label });
 
     const result = await recordSensorEvent(reading);
     if (result.success) {
-      console.log(
-        `[ge-poller] recorded eventId=${result.eventId}` +
-        (result.jobId ? ` jobId=${result.jobId}` : "")
-      );
+      logger.info("ge-poller", "recorded", {
+        eventId: result.eventId,
+        ...(result.jobId ? { jobId: result.jobId } : {}),
+      });
     } else {
-      console.error(`[ge-poller] canister error: ${result.error}`);
+      logger.error("ge-poller", "canister error", { error: result.error });
     }
   }
 }
@@ -226,7 +231,7 @@ export async function pollOnce(state: GETokenState): Promise<void> {
 export function startGEPoller(intervalMs = 5 * 60 * 1000): () => void {
   const initial = loadTokenState();
   if (!initial) {
-    console.warn("[ge-poller] GE_ACCESS_TOKEN or GE_REFRESH_TOKEN not set — poller disabled");
+    logger.warn("ge-poller", "GE_ACCESS_TOKEN or GE_REFRESH_TOKEN not set — poller disabled");
     return () => {};
   }
 
@@ -240,7 +245,7 @@ export function startGEPoller(intervalMs = 5 * 60 * 1000): () => void {
       currentState = await ensureFreshToken(currentState);
       await pollOnce(currentState);
     } catch (err) {
-      console.error("[ge-poller] tick error:", err);
+      logger.error("ge-poller", "tick error", { error: String(err) });
     } finally {
       if (!stopped) {
         timer = setTimeout(tick, intervalMs);
@@ -248,12 +253,12 @@ export function startGEPoller(intervalMs = 5 * 60 * 1000): () => void {
     }
   }
 
-  console.log(`[ge-poller] starting — interval=${intervalMs / 1000}s`);
+  logger.info("ge-poller", "starting", { intervalSec: intervalMs / 1000 });
   tick();
 
   return () => {
     stopped = true;
     if (timer) clearTimeout(timer);
-    console.log("[ge-poller] stopped");
+    logger.info("ge-poller", "stopped");
   };
 }

--- a/agents/iot-gateway/pollers/honeywellHome.ts
+++ b/agents/iot-gateway/pollers/honeywellHome.ts
@@ -22,6 +22,7 @@ import fs from "fs";
 import path from "path";
 import { handleHoneywellHomeEvent } from "../handlers";
 import { recordSensorEvent } from "../icp";
+import { logger } from "../logger";
 import type { HoneywellDevice } from "../types";
 
 const HONEYWELL_API     = "https://api.honeywell.com";
@@ -46,7 +47,7 @@ export function loadTokenState(): TokenState | null {
         return parsed;
       }
     } catch {
-      console.warn("[honeywell-poller] corrupted token file — falling back to env vars");
+      logger.warn("honeywell-poller", "corrupted token file — falling back to env vars");
     }
   }
 
@@ -65,7 +66,7 @@ export function persistTokenState(state: TokenState): void {
   try {
     fs.writeFileSync(TOKENS_FILE, JSON.stringify(state, null, 2), "utf8");
   } catch (err) {
-    console.warn("[honeywell-poller] failed to persist tokens:", err);
+    logger.warn("honeywell-poller", "failed to persist tokens", { error: String(err) });
   }
   process.env.HONEYWELL_ACCESS_TOKEN  = state.accessToken;
   process.env.HONEYWELL_REFRESH_TOKEN = state.refreshToken;
@@ -111,7 +112,7 @@ export async function refreshTokens(state: TokenState): Promise<TokenState> {
   };
 
   persistTokenState(newState);
-  console.log(`[honeywell-poller] tokens refreshed — next expiry in ${Math.round(data.expires_in / 60)} min`);
+  logger.info("honeywell-poller", "tokens refreshed", { expiresInMin: Math.round(data.expires_in / 60) });
   return newState;
 }
 
@@ -146,7 +147,7 @@ interface HoneywellWldApiDevice {
 export async function pollOnce(state: TokenState): Promise<void> {
   const clientId = process.env.HONEYWELL_CLIENT_ID;
   if (!clientId) {
-    console.error("[honeywell-poller] HONEYWELL_CLIENT_ID not set — skipping poll");
+    logger.error("honeywell-poller", "HONEYWELL_CLIENT_ID not set — skipping poll");
     return;
   }
 
@@ -161,9 +162,10 @@ export async function pollOnce(state: TokenState): Promise<void> {
       { headers: { Authorization: `Bearer ${state.accessToken}` } }
     );
     if (!locResp.ok) {
-      console.error(
-        `[honeywell-poller] locations fetch failed (${locResp.status}): ${await locResp.text()}`
-      );
+      logger.error("honeywell-poller", "locations fetch failed", {
+        status: locResp.status,
+        body:   await locResp.text(),
+      });
       return;
     }
     const locs = await locResp.json() as HoneywellLocation[];
@@ -188,10 +190,11 @@ async function pollThermostats(
   );
 
   if (!resp.ok) {
-    console.error(
-      `[honeywell-poller] thermostats fetch failed (${resp.status}) ` +
-      `for location ${locationId}: ${await resp.text()}`
-    );
+    logger.error("honeywell-poller", "thermostats fetch failed", {
+      status:     resp.status,
+      locationId,
+      body:       await resp.text(),
+    });
     return;
   }
 
@@ -223,10 +226,11 @@ async function pollWaterLeakDetectors(
   if (!resp.ok) {
     // 404 is expected when the location has no WLD devices — suppress to keep logs clean.
     if (resp.status !== 404) {
-      console.error(
-        `[honeywell-poller] WLD fetch failed (${resp.status}) ` +
-        `for location ${locationId}: ${await resp.text()}`
-      );
+      logger.error("honeywell-poller", "WLD fetch failed", {
+        status:     resp.status,
+        locationId,
+        body:       await resp.text(),
+      });
     }
     return;
   }
@@ -249,18 +253,19 @@ async function processDevice(device: HoneywellDevice): Promise<void> {
   if (!reading) return;
 
   const eventName = Object.keys(reading.eventType)[0];
-  console.log(
-    `[honeywell-poller] ${eventName} device=${device.deviceID} (${device.userDefinedDeviceName})`
-  );
+  logger.info("honeywell-poller", eventName, {
+    deviceId:   device.deviceID,
+    deviceName: device.userDefinedDeviceName,
+  });
 
   const result = await recordSensorEvent(reading);
   if (result.success) {
-    console.log(
-      `[honeywell-poller] recorded eventId=${result.eventId}` +
-      (result.jobId ? ` jobId=${result.jobId}` : "")
-    );
+    logger.info("honeywell-poller", "recorded", {
+      eventId: result.eventId,
+      ...(result.jobId ? { jobId: result.jobId } : {}),
+    });
   } else {
-    console.error(`[honeywell-poller] canister error: ${result.error}`);
+    logger.error("honeywell-poller", "canister error", { error: result.error });
   }
 }
 
@@ -275,9 +280,7 @@ async function processDevice(device: HoneywellDevice): Promise<void> {
 export function startHoneywellPoller(intervalMs = 3 * 60 * 1000): () => void {
   const initial = loadTokenState();
   if (!initial) {
-    console.warn(
-      "[honeywell-poller] HONEYWELL_ACCESS_TOKEN or HONEYWELL_REFRESH_TOKEN not set — poller disabled"
-    );
+    logger.warn("honeywell-poller", "HONEYWELL_ACCESS_TOKEN or HONEYWELL_REFRESH_TOKEN not set — poller disabled");
     return () => {};
   }
 
@@ -291,7 +294,7 @@ export function startHoneywellPoller(intervalMs = 3 * 60 * 1000): () => void {
       currentState = await ensureFreshToken(currentState);
       await pollOnce(currentState);
     } catch (err) {
-      console.error("[honeywell-poller] tick error:", err);
+      logger.error("honeywell-poller", "tick error", { error: String(err) });
     } finally {
       if (!stopped) {
         timer = setTimeout(tick, intervalMs);
@@ -299,12 +302,12 @@ export function startHoneywellPoller(intervalMs = 3 * 60 * 1000): () => void {
     }
   }
 
-  console.log(`[honeywell-poller] starting — interval=${intervalMs / 1000}s`);
+  logger.info("honeywell-poller", "starting", { intervalSec: intervalMs / 1000 });
   tick();
 
   return () => {
     stopped = true;
     if (timer) clearTimeout(timer);
-    console.log("[honeywell-poller] stopped");
+    logger.info("honeywell-poller", "stopped");
   };
 }

--- a/agents/iot-gateway/pollers/solarEdge.ts
+++ b/agents/iot-gateway/pollers/solarEdge.ts
@@ -11,6 +11,7 @@
 
 import { handleSolarEdgeEvent } from "../handlers";
 import { recordSensorEvent } from "../icp";
+import { logger } from "../logger";
 import type { SolarEdgeEvent } from "../types";
 
 const SOLAREDGE_API = "https://monitoringapi.solaredge.com";
@@ -62,7 +63,11 @@ export async function pollOnce(config: SolarEdgeConfig): Promise<void> {
   ]);
 
   if (!overviewResp.ok) {
-    console.error(`[solaredge-poller] overview fetch failed (${overviewResp.status}): ${await overviewResp.text()}`);
+    logger.error("solaredge-poller", "overview fetch failed", {
+      siteId: config.siteId,
+      status: overviewResp.status,
+      body:   await overviewResp.text(),
+    });
     return;
   }
 
@@ -89,16 +94,16 @@ export async function pollOnce(config: SolarEdgeConfig): Promise<void> {
   if (!reading) return;
 
   const eventName = Object.keys(reading.eventType)[0];
-  console.log(`[solaredge-poller] ${eventName} siteId=${config.siteId} power=${currentPowerW}W`);
+  logger.info("solaredge-poller", eventName, { siteId: config.siteId, powerW: currentPowerW });
 
   const result = await recordSensorEvent(reading);
   if (result.success) {
-    console.log(
-      `[solaredge-poller] recorded eventId=${result.eventId}` +
-      (result.jobId ? ` jobId=${result.jobId}` : "")
-    );
+    logger.info("solaredge-poller", "recorded", {
+      eventId: result.eventId,
+      ...(result.jobId ? { jobId: result.jobId } : {}),
+    });
   } else {
-    console.error(`[solaredge-poller] canister error: ${result.error}`);
+    logger.error("solaredge-poller", "canister error", { error: result.error });
   }
 }
 
@@ -112,9 +117,7 @@ export async function pollOnce(config: SolarEdgeConfig): Promise<void> {
 export function startSolarEdgePoller(intervalMs = 15 * 60 * 1000): () => void {
   const config = loadConfig();
   if (!config) {
-    console.warn(
-      "[solaredge-poller] SOLAREDGE_API_KEY or SOLAREDGE_SITE_ID not set — poller disabled"
-    );
+    logger.warn("solaredge-poller", "SOLAREDGE_API_KEY or SOLAREDGE_SITE_ID not set — poller disabled");
     return () => {};
   }
 
@@ -126,7 +129,7 @@ export function startSolarEdgePoller(intervalMs = 15 * 60 * 1000): () => void {
     try {
       await pollOnce(config);
     } catch (err) {
-      console.error("[solaredge-poller] tick error:", err);
+      logger.error("solaredge-poller", "tick error", { error: String(err) });
     } finally {
       if (!stopped) {
         timer = setTimeout(tick, intervalMs);
@@ -134,12 +137,12 @@ export function startSolarEdgePoller(intervalMs = 15 * 60 * 1000): () => void {
     }
   }
 
-  console.log(`[solaredge-poller] starting — siteId=${config.siteId} interval=${intervalMs / 1000}s`);
+  logger.info("solaredge-poller", "starting", { siteId: config.siteId, intervalSec: intervalMs / 1000 });
   tick();
 
   return () => {
     stopped = true;
     if (timer) clearTimeout(timer);
-    console.log("[solaredge-poller] stopped");
+    logger.info("solaredge-poller", "stopped");
   };
 }

--- a/agents/iot-gateway/pollers/teslaGateway.ts
+++ b/agents/iot-gateway/pollers/teslaGateway.ts
@@ -21,6 +21,7 @@ import fs from "fs";
 import path from "path";
 import { handleTeslaEvent } from "../handlers";
 import { recordSensorEvent } from "../icp";
+import { logger } from "../logger";
 import type { TeslaPowerwallEvent } from "../types";
 
 const DEFAULT_GATEWAY_IP = "192.168.91.1";
@@ -44,7 +45,7 @@ export function loadSession(): TeslaSession | null {
         return parsed;
       }
     } catch {
-      console.warn("[tesla-poller] corrupted session file — will re-authenticate");
+      logger.warn("tesla-poller", "corrupted session file — will re-authenticate");
     }
   }
 
@@ -60,7 +61,7 @@ export function persistSession(session: TeslaSession): void {
   try {
     fs.writeFileSync(SESSION_FILE, JSON.stringify(session, null, 2), "utf8");
   } catch (err) {
-    console.warn("[tesla-poller] failed to persist session:", err);
+    logger.warn("tesla-poller", "failed to persist session", { error: String(err) });
   }
   process.env.TESLA_ACCESS_TOKEN = session.token;
 }
@@ -99,7 +100,7 @@ export async function login(): Promise<TeslaSession> {
   };
 
   persistSession(session);
-  console.log("[tesla-poller] authenticated — session cached for 30 days");
+  logger.info("tesla-poller", "authenticated — session cached for 30 days");
   return session;
 }
 
@@ -126,7 +127,7 @@ export async function pollOnce(session: TeslaSession): Promise<TeslaSession> {
   const serial = process.env.TESLA_POWERWALL_SERIAL;
 
   if (!serial) {
-    console.error("[tesla-poller] TESLA_POWERWALL_SERIAL not set — skipping poll");
+    logger.error("tesla-poller", "TESLA_POWERWALL_SERIAL not set — skipping poll");
     return session;
   }
 
@@ -142,12 +143,16 @@ export async function pollOnce(session: TeslaSession): Promise<TeslaSession> {
 
   // On 401, signal that re-authentication is needed
   if (soeResp.status === 401) {
-    console.warn("[tesla-poller] session expired — will re-authenticate on next tick");
+    logger.warn("tesla-poller", "session expired — will re-authenticate on next tick");
     return { ...session, expiresAt: 0 };
   }
 
   if (!soeResp.ok) {
-    console.error(`[tesla-poller] SOE fetch failed (${soeResp.status}): ${await soeResp.text()}`);
+    logger.error("tesla-poller", "SOE fetch failed", {
+      serial,
+      status: soeResp.status,
+      body:   await soeResp.text(),
+    });
     return session;
   }
 
@@ -159,7 +164,11 @@ export async function pollOnce(session: TeslaSession): Promise<TeslaSession> {
   });
 
   if (!gridResp.ok) {
-    console.error(`[tesla-poller] grid status fetch failed (${gridResp.status}): ${await gridResp.text()}`);
+    logger.error("tesla-poller", "grid status fetch failed", {
+      serial,
+      status: gridResp.status,
+      body:   await gridResp.text(),
+    });
     return session;
   }
 
@@ -177,18 +186,20 @@ export async function pollOnce(session: TeslaSession): Promise<TeslaSession> {
   if (!reading) return session;
 
   const eventName = Object.keys(reading.eventType)[0];
-  console.log(
-    `[tesla-poller] ${eventName} serial=${serial} charge=${soe.percentage.toFixed(1)}% grid=${grid.grid_status}`
-  );
+  logger.info("tesla-poller", eventName, {
+    serial,
+    chargePercent: soe.percentage,
+    gridStatus:    grid.grid_status,
+  });
 
   const result = await recordSensorEvent(reading);
   if (result.success) {
-    console.log(
-      `[tesla-poller] recorded eventId=${result.eventId}` +
-      (result.jobId ? ` jobId=${result.jobId}` : "")
-    );
+    logger.info("tesla-poller", "recorded", {
+      eventId: result.eventId,
+      ...(result.jobId ? { jobId: result.jobId } : {}),
+    });
   } else {
-    console.error(`[tesla-poller] canister error: ${result.error}`);
+    logger.error("tesla-poller", "canister error", { error: result.error });
   }
 
   return session;
@@ -207,9 +218,7 @@ export function startTeslaPoller(intervalMs = 60_000): () => void {
   const serial   = process.env.TESLA_POWERWALL_SERIAL;
 
   if (!email || !password || !serial) {
-    console.warn(
-      "[tesla-poller] TESLA_EMAIL, TESLA_PASSWORD, or TESLA_POWERWALL_SERIAL not set — poller disabled"
-    );
+    logger.warn("tesla-poller", "TESLA_EMAIL, TESLA_PASSWORD, or TESLA_POWERWALL_SERIAL not set — poller disabled");
     return () => {};
   }
 
@@ -223,7 +232,7 @@ export function startTeslaPoller(intervalMs = 60_000): () => void {
       currentSession  = await ensureSession(currentSession);
       currentSession  = await pollOnce(currentSession);
     } catch (err) {
-      console.error("[tesla-poller] tick error:", err);
+      logger.error("tesla-poller", "tick error", { error: String(err) });
     } finally {
       if (!stopped) {
         timer = setTimeout(tick, intervalMs);
@@ -231,12 +240,12 @@ export function startTeslaPoller(intervalMs = 60_000): () => void {
     }
   }
 
-  console.log(`[tesla-poller] starting — ip=${ip} serial=${serial} interval=${intervalMs / 1000}s`);
+  logger.info("tesla-poller", "starting", { ip, serial, intervalSec: intervalMs / 1000 });
   tick();
 
   return () => {
     stopped = true;
     if (timer) clearTimeout(timer);
-    console.log("[tesla-poller] stopped");
+    logger.info("tesla-poller", "stopped");
   };
 }

--- a/agents/voice/logger.ts
+++ b/agents/voice/logger.ts
@@ -1,0 +1,43 @@
+/**
+ * Structured logger for the HomeGentic voice agent server.
+ *
+ * Writes JSON-lines to stdout (info/debug) and stderr (warn/error) so logs
+ * can be parsed by Datadog, CloudWatch, or any JSON-line consumer.
+ *
+ * Level precedence: debug < info < warn < error
+ * Set LOG_LEVEL env var to control minimum level (default: "info").
+ */
+
+type Level = "debug" | "info" | "warn" | "error";
+
+const LEVEL_ORDER: Record<Level, number> = { debug: 0, info: 1, warn: 2, error: 3 };
+
+function minLevel(): Level {
+  const raw = (process.env.LOG_LEVEL ?? "info").toLowerCase();
+  return (raw in LEVEL_ORDER ? raw : "info") as Level;
+}
+
+function emit(level: Level, component: string, msg: string, meta?: Record<string, unknown>): void {
+  if (LEVEL_ORDER[level] < LEVEL_ORDER[minLevel()]) return;
+
+  const entry = JSON.stringify({
+    ts:        new Date().toISOString(),
+    level,
+    component,
+    msg,
+    ...meta,
+  });
+
+  if (level === "warn" || level === "error") {
+    process.stderr.write(entry + "\n");
+  } else {
+    process.stdout.write(entry + "\n");
+  }
+}
+
+export const logger = {
+  debug: (component: string, msg: string, meta?: Record<string, unknown>) => emit("debug", component, msg, meta),
+  info:  (component: string, msg: string, meta?: Record<string, unknown>) => emit("info",  component, msg, meta),
+  warn:  (component: string, msg: string, meta?: Record<string, unknown>) => emit("warn",  component, msg, meta),
+  error: (component: string, msg: string, meta?: Record<string, unknown>) => emit("error", component, msg, meta),
+};

--- a/agents/voice/server.ts
+++ b/agents/voice/server.ts
@@ -19,6 +19,7 @@ import type { ChatRequest } from "./types";
 import type { MaintenanceContext } from "../maintenance/prompts";
 import { checkAndRecord, TIER_LIMITS } from "./agentLimiter";
 import type { SubscriptionTier } from "./agentLimiter";
+import { logger } from "./logger";
 // NOTE: Email (Resend), permits, price-benchmark, forecast, check, report-request
 // and lookup-year-built are handled by the ai_proxy Motoko canister.
 // This relay handles only the 6 Claude AI endpoints.
@@ -32,10 +33,10 @@ if (!process.env.ANTHROPIC_API_KEY) {
   if (process.env.NODE_ENV === "production") {
     throw new Error("ANTHROPIC_API_KEY env var must be set in production");
   }
-  console.warn("[voice-agent] ANTHROPIC_API_KEY not set — Claude API calls will fail");
+  logger.warn("voice-agent", "ANTHROPIC_API_KEY not set — Claude API calls will fail");
 }
 
-console.log(`[voice-agent] STRIPE_SECRET_KEY ${process.env.STRIPE_SECRET_KEY ? "✓" : "✗ not set"}`)
+logger.info("voice-agent", "env check", { stripe_key: !!process.env.STRIPE_SECRET_KEY });
 
 // ── Frontend error aggregation (#297) ────────────────────────────────────────
 // In-memory map: fingerprint → rolling aggregation window.
@@ -88,7 +89,7 @@ if (!VOICE_API_KEY) {
   if (process.env.NODE_ENV === "production") {
     throw new Error("VOICE_AGENT_API_KEY env var must be set in production");
   }
-  console.warn("[voice-agent] VOICE_AGENT_API_KEY not set — API endpoints are unprotected (dev only)");
+  logger.warn("voice-agent", "VOICE_AGENT_API_KEY not set — API endpoints are unprotected (dev only)");
 }
 
 // 14.3.3 — fail-secure: require FRONTEND_ORIGIN in production
@@ -97,7 +98,7 @@ if (!allowedOrigin) {
   if (process.env.NODE_ENV === "production") {
     throw new Error("FRONTEND_ORIGIN env var must be set in production");
   }
-  console.warn("[voice-agent] FRONTEND_ORIGIN not set — accepting any localhost origin (dev only)");
+  logger.warn("voice-agent", "FRONTEND_ORIGIN not set — accepting any localhost origin (dev only)");
 }
 // In production: exact match against FRONTEND_ORIGIN.
 // In dev: accept any localhost port so Vite (:5173), CRA (:3000), etc. all work.
@@ -1306,9 +1307,9 @@ app.post("/api/stripe/verify-session", async (req: Request, res: Response) => {
     if (principal) {
       try {
         await activateInCanister(principal, tier, months);
-        console.log(`[stripe] activated ${tier}/${billing} for ${principal}`);
+        logger.info("stripe", "subscription activated", { tier, billing, principal });
       } catch (e) {
-        console.warn(`[stripe] canister activation skipped: ${(e as Error).message}`);
+        logger.warn("stripe", "canister activation skipped", { error: (e as Error).message });
       }
     }
 
@@ -1372,9 +1373,9 @@ app.post("/api/stripe/verify-subscription", async (req: Request, res: Response) 
     if (principal) {
       try {
         await activateInCanister(principal, tier, months);
-        console.log(`[stripe] subscription activated ${tier}/${billing} for ${principal}`);
+        logger.info("stripe", "subscription activated", { tier, billing, principal });
       } catch (e) {
-        console.warn(`[stripe] canister activation skipped: ${(e as Error).message}`);
+        logger.warn("stripe", "canister activation skipped", { error: (e as Error).message });
       }
     }
 
@@ -1459,9 +1460,9 @@ app.post("/api/stripe/verify-credit-purchase", async (req: Request, res: Respons
 
     try {
       await grantAgentCredits(principal, packSize);
-      console.log(`[stripe] granted ${packSize} agent credits to ${principal}`);
+      logger.info("stripe", "agent credits granted", { packSize, principal });
     } catch (e) {
-      console.warn(`[stripe] credit grant skipped: ${(e as Error).message}`);
+      logger.warn("stripe", "credit grant skipped", { error: (e as Error).message });
     }
 
     res.json({ type: "agent_credits", packSize, principal });
@@ -1552,7 +1553,7 @@ app.post("/api/stripe/webhook", async (req: Request, res: Response) => {
         const principal = (sub.metadata?.icp_principal ?? "") as string;
         if (principal) {
           try { await revertPrincipalToFree(principal); }
-          catch (e) { console.warn(`[stripe-webhook] revert failed: ${(e as Error).message}`); }
+          catch (e) { logger.warn("stripe-webhook", "revert failed", { event: "subscription.deleted", error: (e as Error).message }); }
         }
         break;
       }
@@ -1564,7 +1565,7 @@ app.post("/api/stripe/webhook", async (req: Request, res: Response) => {
           const principal = (sub.metadata?.icp_principal ?? "") as string;
           if (principal) {
             try { await revertPrincipalToFree(principal); }
-            catch (e) { console.warn(`[stripe-webhook] revert failed: ${(e as Error).message}`); }
+            catch (e) { logger.warn("stripe-webhook", "revert failed", { event: "subscription.updated", error: (e as Error).message }); }
           }
         }
         break;
@@ -1579,7 +1580,7 @@ app.post("/api/stripe/webhook", async (req: Request, res: Response) => {
         ) as string;
         if (principal) {
           try { await revertPrincipalToFree(principal); }
-          catch (e) { console.warn(`[stripe-webhook] payment_failed revert: ${(e as Error).message}`); }
+          catch (e) { logger.warn("stripe-webhook", "payment_failed revert failed", { error: (e as Error).message }); }
         }
         break;
       }
@@ -1603,17 +1604,15 @@ app.post("/api/stripe/webhook", async (req: Request, res: Response) => {
         const months  = billing === "Yearly" ? 12 : 1;
         if (principal && tier) {
           try { await activateInCanister(principal, tier, months); }
-          catch (e) { console.warn(`[stripe-webhook] activate failed: ${(e as Error).message}`); }
+          catch (e) { logger.warn("stripe-webhook", "activate failed", { error: (e as Error).message }); }
         }
         break;
       }
       default:
-        process.stdout.write(JSON.stringify({
-          ts: new Date().toISOString(), event: "stripe_webhook_unhandled", type: event.type,
-        }) + "\n");
+        logger.info("stripe-webhook", "unhandled event", { type: event.type });
     }
   } catch (err) {
-    console.error(`[stripe-webhook] handler error: ${(err as Error).message}`);
+    logger.error("stripe-webhook", "handler error", { error: (err as Error).message });
     res.status(500).json({ error: "Internal webhook handler error" });
     return;
   }
@@ -1682,8 +1681,7 @@ export { app };
 
 const httpServer = process.env.NODE_ENV !== "test"
   ? app.listen(port, () => {
-      console.log(`HomeGentic voice agent proxy → http://localhost:${port}`);
-      console.log(`Accepting requests from ${origin}`);
+      logger.info("voice-agent", "started", { port, origin: String(origin) });
     })
   : null;
 
@@ -1692,14 +1690,14 @@ const httpServer = process.env.NODE_ENV !== "test"
 // exiting.  Without this a SIGTERM (deploy, container restart) kills open SSE
 // connections mid-stream, causing the frontend to show a hard error.
 function shutdown(signal: string): void {
-  console.log(`[voice-agent] ${signal} received — shutting down gracefully`);
+  logger.info("voice-agent", "shutting down gracefully", { signal });
   httpServer?.close(() => {
-    console.log("[voice-agent] all connections closed — exiting");
+    logger.info("voice-agent", "all connections closed — exiting");
     process.exit(0);
   });
   // Force-exit after 10 s so a hung stream never blocks a deploy indefinitely.
   setTimeout(() => {
-    console.error("[voice-agent] forced exit after 10 s");
+    logger.error("voice-agent", "forced exit after 10 s timeout");
     process.exit(1);
   }, 10_000).unref();
 }


### PR DESCRIPTION
…(#296)

Creates agents/voice/logger.ts (JSON-lines, same shape as iot-gateway/logger.ts).

Migrates every console.* call in all six IoT gateway pollers and agents/voice/server.ts to structured logger.{info,warn,error} calls with component and metadata fields (deviceId, siteId, serial, status, error, etc.) so log aggregators (Datadog, CloudWatch, Loki) can parse and alert on them.

Zero console.* calls remain in any of the migrated files.

## Summary
<!-- What does this PR do? -->

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [ ] Backend tests pass (`make test`)
- [ ] Frontend builds (`cd frontend && npm run build`)
- [ ] Tested locally with dfx

## Checklist
- [ ] Code follows project conventions
- [ ] Self-review completed
- [ ] No sensitive data committed
