### PR TITLE
feat(ops): audit canister for privileged action logging (#145)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,7 +141,7 @@ jobs:
           # fails on dfx 0.24.x with "dfx metadata not found" for the II canister.
           dfx deploy auth --argument "(principal \"$DEPLOYER\")"
           for canister in ai_proxy property job contractor quote payment photo \
-            monitoring market report maintenance sensor listing agent bills recurring; do
+            monitoring market report maintenance sensor listing agent bills recurring audit; do
             dfx deploy "$canister"
           done
 
@@ -153,6 +153,7 @@ jobs:
           dfx canister call payment grantSubscription "(principal \"$DEPLOYER\", variant { Pro })"
 
           # ── Wire inter-canister IDs ──────────────────────────────────────────
+          AUTH_ID=$(dfx canister id auth)
           PAYMENT_ID=$(dfx canister id payment)
           PROPERTY_ID=$(dfx canister id property)
           PHOTO_ID=$(dfx canister id photo)
@@ -163,6 +164,7 @@ jobs:
           REPORT_ID=$(dfx canister id report)
           BILLS_ID=$(dfx canister id bills)
           MAINTENANCE_ID=$(dfx canister id maintenance)
+          AUDIT_ID=$(dfx canister id audit)
 
           dfx canister call job         setPaymentCanisterId    "(\"$PAYMENT_ID\")"
           dfx canister call property    setPaymentCanisterId    "(principal \"$PAYMENT_ID\")"
@@ -199,6 +201,19 @@ jobs:
           dfx canister call property   addTrustedCanister "(principal \"$QUOTE_ID\")"
           dfx canister call property   addTrustedCanister "(principal \"$REPORT_ID\")"
           dfx canister call job        addTrustedCanister "(principal \"$SENSOR_ID\")"
+
+          # ── Audit canister wiring ────────────────────────────────────────────
+          dfx canister call audit addAdmin "(principal \"$DEPLOYER\")"
+          dfx canister call audit addTrustedCanister "(principal \"$AUTH_ID\")"
+          dfx canister call audit addTrustedCanister "(principal \"$PAYMENT_ID\")"
+          dfx canister call audit addTrustedCanister "(principal \"$PROPERTY_ID\")"
+          dfx canister call audit addTrustedCanister "(principal \"$REPORT_ID\")"
+          dfx canister call audit addTrustedCanister "(principal \"$PHOTO_ID\")"
+          dfx canister call auth     setAuditCanisterId "(principal \"$AUDIT_ID\")"
+          dfx canister call payment  setAuditCanisterId "(principal \"$AUDIT_ID\")"
+          dfx canister call property setAuditCanisterId "(principal \"$AUDIT_ID\")"
+          dfx canister call report   setAuditCanisterId "(principal \"$AUDIT_ID\")"
+          dfx canister call photo    setAuditCanisterId "(principal \"$AUDIT_ID\")"
 
       - name: Run backend tests
         run: bash scripts/test-backend.sh
@@ -252,7 +267,7 @@ jobs:
 
           dfx deploy auth --argument "(principal \"$DEPLOYER\")"
           for canister in ai_proxy property job contractor quote payment photo \
-            monitoring market report maintenance sensor listing agent bills recurring; do
+            monitoring market report maintenance sensor listing agent bills recurring audit; do
             dfx deploy "$canister"
           done
 
@@ -265,6 +280,7 @@ jobs:
           # and would hit the Basic (3) or Pro (10) cap. Principal: fixed seed[0]=42 in setup.ts.
           dfx canister call payment grantSubscription "(principal \"qxmov-duod5-ahrw6-wydp4-lppe4-ljtvj-7zvu3-qke5i-umwsv-vcb7g-mqe\", variant { Premium })"
 
+          AUTH_ID=$(dfx canister id auth)
           PAYMENT_ID=$(dfx canister id payment)
           PROPERTY_ID=$(dfx canister id property)
           PHOTO_ID=$(dfx canister id photo)
@@ -274,6 +290,7 @@ jobs:
           SENSOR_ID=$(dfx canister id sensor)
           REPORT_ID=$(dfx canister id report)
           MAINTENANCE_ID=$(dfx canister id maintenance)
+          AUDIT_ID=$(dfx canister id audit)
 
           dfx canister call job         setPaymentCanisterId    "(\"$PAYMENT_ID\")"
           dfx canister call property    setPaymentCanisterId    "(principal \"$PAYMENT_ID\")"
@@ -308,6 +325,19 @@ jobs:
           dfx canister call property   addTrustedCanister "(principal \"$QUOTE_ID\")"
           dfx canister call property   addTrustedCanister "(principal \"$REPORT_ID\")"
           dfx canister call job        addTrustedCanister "(principal \"$SENSOR_ID\")"
+
+          # ── Audit canister wiring ────────────────────────────────────────────
+          dfx canister call audit addAdmin "(principal \"$DEPLOYER\")"
+          dfx canister call audit addTrustedCanister "(principal \"$AUTH_ID\")"
+          dfx canister call audit addTrustedCanister "(principal \"$PAYMENT_ID\")"
+          dfx canister call audit addTrustedCanister "(principal \"$PROPERTY_ID\")"
+          dfx canister call audit addTrustedCanister "(principal \"$REPORT_ID\")"
+          dfx canister call audit addTrustedCanister "(principal \"$PHOTO_ID\")"
+          dfx canister call auth     setAuditCanisterId "(principal \"$AUDIT_ID\")"
+          dfx canister call payment  setAuditCanisterId "(principal \"$AUDIT_ID\")"
+          dfx canister call property setAuditCanisterId "(principal \"$AUDIT_ID\")"
+          dfx canister call report   setAuditCanisterId "(principal \"$AUDIT_ID\")"
+          dfx canister call photo    setAuditCanisterId "(principal \"$AUDIT_ID\")"
 
       - name: Run integration tests
         run: npm run test:integration

--- a/backend/audit/main.mo
+++ b/backend/audit/main.mo
@@ -1,0 +1,126 @@
+import Array     "mo:core/Array";
+import Nat       "mo:core/Nat";
+import Principal "mo:core/Principal";
+import Result    "mo:core/Result";
+import Time      "mo:core/Time";
+
+/// Append-only privileged-action audit log.
+///
+/// Source canisters call `log()` as a best-effort fire-and-forget after each
+/// admin operation.  Reads are restricted to admins.  No entry can be deleted
+/// or modified once written.
+persistent actor Audit {
+
+  // ── Types ──────────────────────────────────────────────────────────────────
+
+  public type AuditEntry = {
+    id        : Nat;
+    timestamp : Int;      // Time.now() — nanoseconds since epoch
+    caller    : Principal; // msg.caller of the source canister call
+    canister  : Text;      // source canister name ("auth", "payment", …)
+    action    : Text;      // e.g. "AdminAdded", "CanisterPaused"
+    subject   : ?Principal; // affected user / principal when applicable
+    detail    : Text;      // free-form context string
+  };
+
+  type Error = {
+    #NotAuthorized;
+    #InvalidInput : Text;
+  };
+
+  // ── State (all vars implicitly stable via persistent actor) ───────────────
+
+  private var entries          : [AuditEntry] = [];
+  private var nextId           : Nat          = 0;
+  private var admins           : [Principal]  = [];
+  private var adminInitialized : Bool         = false;
+  private var trustedCanisters : [Principal]  = [];
+
+  // ── Internal helpers ───────────────────────────────────────────────────────
+
+  private func isAdmin(p : Principal) : Bool {
+    Array.find<Principal>(admins, func(a) { a == p }) != null
+  };
+
+  private func isTrusted(p : Principal) : Bool {
+    Array.find<Principal>(trustedCanisters, func(a) { a == p }) != null
+  };
+
+  // ── Bootstrap ──────────────────────────────────────────────────────────────
+
+  /// Add an admin.  First call is open (bootstrap); subsequent calls require
+  /// an existing admin caller.
+  public shared(msg) func addAdmin(newAdmin : Principal) : async Result.Result<(), Error> {
+    if (adminInitialized and not isAdmin(msg.caller)) return #err(#NotAuthorized);
+    if (not isAdmin(newAdmin)) {
+      admins := Array.concat(admins, [newAdmin]);
+    };
+    adminInitialized := true;
+    #ok(())
+  };
+
+  /// Register a canister principal allowed to call `log()`.
+  public shared(msg) func addTrustedCanister(canisterId : Principal) : async Result.Result<(), Error> {
+    if (not isAdmin(msg.caller)) return #err(#NotAuthorized);
+    if (not isTrusted(canisterId)) {
+      trustedCanisters := Array.concat(trustedCanisters, [canisterId]);
+    };
+    #ok(())
+  };
+
+  // ── Write (append-only) ────────────────────────────────────────────────────
+
+  /// Append a new audit entry.  Only registered trusted canisters and admins
+  /// may write.  Returns the assigned entry id.
+  public shared(msg) func log(
+    canister : Text,
+    action   : Text,
+    subject  : ?Principal,
+    detail   : Text,
+  ) : async Result.Result<Nat, Error> {
+    if (not isTrusted(msg.caller) and not isAdmin(msg.caller)) {
+      return #err(#NotAuthorized);
+    };
+    let entry : AuditEntry = {
+      id        = nextId;
+      timestamp = Time.now();
+      caller    = msg.caller;
+      canister;
+      action;
+      subject;
+      detail;
+    };
+    entries := Array.concat(entries, [entry]);
+    nextId  := nextId + 1;
+    #ok(entry.id)
+  };
+
+  // ── Queries (admin-only) ───────────────────────────────────────────────────
+
+  /// Paginated read.  Returns up to `limit` entries starting at index `from`.
+  public shared(msg) func getEntries(
+    from  : Nat,
+    limit : Nat,
+  ) : async Result.Result<[AuditEntry], Error> {
+    if (not isAdmin(msg.caller)) return #err(#NotAuthorized);
+    let total = entries.size();
+    if (from >= total) return #ok([]);
+    let bound = Nat.min(from + limit, total);
+    #ok(Array.tabulate<AuditEntry>(bound - from, func(i) { entries[from + i] }))
+  };
+
+  /// Filtered read by the source caller principal and action string.
+  public shared(msg) func getEntriesByCallerAndAction(
+    target : Principal,
+    action : Text,
+  ) : async Result.Result<[AuditEntry], Error> {
+    if (not isAdmin(msg.caller)) return #err(#NotAuthorized);
+    #ok(Array.filter<AuditEntry>(entries, func(e) {
+      e.caller == target and e.action == action
+    }))
+  };
+
+  public query func metrics() : async { entryCount : Nat } {
+    { entryCount = entries.size() }
+  };
+}

--- a/backend/auth/main.mo
+++ b/backend/auth/main.mo
@@ -87,6 +87,7 @@ persistent actor class Auth(initDeployer : Principal) {
   // initDeployer is set atomically at install time — no open window for a
   // first-caller race. On upgrade, stable storage restores the existing value.
   private var admins: [Principal] = [initDeployer];
+  private var auditCanisterId : ?Principal = null;
 
   /// Per-principal update-call rate limiting (cycle-drain protection).
   private transient let updateCallLimits : Map.Map<Text, (Nat, Int)> = Map.empty();
@@ -183,6 +184,7 @@ persistent actor class Auth(initDeployer : Principal) {
     if (not isAdmin(newAdmin)) {
       admins := Array.concat(admins, [newAdmin]);
     };
+    try { ignore await auditLog("AdminAdded", ?newAdmin, "caller=" # Principal.toText(msg.caller)) } catch _ {};
     #ok(())
   };
 
@@ -194,6 +196,7 @@ persistent actor class Auth(initDeployer : Principal) {
       case null    { null };
       case (?secs) { ?(Time.now() + secs * 1_000_000_000) };
     };
+    try { ignore await auditLog("CanisterPaused", null, "caller=" # Principal.toText(msg.caller)) } catch _ {};
     #ok(())
   };
 
@@ -202,7 +205,26 @@ persistent actor class Auth(initDeployer : Principal) {
     if (not isAdmin(msg.caller)) return #err(#NotAuthorized);
     isPaused := false;
     pauseExpiryNs := null;
+    try { ignore await auditLog("CanisterUnpaused", null, "caller=" # Principal.toText(msg.caller)) } catch _ {};
     #ok(())
+  };
+
+  public shared(msg) func setAuditCanisterId(id : Principal) : async Result.Result<(), Error> {
+    if (not isAdmin(msg.caller)) return #err(#NotAuthorized);
+    auditCanisterId := ?id;
+    #ok(())
+  };
+
+  private func auditLog(action : Text, subject : ?Principal, detail : Text) : async () {
+    switch (auditCanisterId) {
+      case null {};
+      case (?aid) {
+        let a : actor {
+          log : (Text, Text, ?Principal, Text) -> async { #ok : Nat; #err : { #NotAuthorized; #InvalidInput : Text } }
+        } = actor(Principal.toText(aid));
+        try { ignore await a.log("auth", action, subject, detail) } catch _ {};
+      };
+    };
   };
 
   // ─── Validation Helpers ───────────────────────────────────────────────────────

--- a/backend/payment/main.mo
+++ b/backend/payment/main.mo
@@ -235,8 +235,9 @@ persistent actor Payment {
   };
 
   // Admin
-  private var adminEntries     : [Principal] = [];
-  private var adminInitialized : Bool        = false;
+  private var adminEntries      : [Principal]  = [];
+  private var adminInitialized  : Bool         = false;
+  private var auditCanisterId   : ?Principal   = null;
   // ── Ingress inspection ────────────────────────────────────────────────────
   /// Reject anonymous callers and zero-byte payloads before execution.
   /// Empty payload cannot be valid Candid for any method that takes a struct
@@ -340,6 +341,24 @@ persistent actor Payment {
 
   public query func isAdminPrincipal(p: Principal) : async Bool {
     isAdmin(p)
+  };
+
+  public shared(msg) func setAuditCanisterId(id : Principal) : async Result.Result<(), Error> {
+    if (not isAdmin(msg.caller)) return #err(#NotAuthorized);
+    auditCanisterId := ?id;
+    #ok(())
+  };
+
+  private func auditLog(action : Text, subject : ?Principal, detail : Text) : async () {
+    switch (auditCanisterId) {
+      case null {};
+      case (?aid) {
+        let a : actor {
+          log : (Text, Text, ?Principal, Text) -> async { #ok : Nat; #err : { #NotAuthorized; #InvalidInput : Text } }
+        } = actor(Principal.toText(aid));
+        try { ignore await a.log("payment", action, subject, detail) } catch _ {};
+      };
+    };
   };
 
   /// Configure the canister IDs that receive setTier calls when a subscription
@@ -837,6 +856,7 @@ persistent actor Payment {
     };
     Map.add(subscriptions, Principal.compare, userPrincipal, sub);
     await propagateTier(userPrincipal, tier);
+    try { ignore await auditLog("TierActivated", ?userPrincipal, "months=" # Nat.toText(months) # " caller=" # Principal.toText(msg.caller)) } catch _ {};
     #ok(sub)
   };
 
@@ -858,6 +878,7 @@ persistent actor Payment {
     };
     Map.add(subscriptions, Principal.compare, principal, sub);
     await propagateTier(principal, tier);
+    try { ignore await auditLog("TierGranted", ?principal, "caller=" # Principal.toText(msg.caller)) } catch _ {};
     #ok(sub)
   };
 

--- a/backend/photo/main.mo
+++ b/backend/photo/main.mo
@@ -85,6 +85,7 @@ persistent actor Photo {
   private var isPaused: Bool = false;
   private var pauseExpiryNs: ?Int = null;
   private var adminListEntries: [Principal] = [];
+  private var auditCanisterId : ?Principal  = null;
   /// Payment canister ID — set post-deploy via setPaymentCanisterId().
   /// When set, uploadPhoto() cross-calls getTierForPrincipal() instead of
   /// reading the local tierGrants map.
@@ -451,6 +452,7 @@ persistent actor Photo {
           createdAt   = existing.createdAt;
         };
         Map.add(photos, Text.compare, photoId, updated);
+        try { ignore await auditLog("PhotoApproved", ?existing.owner, "photoId=" # photoId # " caller=" # Principal.toText(msg.caller)) } catch _ {};
         #ok(updated)
       };
     }
@@ -516,7 +518,26 @@ persistent actor Photo {
     if (not isAdmin(newAdmin)) {
       adminListEntries := Array.concat(adminListEntries, [newAdmin]);
     };
+    try { ignore await auditLog("AdminAdded", ?newAdmin, "caller=" # Principal.toText(msg.caller)) } catch _ {};
     #ok(())
+  };
+
+  public shared(msg) func setAuditCanisterId(id : Principal) : async Result.Result<(), Error> {
+    if (not isAdmin(msg.caller)) return #err(#Unauthorized);
+    auditCanisterId := ?id;
+    #ok(())
+  };
+
+  private func auditLog(action : Text, subject : ?Principal, detail : Text) : async () {
+    switch (auditCanisterId) {
+      case null {};
+      case (?aid) {
+        let a : actor {
+          log : (Text, Text, ?Principal, Text) -> async { #ok : Nat; #err : { #NotAuthorized; #InvalidInput : Text } }
+        } = actor(Principal.toText(aid));
+        try { ignore await a.log("photo", action, subject, detail) } catch _ {};
+      };
+    };
   };
 
   public shared(msg) func pause(durationSeconds: ?Nat) : async Result.Result<(), Error> {
@@ -526,6 +547,7 @@ persistent actor Photo {
       case null    { null };
       case (?secs) { ?(Time.now() + secs * 1_000_000_000) };
     };
+    try { ignore await auditLog("CanisterPaused", null, "caller=" # Principal.toText(msg.caller)) } catch _ {};
     #ok(())
   };
 
@@ -533,6 +555,7 @@ persistent actor Photo {
     if (not isAdmin(msg.caller)) return #err(#Unauthorized);
     isPaused := false;
     pauseExpiryNs := null;
+    try { ignore await auditLog("CanisterUnpaused", null, "caller=" # Principal.toText(msg.caller)) } catch _ {};
     #ok(())
   };
 

--- a/backend/property/main.mo
+++ b/backend/property/main.mo
@@ -288,6 +288,7 @@ persistent actor Property {
   private var admins                   : [Principal] = [];
   private var adminInitialized         : Bool        = false;
   private var trustedCanisterEntries   : [Principal] = [];
+  private var auditCanisterId          : ?Principal  = null;
   /// Payment canister ID — set post-deploy via setPaymentCanisterId().
   /// When set, registerProperty() cross-calls getTierForPrincipal() instead of
   /// reading the local tierGrants map.
@@ -757,6 +758,7 @@ persistent actor Property {
           isActive            = existing.isActive;
         };
         Map.add(properties, Text.compare, id, updated);
+        try { ignore await auditLog("PropertyVerified", ?existing.owner, "propertyId=" # id # " caller=" # Principal.toText(msg.caller)) } catch _ {};
         #ok(updated)
       };
     }
@@ -1311,7 +1313,26 @@ persistent actor Property {
     if (adminInitialized and not isAdmin(msg.caller)) return #err(#NotAuthorized);
     admins := Array.concat(admins, [newAdmin]);
     adminInitialized := true;
+    try { ignore await auditLog("AdminAdded", ?newAdmin, "caller=" # Principal.toText(msg.caller)) } catch _ {};
     #ok(())
+  };
+
+  public shared(msg) func setAuditCanisterId(id : Principal) : async Result.Result<(), Error> {
+    if (not isAdmin(msg.caller)) return #err(#NotAuthorized);
+    auditCanisterId := ?id;
+    #ok(())
+  };
+
+  private func auditLog(action : Text, subject : ?Principal, detail : Text) : async () {
+    switch (auditCanisterId) {
+      case null {};
+      case (?aid) {
+        let a : actor {
+          log : (Text, Text, ?Principal, Text) -> async { #ok : Nat; #err : { #NotAuthorized; #InvalidInput : Text } }
+        } = actor(Principal.toText(aid));
+        try { ignore await a.log("property", action, subject, detail) } catch _ {};
+      };
+    };
   };
 
   /// Register a canister principal as trusted for inter-canister calls.
@@ -1341,6 +1362,7 @@ persistent actor Property {
       case null    { null };
       case (?secs) { ?(Time.now() + secs * 1_000_000_000) };
     };
+    try { ignore await auditLog("CanisterPaused", null, "caller=" # Principal.toText(msg.caller)) } catch _ {};
     #ok(())
   };
 
@@ -1348,6 +1370,7 @@ persistent actor Property {
     if (not isAdmin(msg.caller)) return #err(#NotAuthorized);
     isPaused := false;
     pauseExpiryNs := null;
+    try { ignore await auditLog("CanisterUnpaused", null, "caller=" # Principal.toText(msg.caller)) } catch _ {};
     #ok(())
   };
 

--- a/backend/report/main.mo
+++ b/backend/report/main.mo
@@ -169,6 +169,7 @@ persistent actor Report {
   private var adminListEntries         : [Principal] = [];
   private var adminInitialized         : Bool        = false;
   private var trustedCanisterEntries   : [Principal] = [];
+  private var auditCanisterId          : ?Principal  = null;
   private var snapshotSchemaVersion : Nat         = 2;   // 14.4.3 — incremented when schema changes; kept as stable var for audit
   private var propCanisterId        : Text        = "";
 
@@ -532,6 +533,7 @@ persistent actor Report {
           hideDescriptions = link.hideDescriptions;
         };
         Map.add(links, Text.compare, token, revoked);
+        try { ignore await auditLog("ShareLinkRevoked", ?link.createdBy, "token=" # token # " caller=" # Principal.toText(msg.caller)) } catch _ {};
         #ok(())
       };
     }
@@ -561,7 +563,26 @@ persistent actor Report {
       adminListEntries := Array.concat(adminListEntries, [newAdmin]);
     };
     adminInitialized := true;
+    try { ignore await auditLog("AdminAdded", ?newAdmin, "caller=" # Principal.toText(msg.caller)) } catch _ {};
     #ok(())
+  };
+
+  public shared(msg) func setAuditCanisterId(id : Principal) : async Result.Result<(), Error> {
+    if (not isAdmin(msg.caller)) return #err(#Unauthorized);
+    auditCanisterId := ?id;
+    #ok(())
+  };
+
+  private func auditLog(action : Text, subject : ?Principal, detail : Text) : async () {
+    switch (auditCanisterId) {
+      case null {};
+      case (?aid) {
+        let a : actor {
+          log : (Text, Text, ?Principal, Text) -> async { #ok : Nat; #err : { #NotAuthorized; #InvalidInput : Text } }
+        } = actor(Principal.toText(aid));
+        try { ignore await a.log("report", action, subject, detail) } catch _ {};
+      };
+    };
   };
 
   /// Register a canister principal as trusted for inter-canister calls.
@@ -593,6 +614,7 @@ persistent actor Report {
       case null    { null };
       case (?secs) { ?(Time.now() + secs * 1_000_000_000) };
     };
+    try { ignore await auditLog("CanisterPaused", null, "caller=" # Principal.toText(msg.caller)) } catch _ {};
     #ok(())
   };
 
@@ -600,6 +622,7 @@ persistent actor Report {
     if (not isAdmin(msg.caller)) return #err(#Unauthorized);
     isPaused := false;
     pauseExpiryNs := null;
+    try { ignore await auditLog("CanisterUnpaused", null, "caller=" # Principal.toText(msg.caller)) } catch _ {};
     #ok(())
   };
 

--- a/dfx.json
+++ b/dfx.json
@@ -72,6 +72,10 @@
       "main": "backend/recurring/main.mo",
       "type": "motoko"
     },
+    "audit": {
+      "main": "backend/audit/main.mo",
+      "type": "motoko"
+    },
     "frontend": {
       "dependencies": [
         "auth", "property", "job", "contractor", "quote", "payment",

--- a/dfx.json
+++ b/dfx.json
@@ -80,7 +80,7 @@
       "dependencies": [
         "auth", "property", "job", "contractor", "quote", "payment",
         "photo", "report", "maintenance", "market", "sensor", "monitoring",
-        "listing", "agent", "recurring", "bills", "ai_proxy"
+        "listing", "agent", "recurring", "bills", "ai_proxy", "audit"
       ],
       "source": ["frontend/dist"],
       "type": "assets",

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-DEPLOY_SCRIPT_VERSION="1.7.0"
+DEPLOY_SCRIPT_VERSION="1.7.1"
 ENV=${1:-local}
 
 echo "============================================"
@@ -561,6 +561,7 @@ QUOTE_ID=$(icp canister status quote -e "$ENV" --id-only 2>/dev/null || echo "")
 SENSOR_ID=$(icp canister status sensor -e "$ENV" --id-only 2>/dev/null || echo "")
 REPORT_ID=$(icp canister status report -e "$ENV" --id-only 2>/dev/null || echo "")
 BILLS_ID=$(icp canister status bills -e "$ENV" --id-only 2>/dev/null || echo "")
+AUTH_ID=$(icp canister status auth -e "$ENV" --id-only 2>/dev/null || echo "")
 AUDIT_ID=$(icp canister status audit -e "$ENV" --id-only 2>/dev/null || echo "")
 
 if [ -n "$JOB_ID" ]      && [ -n "$PAYMENT_ID" ];    then
@@ -700,15 +701,17 @@ fi
 # Wire audit canister: register source canisters as trusted writers, then give
 # each source canister the audit canister ID so it can call log().
 if [ -n "$AUDIT_ID" ]; then
-  for src_canister in auth payment property report photo; do
-    src_id=$(icp canister status "$src_canister" -e "$ENV" --id-only 2>/dev/null || echo "")
-    if [ -n "$src_id" ]; then
-      echo "  audit: trusting $src_canister ($src_id)..."
-      icp canister call audit addTrustedCanister "(principal \"$src_id\")" -e "$ENV" 2>/dev/null &
-      echo "  $src_canister: wiring audit canister ($AUDIT_ID)..."
-      icp canister call "$src_canister" setAuditCanisterId "(principal \"$AUDIT_ID\")" -e "$ENV" 2>/dev/null &
-    fi
-  done
+  [ -n "$AUTH_ID" ]     && icp canister call audit addTrustedCanister "(principal \"$AUTH_ID\")"     -e "$ENV" 2>/dev/null &
+  [ -n "$PAYMENT_ID" ]  && icp canister call audit addTrustedCanister "(principal \"$PAYMENT_ID\")"  -e "$ENV" 2>/dev/null &
+  [ -n "$PROPERTY_ID" ] && icp canister call audit addTrustedCanister "(principal \"$PROPERTY_ID\")" -e "$ENV" 2>/dev/null &
+  [ -n "$REPORT_ID" ]   && icp canister call audit addTrustedCanister "(principal \"$REPORT_ID\")"   -e "$ENV" 2>/dev/null &
+  [ -n "$PHOTO_ID" ]    && icp canister call audit addTrustedCanister "(principal \"$PHOTO_ID\")"    -e "$ENV" 2>/dev/null &
+
+  [ -n "$AUTH_ID" ]     && icp canister call auth     setAuditCanisterId "(principal \"$AUDIT_ID\")" -e "$ENV" 2>/dev/null &
+  [ -n "$PAYMENT_ID" ]  && icp canister call payment  setAuditCanisterId "(principal \"$AUDIT_ID\")" -e "$ENV" 2>/dev/null &
+  [ -n "$PROPERTY_ID" ] && icp canister call property setAuditCanisterId "(principal \"$AUDIT_ID\")" -e "$ENV" 2>/dev/null &
+  [ -n "$REPORT_ID" ]   && icp canister call report   setAuditCanisterId "(principal \"$AUDIT_ID\")" -e "$ENV" 2>/dev/null &
+  [ -n "$PHOTO_ID" ]    && icp canister call photo    setAuditCanisterId "(principal \"$AUDIT_ID\")" -e "$ENV" 2>/dev/null &
 fi
 
 wait

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-DEPLOY_SCRIPT_VERSION="1.6.0"
+DEPLOY_SCRIPT_VERSION="1.7.0"
 ENV=${1:-local}
 
 echo "============================================"
@@ -202,7 +202,7 @@ fi
 #   non-local — three-phase: create (sequential) → build (sequential) → install
 #               (sequential). Sequential builds avoid concurrent writes to local.ids.json.
 
-CANISTERS=(auth property job contractor quote payment photo report maintenance market sensor monitoring listing agent recurring bills ai_proxy)
+CANISTERS=(auth property job contractor quote payment photo report maintenance market sensor monitoring listing agent recurring bills ai_proxy audit)
 LOG_DIR=$(mktemp -d /tmp/icp-deploy-XXXXXX)
 trap 'rm -rf "$LOG_DIR"' EXIT
 DEPLOY_PRINCIPAL=$(icp identity principal)
@@ -530,7 +530,7 @@ echo "============================================"
 DEPLOYER=$(icp identity principal)
 echo "  Deployer principal: $DEPLOYER"
 
-ADMIN_CANISTERS=(property job contractor quote photo report maintenance market sensor listing agent recurring bills monitoring)
+ADMIN_CANISTERS=(property job contractor quote photo report maintenance market sensor listing agent recurring bills monitoring audit)
 
 for canister in "${ADMIN_CANISTERS[@]}"; do
   echo "  $canister: adding deployer as admin..."
@@ -561,6 +561,7 @@ QUOTE_ID=$(icp canister status quote -e "$ENV" --id-only 2>/dev/null || echo "")
 SENSOR_ID=$(icp canister status sensor -e "$ENV" --id-only 2>/dev/null || echo "")
 REPORT_ID=$(icp canister status report -e "$ENV" --id-only 2>/dev/null || echo "")
 BILLS_ID=$(icp canister status bills -e "$ENV" --id-only 2>/dev/null || echo "")
+AUDIT_ID=$(icp canister status audit -e "$ENV" --id-only 2>/dev/null || echo "")
 
 if [ -n "$JOB_ID" ]      && [ -n "$PAYMENT_ID" ];    then
   echo "  Wiring payment -> job..."
@@ -696,6 +697,20 @@ if [ -n "$SENSOR_ID" ] && [ -n "$JOB_ID" ]; then
   icp canister call job addTrustedCanister "(principal \"$SENSOR_ID\")"       -e "$ENV" 2>/dev/null &
 fi
 
+# Wire audit canister: register source canisters as trusted writers, then give
+# each source canister the audit canister ID so it can call log().
+if [ -n "$AUDIT_ID" ]; then
+  for src_canister in auth payment property report photo; do
+    src_id=$(icp canister status "$src_canister" -e "$ENV" --id-only 2>/dev/null || echo "")
+    if [ -n "$src_id" ]; then
+      echo "  audit: trusting $src_canister ($src_id)..."
+      icp canister call audit addTrustedCanister "(principal \"$src_id\")" -e "$ENV" 2>/dev/null &
+      echo "  $src_canister: wiring audit canister ($AUDIT_ID)..."
+      icp canister call "$src_canister" setAuditCanisterId "(principal \"$AUDIT_ID\")" -e "$ENV" 2>/dev/null &
+    fi
+  done
+fi
+
 wait
 
 # ── AI Proxy canister — wire API keys from environment ────────────────────────
@@ -766,7 +781,7 @@ echo "============================================"
 FREEZE_CANISTERS=(
   auth property job contractor quote payment photo
   report maintenance market sensor monitoring listing
-  agent recurring bills ai_proxy
+  agent recurring bills ai_proxy audit
 )
 FREEZE_THRESHOLD=2592000  # 30 days in seconds
 if command -v dfx >/dev/null 2>&1; then


### PR DESCRIPTION
New append-only `audit` canister with admin-only paginated and filtered query interfaces. Source canisters (auth, payment, property, report, photo) each gain a `setAuditCanisterId` setter and a private `auditLog` helper that fires best-effort try/catch inter-canister calls after each privileged operation: AdminAdded, CanisterPaused/Unpaused, TierGranted, TierActivated, PropertyVerified, ShareLinkRevoked, PhotoApproved.

deploy.sh v1.6.0 → v1.7.0: adds audit to CANISTERS / ADMIN_CANISTERS / FREEZE_CANISTERS and wires setAuditCanisterId + addTrustedCanister for all five source canisters.

## Summary
<!-- What does this PR do? -->

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [ ] Backend tests pass (`make test`)
- [ ] Frontend builds (`cd frontend && npm run build`)
- [ ] Tested locally with dfx

## Checklist
- [ ] Code follows project conventions
- [ ] Self-review completed
- [ ] No sensitive data committed
