### PR TITLE
fix(security): address audit findings from issue #312

### DIFF
--- a/agents/iot-gateway/server.ts
+++ b/agents/iot-gateway/server.ts
@@ -127,7 +127,7 @@ function verifyHmac(
   headerName: string,
   secret: string | undefined
 ): boolean {
-  if (!secret) return true; // secret not configured — skip in dev
+  if (!secret) return false;
   const sig = req.headers[headerName.toLowerCase()] as string | undefined;
   if (!sig) return false;
   const raw = (req as Request & { rawBody?: Buffer }).rawBody;
@@ -140,7 +140,7 @@ function verifyHmac(
 
 // SmartThings signs requests with base64-encoded HMAC-SHA256 (not hex).
 function verifySmartThingsHmac(req: Request, secret: string | undefined): boolean {
-  if (!secret) return true;
+  if (!secret) return false;
   const sig = req.headers["x-st-hmac-sha256"] as string | undefined;
   if (!sig) return false;
   const raw = (req as Request & { rawBody?: Buffer }).rawBody;
@@ -171,7 +171,7 @@ app.post("/webhooks/nest", nestLimiter, async (req: Request, res: Response): Pro
   const expected = process.env.NEST_WEBHOOK_SECRET;
 
   const reqId = (req as RequestWithId).reqId;
-  if (expected && token !== expected) {
+  if (!expected || token !== expected) {
     logger.warn("nest", "rejected — invalid token", { reqId });
     res.status(401).json({ error: "Unauthorized" });
     return;
@@ -408,7 +408,7 @@ app.post("/webhooks/lgthinq", lgThinQLimiter, async (req: Request, res: Response
   const bearerToken = (req.headers["authorization"] ?? "").replace(/^Bearer\s+/i, "");
   const expectedPat = process.env.LG_THINQ_PAT;
 
-  if (expectedPat && bearerToken !== expectedPat) {
+  if (!expectedPat || bearerToken !== expectedPat) {
     logger.warn("lgthinq", "rejected — invalid PAT", { reqId });
     res.status(401).json({ error: "Unauthorized" });
     return;

--- a/backend/agent/main.mo
+++ b/backend/agent/main.mo
@@ -379,6 +379,13 @@ persistent actor Agent {
     #ok(())
   };
 
+  /// Remove an existing admin principal (existing admin only).
+  public shared(msg) func removeAdmin(target: Principal) : async Result.Result<(), Error> {
+    if (not isAdmin(msg.caller)) return #err(#Unauthorized);
+    adminListEntries := Array.filter<Principal>(adminListEntries, func(a) { a != target });
+    #ok(())
+  };
+
   public shared(msg) func pause(durationSeconds: ?Nat) : async Result.Result<(), Error> {
     if (not isAdmin(msg.caller)) return #err(#Unauthorized);
     isPaused := true;

--- a/backend/ai_proxy/main.mo
+++ b/backend/ai_proxy/main.mo
@@ -756,6 +756,13 @@ persistent actor AiProxy {
     #ok(())
   };
 
+  /// Remove an existing admin principal (existing admin only).
+  public shared(msg) func removeAdmin(target: Principal) : async Result.Result<(), Error> {
+    if (not isAdmin(msg.caller)) return #err(#Unauthorized);
+    adminListEntries := Array.filter<Principal>(adminListEntries, func(a) { a != target });
+    #ok(())
+  };
+
   public shared(msg) func setResendApiKey(key: Text) : async Result.Result<(), Error> {
     if (not isAdmin(msg.caller)) return #err(#Unauthorized);
     resendApiKey := key;

--- a/backend/audit/main.mo
+++ b/backend/audit/main.mo
@@ -59,6 +59,13 @@ persistent actor Audit {
     #ok(())
   };
 
+  /// Remove an existing admin principal (existing admin only).
+  public shared(msg) func removeAdmin(target: Principal) : async Result.Result<(), Error> {
+    if (adminInitialized and not isAdmin(msg.caller)) return #err(#NotAuthorized);
+    admins := Array.filter<Principal>(admins, func(a) { a != target });
+    #ok(())
+  };
+
   /// Register a canister principal allowed to call `log()`.
   public shared(msg) func addTrustedCanister(canisterId : Principal) : async Result.Result<(), Error> {
     if (not isAdmin(msg.caller)) return #err(#NotAuthorized);

--- a/backend/auth/main.mo
+++ b/backend/auth/main.mo
@@ -101,7 +101,9 @@ persistent actor class Auth(initDeployer : Principal) {
 
   private func countError(method : Text) {
     let prev = Option.get(Map.get(errsByMethod, Text.compare, method), 0);
-    Map.add(errsByMethod, Text.compare, method, prev + 1);
+    if (prev < 999_999) {
+      Map.add(errsByMethod, Text.compare, method, prev + 1);
+    };
   };
 
   // ─── Ingress Inspection ───────────────────────────────────────────────────────
@@ -185,6 +187,14 @@ persistent actor class Auth(initDeployer : Principal) {
       admins := Array.concat(admins, [newAdmin]);
     };
     try { ignore await auditLog("AdminAdded", ?newAdmin, "caller=" # Principal.toText(msg.caller)) } catch _ {};
+    #ok(())
+  };
+
+  /// Remove an existing admin principal (existing admin only).
+  public shared(msg) func removeAdmin(target: Principal) : async Result.Result<(), Error> {
+    if (not isAdmin(msg.caller)) return #err(#NotAuthorized);
+    admins := Array.filter<Principal>(admins, func(a) { a != target });
+    try { ignore await auditLog("AdminRemoved", ?target, "caller=" # Principal.toText(msg.caller)) } catch _ {};
     #ok(())
   };
 

--- a/backend/bills/main.mo
+++ b/backend/bills/main.mo
@@ -394,6 +394,13 @@ persistent actor Bills {
     #ok(())
   };
 
+  /// Remove an existing admin principal (existing admin only).
+  public shared(msg) func removeAdmin(target: Principal) : async Result.Result<(), Error> {
+    if (not isAdmin(msg.caller)) return #err(#Unauthorized);
+    adminListEntries := Array.filter<Principal>(adminListEntries, func(a) { a != target });
+    #ok(())
+  };
+
   public shared(msg) func pause(durationSeconds: ?Nat) : async Result.Result<(), Error> {
     if (not isAdmin(msg.caller)) return #err(#Unauthorized);
     isPaused := true;

--- a/backend/contractor/main.mo
+++ b/backend/contractor/main.mo
@@ -543,6 +543,13 @@ persistent actor Contractor {
     #ok(())
   };
 
+  /// Remove an existing admin principal (existing admin only).
+  public shared(msg) func removeAdmin(target: Principal) : async Result.Result<(), Error> {
+    if (not isAdmin(msg.caller)) return #err(#Unauthorized);
+    admins := Array.filter<Principal>(admins, func(a) { a != target });
+    #ok(())
+  };
+
   /// Register a canister principal as trusted for inter-canister calls.
   /// Trusted canisters (job) bypass per-principal rate limiting. Admin only.
   public shared(msg) func addTrustedCanister(p: Principal) : async Result.Result<(), Error> {

--- a/backend/job/main.mo
+++ b/backend/job/main.mo
@@ -654,6 +654,13 @@ persistent actor Job {
     #ok(())
   };
 
+  /// Remove an existing admin principal (existing admin only).
+  public shared(msg) func removeAdmin(target: Principal) : async Result.Result<(), Error> {
+    if (not isAdmin(msg.caller)) return #err(#Unauthorized);
+    adminListEntries := Array.filter<Principal>(adminListEntries, func(a) { a != target });
+    #ok(())
+  };
+
   /// Register a canister principal as trusted for inter-canister calls.
   /// Trusted canisters bypass per-principal rate limiting and may call
   /// restricted functions (e.g. createSensorJob). Admin only.

--- a/backend/listing/main.mo
+++ b/backend/listing/main.mo
@@ -572,6 +572,13 @@ persistent actor Listing {
     #ok(())
   };
 
+  /// Remove an existing admin principal (existing admin only).
+  public shared(msg) func removeAdmin(target: Principal) : async Result.Result<(), Error> {
+    if (not isAdmin(msg.caller)) return #err(#Unauthorized);
+    adminListEntries := Array.filter<Principal>(adminListEntries, func(a) { a != target });
+    #ok(())
+  };
+
   public shared(msg) func pause(durationSeconds: ?Nat) : async Result.Result<(), Error> {
     if (not isAdmin(msg.caller)) return #err(#Unauthorized);
     isPaused := true;

--- a/backend/maintenance/main.mo
+++ b/backend/maintenance/main.mo
@@ -394,6 +394,13 @@ persistent actor Maintenance {
     #ok(())
   };
 
+  /// Remove an existing admin principal (existing admin only).
+  public shared(msg) func removeAdmin(target: Principal) : async Result.Result<(), Error> {
+    if (not isAdmin(msg.caller)) return #err(#Unauthorized);
+    adminListEntries := Array.filter<Principal>(adminListEntries, func(a) { a != target });
+    #ok(())
+  };
+
   public shared(msg) func pause(durationSeconds: ?Nat) : async Result.Result<(), Error> {
     if (not isAdmin(msg.caller)) return #err(#Unauthorized);
     isPaused := true;

--- a/backend/market/main.mo
+++ b/backend/market/main.mo
@@ -747,6 +747,13 @@ persistent actor MarketIntelligence {
     #ok(())
   };
 
+  /// Remove an existing admin principal (existing admin only).
+  public shared(msg) func removeAdmin(target: Principal) : async Result.Result<(), Error> {
+    if (not isAdmin(msg.caller)) return #err(#Unauthorized);
+    adminListEntries := Array.filter<Principal>(adminListEntries, func(a) { a != target });
+    #ok(())
+  };
+
   public shared(msg) func pause(durationSeconds: ?Nat) : async Result.Result<(), Error> {
     if (not isAdmin(msg.caller)) return #err(#Unauthorized);
     isPaused := true;

--- a/backend/monitoring/main.mo
+++ b/backend/monitoring/main.mo
@@ -876,6 +876,13 @@ persistent actor Monitoring {
     #ok(())
   };
 
+  /// Remove an existing admin principal (existing admin only).
+  public shared(msg) func removeAdmin(target: Principal) : async Result.Result<(), Error> {
+    if (not isAdmin(msg.caller)) return #err(#Unauthorized);
+    adminListEntries := Array.filter<Principal>(adminListEntries, func(a) { a != target });
+    #ok(())
+  };
+
   public shared(msg) func pause(durationSeconds: ?Nat) : async Result.Result<(), Error> {
     if (not isAdmin(msg.caller)) return #err(#Unauthorized);
     isPaused := true;

--- a/backend/payment/main.mo
+++ b/backend/payment/main.mo
@@ -339,6 +339,24 @@ persistent actor Payment {
     #ok(())
   };
 
+  /// Add a new admin principal (existing admin only).
+  public shared(msg) func addAdmin(newAdmin: Principal) : async Result.Result<(), Error> {
+    if (not isAdmin(msg.caller)) return #err(#NotAuthorized);
+    if (not isAdmin(newAdmin)) {
+      adminEntries := Array.concat(adminEntries, [newAdmin]);
+    };
+    try { ignore await auditLog("AdminAdded", ?newAdmin, "caller=" # Principal.toText(msg.caller)) } catch _ {};
+    #ok(())
+  };
+
+  /// Remove an existing admin principal (existing admin only).
+  public shared(msg) func removeAdmin(target: Principal) : async Result.Result<(), Error> {
+    if (not isAdmin(msg.caller)) return #err(#NotAuthorized);
+    adminEntries := Array.filter<Principal>(adminEntries, func(a) { a != target });
+    try { ignore await auditLog("AdminRemoved", ?target, "caller=" # Principal.toText(msg.caller)) } catch _ {};
+    #ok(())
+  };
+
   public query func isAdminPrincipal(p: Principal) : async Bool {
     isAdmin(p)
   };

--- a/backend/photo/main.mo
+++ b/backend/photo/main.mo
@@ -522,6 +522,13 @@ persistent actor Photo {
     #ok(())
   };
 
+  /// Remove an existing admin principal (existing admin only).
+  public shared(msg) func removeAdmin(target: Principal) : async Result.Result<(), Error> {
+    if (not isAdmin(msg.caller)) return #err(#Unauthorized);
+    adminListEntries := Array.filter<Principal>(adminListEntries, func(a) { a != target });
+    #ok(())
+  };
+
   public shared(msg) func setAuditCanisterId(id : Principal) : async Result.Result<(), Error> {
     if (not isAdmin(msg.caller)) return #err(#Unauthorized);
     auditCanisterId := ?id;

--- a/backend/property/main.mo
+++ b/backend/property/main.mo
@@ -1317,6 +1317,13 @@ persistent actor Property {
     #ok(())
   };
 
+  /// Remove an existing admin principal (existing admin only).
+  public shared(msg) func removeAdmin(target: Principal) : async Result.Result<(), Error> {
+    if (not isAdmin(msg.caller)) return #err(#NotAuthorized);
+    admins := Array.filter<Principal>(admins, func(a) { a != target });
+    #ok(())
+  };
+
   public shared(msg) func setAuditCanisterId(id : Principal) : async Result.Result<(), Error> {
     if (not isAdmin(msg.caller)) return #err(#NotAuthorized);
     auditCanisterId := ?id;

--- a/backend/quote/main.mo
+++ b/backend/quote/main.mo
@@ -1043,6 +1043,13 @@ persistent actor Quote {
     #ok(())
   };
 
+  /// Remove an existing admin principal (existing admin only).
+  public shared(msg) func removeAdmin(target: Principal) : async Result.Result<(), Error> {
+    if (not isAdmin(msg.caller)) return #err(#Unauthorized);
+    adminListEntries := Array.filter<Principal>(adminListEntries, func(a) { a != target });
+    #ok(())
+  };
+
   public shared(msg) func pause(durationSeconds: ?Nat) : async Result.Result<(), Error> {
     if (not isAdmin(msg.caller)) return #err(#Unauthorized);
     isPaused := true;

--- a/backend/recurring/main.mo
+++ b/backend/recurring/main.mo
@@ -373,6 +373,13 @@ persistent actor Recurring {
     #ok(())
   };
 
+  /// Remove an existing admin principal (existing admin only).
+  public shared(msg) func removeAdmin(target: Principal) : async Result.Result<(), Error> {
+    if (not isAdmin(msg.caller)) return #err(#Unauthorized);
+    adminListEntries := Array.filter<Principal>(adminListEntries, func(a) { a != target });
+    #ok(())
+  };
+
   public shared(msg) func pause(durationSeconds: ?Nat) : async Result.Result<(), Error> {
     if (not isAdmin(msg.caller)) return #err(#Unauthorized);
     isPaused := true;

--- a/backend/report/main.mo
+++ b/backend/report/main.mo
@@ -567,6 +567,13 @@ persistent actor Report {
     #ok(())
   };
 
+  /// Remove an existing admin principal (existing admin only).
+  public shared(msg) func removeAdmin(target: Principal) : async Result.Result<(), Error> {
+    if (not isAdmin(msg.caller)) return #err(#Unauthorized);
+    adminListEntries := Array.filter<Principal>(adminListEntries, func(a) { a != target });
+    #ok(())
+  };
+
   public shared(msg) func setAuditCanisterId(id : Principal) : async Result.Result<(), Error> {
     if (not isAdmin(msg.caller)) return #err(#Unauthorized);
     auditCanisterId := ?id;

--- a/backend/sensor/main.mo
+++ b/backend/sensor/main.mo
@@ -155,6 +155,11 @@ persistent actor Sensor {
   private var maxUpdatesPerMin : Nat = 30;
   private let ONE_MINUTE_NS       : Int = 60_000_000_000;
 
+  /// Per-device last auto-job creation timestamp (internal device ID → nanoseconds).
+  /// Transient: resets on upgrade — acceptable, it is a DoS guard not business logic.
+  private transient let lastCriticalJobNs : Map.Map<Text, Int> = Map.empty();
+  private let CRITICAL_JOB_COOLDOWN_NS : Int = 60 * 60 * 1_000_000_000;  // 1 hour
+
   private func tryConsumeUpdateSlot(caller: Principal) : Bool {
     if (isAdmin(caller)) return true;
     let key = Principal.toText(caller);
@@ -423,26 +428,33 @@ persistent actor Sensor {
     let eventId  = nextEventId();
     let now      = Time.now();
 
-    // Auto-create a pending job for critical events
+    // Auto-create a pending job for critical events (max one per device per hour).
     var maybeJobId : ?Text = null;
     if (isCritical(severity) and Text.size(jobCanisterId) > 0) {
       switch (jobDetailsFor(eventType, device.name)) {
         case (?(title, svcType, desc)) {
-          let jobActor = actor(jobCanisterId) : actor {
-            createSensorJob : (
-              Text, Principal, Text, JobServiceType, Text
-            ) -> async Result.Result<Text, Text>;
-          };
-          let res = await jobActor.createSensorJob(
-            device.propertyId,
-            device.homeowner,
-            title,
-            svcType,
-            desc
-          );
-          switch res {
-            case (#ok id)  { maybeJobId := ?id; jobsCreatedCount += 1 };
-            case (#err _)  {};   // job creation failed — still record the event
+          let lastT = Option.get(Map.get(lastCriticalJobNs, Text.compare, deviceId), 0);
+          if (now - lastT >= CRITICAL_JOB_COOLDOWN_NS) {
+            let jobActor = actor(jobCanisterId) : actor {
+              createSensorJob : (
+                Text, Principal, Text, JobServiceType, Text
+              ) -> async Result.Result<Text, Text>;
+            };
+            let res = await jobActor.createSensorJob(
+              device.propertyId,
+              device.homeowner,
+              title,
+              svcType,
+              desc
+            );
+            switch res {
+              case (#ok id)  {
+                maybeJobId := ?id;
+                jobsCreatedCount += 1;
+                Map.add(lastCriticalJobNs, Text.compare, deviceId, now);
+              };
+              case (#err _)  {};   // job creation failed — still record the event
+            };
           };
         };
         case null {};
@@ -518,6 +530,13 @@ persistent actor Sensor {
     if (not isAdmin(newAdmin)) {
       adminListEntries := Array.concat(adminListEntries, [newAdmin]);
     };
+    #ok(())
+  };
+
+  /// Remove an existing admin principal (existing admin only).
+  public shared(msg) func removeAdmin(target: Principal) : async Result.Result<(), Error> {
+    if (not isAdmin(msg.caller)) return #err(#Unauthorized);
+    adminListEntries := Array.filter<Principal>(adminListEntries, func(a) { a != target });
     #ok(())
   };
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -38,6 +38,14 @@ private transient var updateCallLimits : Map.Map<Text, (Nat, Int)> = Map.empty()
 SEC.2 tests assert that no canister uses bare `var updateCallLimits` (which
 would persist across upgrades in a `persistent actor`).
 
+**Known limitation — window resets on upgrade (H-2):** Because
+`updateCallLimits` is `transient`, every canister upgrade clears all
+per-principal sliding windows. A principal that was mid-window at upgrade
+time gets a fresh quota immediately after the upgrade completes. This is an
+accepted tradeoff: the window provides cycle-drain protection in steady
+state; the reset is bounded to the brief upgrade window and is preferable
+to unbounded stable-memory growth from accumulating stale principal entries.
+
 ## TOCTOU / CallerGuard (payment.subscribe)
 
 `payment.subscribe()` makes two sequential inter-canister `await` calls


### PR DESCRIPTION
C-1: IoT gateway HMAC helpers now fail-closed — verifyHmac and verifySmartThingsHmac return false when secret is absent; Nest and LG ThinQ handlers reject when env var is unset (was: silently allowed).

H-1: Add removeAdmin to all 17 canisters so a compromised key can be revoked without a full canister upgrade. auth/payment also emit AdminRemoved audit log entries. payment also gets addAdmin (was only bulk initAdmins).

H-5: Sensor canister enforces a 1-hour per-device cooldown on automatic job creation for Critical events, preventing a spoofed device from flooding the job canister.

H-9: auth errsByMethod counter capped at 999_999 to prevent unbounded stable-map growth from repeated error-inducing calls.

H-2: SECURITY.md documents that the auth rate-limit sliding window is transient and resets on canister upgrade (known limitation).

Closes #312

## Summary
<!-- What does this PR do? -->

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [ ] Backend tests pass (`make test`)
- [ ] Frontend builds (`cd frontend && npm run build`)
- [ ] Tested locally with dfx

## Checklist
- [ ] Code follows project conventions
- [ ] Self-review completed
- [ ] No sensitive data committed
