### PR TITLE
fix(security): fix SSRF in SmartThings webhook and FSBO trust-signal …

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,6 +182,9 @@ jobs:
           dfx canister call report      setPropertyCanisterId   "(\"$PROPERTY_ID\")"
           dfx canister call report      setSensorCanisterId     "(\"$SENSOR_ID\")"
           dfx canister call report      setRiskJobCanisterId    "(\"$JOB_ID\")"
+          dfx canister call listing     setPropertyCanisterId   "(\"$PROPERTY_ID\")"
+          dfx canister call listing     setJobCanisterId        "(\"$JOB_ID\")"
+          dfx canister call listing     setReportCanisterId     "(\"$REPORT_ID\")"
 
           # ── Tier propagation wiring ──────────────────────────────────────────
           dfx canister call property addAdmin "(principal \"$PAYMENT_ID\")"
@@ -308,6 +311,9 @@ jobs:
           dfx canister call report      setPropertyCanisterId   "(\"$PROPERTY_ID\")"
           dfx canister call report      setSensorCanisterId     "(\"$SENSOR_ID\")"
           dfx canister call report      setRiskJobCanisterId    "(\"$JOB_ID\")"
+          dfx canister call listing     setPropertyCanisterId   "(\"$PROPERTY_ID\")"
+          dfx canister call listing     setJobCanisterId        "(\"$JOB_ID\")"
+          dfx canister call listing     setReportCanisterId     "(\"$REPORT_ID\")"
 
           dfx canister call property addAdmin "(principal \"$PAYMENT_ID\")"
           dfx canister call quote    addAdmin "(principal \"$PAYMENT_ID\")"

--- a/agents/iot-gateway/server.ts
+++ b/agents/iot-gateway/server.ts
@@ -394,6 +394,19 @@ app.post("/webhooks/smartthings", smartThingsLimiter, async (req: Request, res: 
       res.status(400).json({ error: "missing confirmationUrl" });
       return;
     }
+    // SSRF guard: only allow https requests to the SmartThings API host.
+    let parsedUrl: URL;
+    try {
+      parsedUrl = new URL(confirmationUrl);
+    } catch {
+      res.status(400).json({ error: "invalid confirmationUrl" });
+      return;
+    }
+    if (parsedUrl.protocol !== "https:" || parsedUrl.hostname !== "api.smartthings.com") {
+      logger.warn("smartthings", "rejected CONFIRMATION — confirmationUrl not on api.smartthings.com", { reqId });
+      res.status(400).json({ error: "confirmationUrl must be https://api.smartthings.com/..." });
+      return;
+    }
     try {
       await fetch(confirmationUrl);
       logger.info("smartthings", "webhook confirmed", { reqId, confirmationUrl });

--- a/backend/listing/main.mo
+++ b/backend/listing/main.mo
@@ -101,6 +101,11 @@ persistent actor Listing {
   private var pauseExpiryNs:   ?Int = null;
   private var adminListEntries: [Principal] = [];
   private var adminInitialized: Bool = false;
+  /// Canister IDs for FSBO trust-signal resolution — set post-deploy via setXxxCanisterId().
+  /// When wired, activateFsboListing() fetches authoritative values instead of trusting the caller.
+  private var propCanisterId   : Text = "";
+  private var jobCanisterId    : Text = "";
+  private var reportCanisterId : Text = "";
 
   // ─── Stable State ────────────────────────────────────────────────────────────
 
@@ -504,6 +509,9 @@ persistent actor Listing {
 
   /// Register or update a property in the public FSBO buyer search index.
   /// Only the property owner may call this; caller is recorded as homeowner.
+  /// Trust signals (verificationLevel, verifiedJobCount, hasPublicReport) are
+  /// resolved from their authoritative canisters when wired; caller-supplied
+  /// values for those fields are always ignored.
   public shared(msg) func activateFsboListing(listing: PublicFsboListing) : async Result.Result<(), Error> {
     switch (requireActive(msg.caller)) { case (#err(e)) return #err(e); case _ {} };
     if (Text.size(listing.propertyId) == 0) return #err(#InvalidInput("propertyId cannot be empty"));
@@ -512,7 +520,52 @@ persistent actor Listing {
       case (?d) { if (Text.size(d) > 5000) return #err(#InvalidInput("description exceeds 5000 characters")) };
       case null {};
     };
-    // Stamp the caller as the owner regardless of what was passed in the record.
+
+    // ── Authoritative trust-signal resolution ─────────────────────────────────
+    // These values are fetched cross-canister and cannot be forged by the caller.
+    // When a canister is not yet wired the field defaults to its safe minimum.
+    var resolvedVerificationLevel : Text = "Unverified";
+    var resolvedVerifiedJobCount  : Nat  = 0;
+    var resolvedHasPublicReport   : Bool = false;
+
+    if (propCanisterId != "") {
+      let propActor = actor(propCanisterId) : actor {
+        getPropertyOwner     : query (Text) -> async ?Principal;
+        getVerificationLevel : query (Text) -> async ?Text;
+      };
+      // Verify the caller actually owns this property.
+      switch (await propActor.getPropertyOwner(listing.propertyId)) {
+        case null    { return #err(#NotFound) };
+        case (?owner) {
+          if (owner != msg.caller) return #err(#NotAuthorized);
+        };
+      };
+      switch (await propActor.getVerificationLevel(listing.propertyId)) {
+        case null        {};
+        case (?level)    { resolvedVerificationLevel := level };
+      };
+    };
+
+    if (jobCanisterId != "") {
+      let jobActor = actor(jobCanisterId) : actor {
+        getCertificationData : query (Text) -> async {
+          verifiedJobCount   : Nat;
+          verifiedKeySystems : [Text];
+          meetsStructural    : Bool;
+        };
+      };
+      let certData = await jobActor.getCertificationData(listing.propertyId);
+      resolvedVerifiedJobCount := certData.verifiedJobCount;
+    };
+
+    if (reportCanisterId != "") {
+      let reportActor = actor(reportCanisterId) : actor {
+        hasActivePublicShareLink : query (Text) -> async Bool;
+      };
+      resolvedHasPublicReport := await reportActor.hasActivePublicShareLink(listing.propertyId);
+    };
+
+    // Stamp the caller as the owner; replace all trust signals with authoritative values.
     let stamped : PublicFsboListing = {
       propertyId        = listing.propertyId;
       homeowner         = msg.caller;
@@ -527,12 +580,12 @@ persistent actor Listing {
       squareFeet        = listing.squareFeet;
       bedrooms          = listing.bedrooms;
       bathrooms         = listing.bathrooms;
-      verificationLevel = listing.verificationLevel;
-      score             = listing.score;
-      verifiedJobCount  = listing.verifiedJobCount;
+      verificationLevel = resolvedVerificationLevel;
+      score             = null;   // no scoring canister — cannot be caller-supplied
+      verifiedJobCount  = resolvedVerifiedJobCount;
       description       = listing.description;
       photoUrl          = listing.photoUrl;
-      hasPublicReport   = listing.hasPublicReport;
+      hasPublicReport   = resolvedHasPublicReport;
       systemHighlights  = listing.systemHighlights;
     };
     Map.add(fsboListings, Text.compare, listing.propertyId, stamped);
@@ -558,6 +611,27 @@ persistent actor Listing {
   /// Return all active public FSBO listings. No authentication required.
   public query func listActiveFsboListings() : async [PublicFsboListing] {
     Iter.toArray(Map.values(fsboListings))
+  };
+
+  /// Wire the property canister for ownership verification and verificationLevel lookup.
+  public shared(msg) func setPropertyCanisterId(id: Text) : async Result.Result<(), Error> {
+    if (not isAdmin(msg.caller)) return #err(#NotAuthorized);
+    propCanisterId := id;
+    #ok(())
+  };
+
+  /// Wire the job canister for verifiedJobCount lookup.
+  public shared(msg) func setJobCanisterId(id: Text) : async Result.Result<(), Error> {
+    if (not isAdmin(msg.caller)) return #err(#NotAuthorized);
+    jobCanisterId := id;
+    #ok(())
+  };
+
+  /// Wire the report canister for hasPublicReport lookup.
+  public shared(msg) func setReportCanisterId(id: Text) : async Result.Result<(), Error> {
+    if (not isAdmin(msg.caller)) return #err(#NotAuthorized);
+    reportCanisterId := id;
+    #ok(())
   };
 
   /// Set the update-call rate limit (admin only). Pass 0 to disable enforcement.

--- a/backend/report/main.mo
+++ b/backend/report/main.mo
@@ -503,6 +503,23 @@ persistent actor Report {
 
   // ─── Share Link Management ────────────────────────────────────────────────────
 
+  /// Returns true if the property has at least one active, non-expired share link
+  /// with Public visibility. Called cross-canister by the listing canister to
+  /// populate hasPublicReport in FSBO listings without exposing the full link list.
+  public query func hasActivePublicShareLink(propertyId: Text) : async Bool {
+    let now = Time.now();
+    var found = false;
+    for (l in Map.values(links)) {
+      if (l.propertyId == propertyId and l.isActive and l.visibility == #Public) {
+        switch (l.expiresAt) {
+          case null   { found := true };
+          case (?exp) { if (now < exp) found := true };
+        };
+      };
+    };
+    found
+  };
+
   /// List all share links the caller created for a property.
   public shared(msg) func listShareLinks(propertyId: Text) : async [ShareLink] {
     Iter.toArray(Iter.filter(Map.values(links), func(l: ShareLink) : Bool {

--- a/frontend/src/__tests__/contracts/__snapshots__/candid.contract.test.ts.snap
+++ b/frontend/src/__tests__/contracts/__snapshots__/candid.contract.test.ts.snap
@@ -677,6 +677,33 @@ exports[`listing IDL factory > full signature snapshot 1`] = `
       "variant {ok; err:variant {InvalidInput:text; DeadlinePassed; NotFound; NotAuthorized; AlreadyCancelled}}",
     ],
   },
+  "setJobCanisterId": {
+    "args": [
+      "text",
+    ],
+    "mode": [],
+    "rets": [
+      "variant {ok; err:variant {InvalidInput:text; DeadlinePassed; NotFound; NotAuthorized; AlreadyCancelled}}",
+    ],
+  },
+  "setPropertyCanisterId": {
+    "args": [
+      "text",
+    ],
+    "mode": [],
+    "rets": [
+      "variant {ok; err:variant {InvalidInput:text; DeadlinePassed; NotFound; NotAuthorized; AlreadyCancelled}}",
+    ],
+  },
+  "setReportCanisterId": {
+    "args": [
+      "text",
+    ],
+    "mode": [],
+    "rets": [
+      "variant {ok; err:variant {InvalidInput:text; DeadlinePassed; NotFound; NotAuthorized; AlreadyCancelled}}",
+    ],
+  },
   "submitProposal": {
     "args": [
       "text",
@@ -1465,6 +1492,17 @@ exports[`report IDL factory > full signature snapshot 1`] = `
     ],
     "rets": [
       "variant {ok:record {sensorCoverage:vec record {source:text; name:text; isActive:bool; deviceId:text; lastEventAt:opt int; eventCount:nat}; token:text; expiresAt:opt int; generatedAt:int; maintenanceScore:nat; propertyId:text; recentAlerts:vec record {alertId:text; resolvedByJobId:opt text; timestamp:int; severity:text; eventType:text}; verificationLevel:text; schemaVersion:text; verifiedJobCount:nat; permitCount:nat; openJobs:nat}; err:variant {InvalidInput:text; NotFound; NotAuthorized; Expired}}",
+    ],
+  },
+  "hasActivePublicShareLink": {
+    "args": [
+      "text",
+    ],
+    "mode": [
+      "query",
+    ],
+    "rets": [
+      "bool",
     ],
   },
   "listShareLinks": {

--- a/frontend/src/__tests__/contracts/candid.contract.test.ts
+++ b/frontend/src/__tests__/contracts/candid.contract.test.ts
@@ -305,6 +305,9 @@ describe("listing IDL factory", () => {
       "listActiveFsboListings",
       "removeListingPhoto",
       "reorderListingPhotos",
+      "setJobCanisterId",
+      "setPropertyCanisterId",
+      "setReportCanisterId",
       "submitProposal",
     ]);
   });
@@ -506,6 +509,7 @@ describe("report IDL factory", () => {
       "generateRiskProfile",
       "getReport",
       "getRiskProfile",
+      "hasActivePublicShareLink",
       "listShareLinks",
       "revokeShareLink",
     ]);

--- a/frontend/src/__tests__/services/__snapshots__/candidContracts.test.ts.snap
+++ b/frontend/src/__tests__/services/__snapshots__/candidContracts.test.ts.snap
@@ -107,6 +107,9 @@ getProposalsForRequest(1) -> (1) [query]
 listActiveFsboListings(0) -> (1) [query]
 removeListingPhoto(2) -> (1)
 reorderListingPhotos(2) -> (1)
+setJobCanisterId(1) -> (1)
+setPropertyCanisterId(1) -> (1)
+setReportCanisterId(1) -> (1)
 submitProposal(11) -> (1)"
 `;
 
@@ -220,6 +223,7 @@ exports[`Candid contract snapshots — method arity > report 1`] = `
 generateRiskProfile(3) -> (1)
 getReport(1) -> (1)
 getRiskProfile(1) -> (1) [query]
+hasActivePublicShareLink(1) -> (1) [query]
 listShareLinks(1) -> (1)
 revokeShareLink(1) -> (1)"
 `;

--- a/frontend/src/services/listing.ts
+++ b/frontend/src/services/listing.ts
@@ -127,6 +127,21 @@ export const idlFactory = ({ IDL }: any) => {
       [IDL.Variant({ ok: IDL.Null, err: Error })],
       []
     ),
+    setPropertyCanisterId: IDL.Func(
+      [IDL.Text],
+      [IDL.Variant({ ok: IDL.Null, err: Error })],
+      []
+    ),
+    setJobCanisterId: IDL.Func(
+      [IDL.Text],
+      [IDL.Variant({ ok: IDL.Null, err: Error })],
+      []
+    ),
+    setReportCanisterId: IDL.Func(
+      [IDL.Text],
+      [IDL.Variant({ ok: IDL.Null, err: Error })],
+      []
+    ),
   });
 };
 

--- a/frontend/src/services/report.ts
+++ b/frontend/src/services/report.ts
@@ -158,6 +158,7 @@ export const idlFactory = ({ IDL }: any) => {
       [IDL.Variant({ ok: IDL.Tuple(ShareLink, ReportSnapshot), err: Error })],
       []
     ),
+    hasActivePublicShareLink: IDL.Func([IDL.Text], [IDL.Bool], ["query"]),
     listShareLinks: IDL.Func([IDL.Text], [IDL.Vec(ShareLink)], []),
     revokeShareLink: IDL.Func(
       [IDL.Text],

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-DEPLOY_SCRIPT_VERSION="1.7.1"
+DEPLOY_SCRIPT_VERSION="1.7.2"
 ENV=${1:-local}
 
 echo "============================================"
@@ -560,6 +560,7 @@ PHOTO_ID=$(icp canister status photo -e "$ENV" --id-only 2>/dev/null || echo "")
 QUOTE_ID=$(icp canister status quote -e "$ENV" --id-only 2>/dev/null || echo "")
 SENSOR_ID=$(icp canister status sensor -e "$ENV" --id-only 2>/dev/null || echo "")
 REPORT_ID=$(icp canister status report -e "$ENV" --id-only 2>/dev/null || echo "")
+LISTING_ID=$(icp canister status listing -e "$ENV" --id-only 2>/dev/null || echo "")
 BILLS_ID=$(icp canister status bills -e "$ENV" --id-only 2>/dev/null || echo "")
 AUTH_ID=$(icp canister status auth -e "$ENV" --id-only 2>/dev/null || echo "")
 AUDIT_ID=$(icp canister status audit -e "$ENV" --id-only 2>/dev/null || echo "")
@@ -648,6 +649,18 @@ fi
 if [ -n "$REPORT_ID" ]     && [ -n "$JOB_ID" ]; then
   echo "  Wiring job -> report..."
   icp canister call report     setRiskJobCanisterId    "(\"$JOB_ID\")"              -e "$ENV" &
+fi
+if [ -n "$LISTING_ID" ]    && [ -n "$PROPERTY_ID" ]; then
+  echo "  Wiring property -> listing (trust signals)..."
+  icp canister call listing    setPropertyCanisterId   "(\"$PROPERTY_ID\")"         -e "$ENV" &
+fi
+if [ -n "$LISTING_ID" ]    && [ -n "$JOB_ID" ]; then
+  echo "  Wiring job -> listing (trust signals)..."
+  icp canister call listing    setJobCanisterId        "(\"$JOB_ID\")"              -e "$ENV" &
+fi
+if [ -n "$LISTING_ID" ]    && [ -n "$REPORT_ID" ]; then
+  echo "  Wiring report -> listing (trust signals)..."
+  icp canister call listing    setReportCanisterId     "(\"$REPORT_ID\")"           -e "$ENV" &
 fi
 
 wait


### PR DESCRIPTION
…forgery

Vuln 1 — SSRF (server.ts): The SmartThings CONFIRMATION handler fetched any caller-supplied URL before HMAC auth. Now validates that confirmationUrl is https://api.smartthings.com/... and rejects anything else with 400.

Vuln 2 — FSBO trust-signal forgery (listing/main.mo): activateFsboListing() was copying verificationLevel, score, verifiedJobCount, and hasPublicReport verbatim from the caller-supplied record, letting any $10/mo user forge Premium verification badges and job counts visible to all buyers.

Fix: these fields are now resolved cross-canister from their authoritative sources (property, job, report) when wired; score is forced to null (no scoring canister). The function also verifies caller owns the property via the property canister when wired.

Added:
- report/main.mo: hasActivePublicShareLink() public query
- listing/main.mo: setPropertyCanisterId/setJobCanisterId/setReportCanisterId
- scripts/deploy.sh: wires listing to property/job/report (v1.7.2)
- .github/workflows/ci.yml: same wiring in both deploy blocks
- IDL factories and contract test snapshots updated to match

## Summary
<!-- What does this PR do? -->

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [ ] Backend tests pass (`make test`)
- [ ] Frontend builds (`cd frontend && npm run build`)
- [ ] Tested locally with dfx

## Checklist
- [ ] Code follows project conventions
- [ ] Self-review completed
- [ ] No sensitive data committed
