### PR TITLE
fix(ci): upgrade upload-artifact from v4 to v7 to fix Node.js 20 depr…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -358,7 +358,7 @@ jobs:
 
       - name: Upload integration test results on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: integration-test-results
           path: frontend/test-results/
@@ -387,7 +387,7 @@ jobs:
         run: cd frontend && npm run test:unit:coverage
 
       - name: Upload coverage report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-report
           path: frontend/coverage/
@@ -486,7 +486,7 @@ jobs:
 
       - name: Upload E2E artifacts on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-report
           path: test-results/


### PR DESCRIPTION
…ecation

actions/upload-artifact@v4 runs on Node.js 20 which GitHub is removing from runners on June 2nd 2026. v7 is the current release and uses Node.js 24. Updated all three upload-artifact usages in ci.yml (integration test results, coverage report, E2E artifacts).

## Summary
<!-- What does this PR do? -->

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [ ] Backend tests pass (`make test`)
- [ ] Frontend builds (`cd frontend && npm run build`)
- [ ] Tested locally with dfx

## Checklist
- [ ] Code follows project conventions
- [ ] Self-review completed
- [ ] No sensitive data committed
