### PR TITLE
feat(landing): redesign landing page with ICP/Quorum-focused layout

### DIFF
--- a/frontend/src/__tests__/components/LandingPageMob2.test.tsx
+++ b/frontend/src/__tests__/components/LandingPageMob2.test.tsx
@@ -41,10 +41,10 @@ describe("LandingPage — key sections render", () => {
     expect(btns.length).toBeGreaterThan(0);
   });
 
-  it("renders 4 How It Works steps", () => {
+  it("renders the pricing section with plan cards", () => {
     const { container } = renderLanding();
-    const steps = container.querySelectorAll(".hfl-step");
-    expect(steps.length).toBe(4);
+    const cards = container.querySelectorAll(".hfl-plan-card");
+    expect(cards.length).toBeGreaterThanOrEqual(3);
   });
 
 });

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -322,7 +322,7 @@ export default function LandingPage() {
               <span className="green">Protect. Your Home.</span>
             </h1>
             <p>
-              HomeGentic helps homeowners and contractors manage maintenance,
+              HomeGentic helps homeowners manage maintenance,
               documentation, and transactions with blockchain-verified trust
               and AI-powered insights.
             </p>

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -88,7 +88,7 @@ function DashboardMockup() {
       <div className="hfl-dm-topbar">
         <div className="hfl-dm-topbar-logo">
           <HouseSvg />
-          Home<span className="green">Gentic</span>
+          <span>Home<span className="green">Gentic</span></span>
         </div>
         <div className="hfl-dm-topbar-icons">
           <span>🔔</span>
@@ -286,7 +286,7 @@ export default function LandingPage() {
           <div style={{ display: "flex", alignItems: "center", gap: "1.25rem" }}>
             <a href="/" className="hfl-logo">
               <HouseSvg />
-              Home<span>Gentic</span>
+              <span className="hfl-logo-text">Home<span>Gentic</span></span>
             </a>
             <ul className="hfl-nav-links">
               <li><a onClick={(e) => { e.preventDefault(); scrollTo("hfl-features-section"); }}>Features</a></li>

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -4,52 +4,236 @@ import { neighborReferralService } from "@/services/neighborReferral";
 import { Helmet } from "react-helmet-async";
 import { CSS } from "./landingStyles";
 
+/* ── House SVG logo (matches mockup: green roof, orange-left/blue-right body) */
+function HouseSvg() {
+  return (
+    <svg width="26" height="24" viewBox="0 0 26 24" fill="none" aria-hidden="true">
+      <polygon points="13,1 25,11 1,11" fill="#16A34A" />
+      <rect x="1" y="11" width="12" height="12" fill="#F97316" />
+      <rect x="13" y="11" width="12" height="12" fill="#2563EB" />
+      <rect x="10" y="17" width="6" height="6" fill="white" fillOpacity="0.9" />
+    </svg>
+  );
+}
+
+/* ── ICP gradient infinity symbol ── */
+function IcpLogo({ size = 40 }: { size?: number }) {
+  const id = `icp-${size}`;
+  return (
+    <svg width={size} height={size * 0.6} viewBox="0 0 60 36" fill="none" aria-hidden="true">
+      <defs>
+        <linearGradient id={id} x1="0%" y1="0%" x2="100%" y2="0%">
+          <stop offset="0%"   stopColor="#8B5CF6" />
+          <stop offset="50%"  stopColor="#F97316" />
+          <stop offset="100%" stopColor="#EAB308" />
+        </linearGradient>
+      </defs>
+      <path
+        d="M30 18C30 18 20 2 10 2C2 2 2 18 10 18C2 18 2 34 10 34C20 34 30 18 30 18Z"
+        fill={`url(#${id})`}
+      />
+      <path
+        d="M30 18C30 18 40 2 50 2C58 2 58 18 50 18C58 18 58 34 50 34C40 34 30 18 30 18Z"
+        fill={`url(#${id})`}
+      />
+    </svg>
+  );
+}
+
+/* ── Quorum hexagon logo ── */
+function QuorumLogo() {
+  return (
+    <svg width="44" height="44" viewBox="0 0 44 44" fill="none" aria-hidden="true">
+      <polygon points="22,2 40,12 40,32 22,42 4,32 4,12" fill="#0F4C2A" />
+      <polygon points="22,8 36,16 36,30 22,38 8,30 8,16" fill="#16A34A" fillOpacity="0.3" />
+      <text x="22" y="26" textAnchor="middle" fontSize="11" fontWeight="700" fill="white" fontFamily="Inter,sans-serif">Q</text>
+    </svg>
+  );
+}
+
+/* ── Gift icon ── */
+function GiftIcon() {
+  return (
+    <svg width="44" height="44" viewBox="0 0 44 44" fill="none" aria-hidden="true">
+      <rect x="4" y="18" width="36" height="24" rx="2" fill="#FED7AA" />
+      <rect x="4" y="12" width="36" height="8" rx="2" fill="#FB923C" />
+      <rect x="20" y="4" width="4" height="36" fill="#F97316" />
+      <path d="M22 12C22 12 16 4 12 6C9 7.5 10 12 22 12Z" fill="#F97316" />
+      <path d="M22 12C22 12 28 4 32 6C35 7.5 34 12 22 12Z" fill="#F97316" />
+    </svg>
+  );
+}
+
+/* ── Dashboard mockup (right side of hero) ── */
+function DashboardMockup() {
+  const navItems = [
+    { icon: "📊", label: "Dashboard",      active: true },
+    { icon: "🏠", label: "My Properties"  },
+    { icon: "🔧", label: "Maintenance"    },
+    { icon: "📄", label: "Documents"      },
+    { icon: "💳", label: "Transactions"   },
+    { icon: "⚡", label: "Bills & Utilities" },
+    { icon: "📡", label: "IoT Devices"    },
+    { icon: "📋", label: "Reports"        },
+    { icon: "🤖", label: "AI Assistant"   },
+  ];
+  const activity = [
+    { dot: "hfl-dm-act-dot-green",  title: "HVAC maintenance completed",    sub: "Duct cleaning by you and AC Pro Services", date: "May 4" },
+    { dot: "hfl-dm-act-dot-blue",   title: "Added document: Roof Inspection", sub: "Uploaded to 123 Maple St",                date: "May 3" },
+    { dot: "hfl-dm-act-dot-orange", title: "New quote received",             sub: "Kitchen sink repair",                      date: "May 2" },
+  ];
+  return (
+    <div className="hfl-dm">
+      {/* Top bar */}
+      <div className="hfl-dm-topbar">
+        <div className="hfl-dm-topbar-logo">
+          <HouseSvg />
+          Home<span className="green">Gentic</span>
+        </div>
+        <div className="hfl-dm-topbar-icons">
+          <span>🔔</span>
+          <span>⋮</span>
+        </div>
+      </div>
+
+      {/* Body */}
+      <div className="hfl-dm-body">
+        {/* Sidebar */}
+        <div className="hfl-dm-sidebar">
+          {navItems.map((item) => (
+            <div key={item.label} className={`hfl-dm-nav${item.active ? " hfl-dm-nav-active" : ""}`}>
+              <span>{item.icon}</span>
+              {item.label}
+            </div>
+          ))}
+        </div>
+
+        {/* Main content */}
+        <div className="hfl-dm-main">
+          <div className="hfl-dm-welcome">Welcome back, Sarah!</div>
+
+          {/* Score + Maintenance */}
+          <div className="hfl-dm-cards-row">
+            <div className="hfl-dm-score-card">
+              <div className="hfl-dm-card-label">Property Health Score</div>
+              <div className="hfl-dm-score-wrap">
+                <div className="hfl-dm-score-ring">
+                  <span className="hfl-dm-score-val">82</span>
+                </div>
+                <div>
+                  <div className="hfl-dm-score-delta">↑ 12 pts</div>
+                  <div className="hfl-dm-score-sub">vs last month</div>
+                </div>
+              </div>
+            </div>
+            <div className="hfl-dm-maint-card">
+              <div className="hfl-dm-card-label">Upcoming Maintenance</div>
+              <div className="hfl-dm-maint-nums">
+                <div>
+                  <div className="hfl-dm-maint-num">3</div>
+                  <div className="hfl-dm-maint-lbl">This Week</div>
+                </div>
+                <div>
+                  <div className="hfl-dm-maint-num">7</div>
+                  <div className="hfl-dm-maint-lbl">This Month</div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* Stats */}
+          <div className="hfl-dm-stats-row">
+            {[
+              { label: "Open Jobs",       val: 2 },
+              { label: "Quotes Received", val: 5 },
+              { label: "Open Offers",     val: 1 },
+            ].map((s) => (
+              <div key={s.label} className="hfl-dm-stat">
+                <div className="hfl-dm-stat-label">{s.label}</div>
+                <div className="hfl-dm-stat-val">{s.val}</div>
+                <div className="hfl-dm-stat-link">View</div>
+              </div>
+            ))}
+          </div>
+
+          {/* Recent Activity */}
+          <div className="hfl-dm-activity-label">Recent Activity</div>
+          {activity.map((a) => (
+            <div key={a.title} className="hfl-dm-act-item">
+              <div className={`hfl-dm-act-dot ${a.dot}`} />
+              <div className="hfl-dm-act-body">
+                <div className="hfl-dm-act-title">{a.title}</div>
+                <div className="hfl-dm-act-sub">{a.sub}</div>
+              </div>
+              <div className="hfl-dm-act-date">{a.date}</div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ── Data ── */
 const TRUST_BADGES = [
-  { bg: "#F0FDF4", color: "#16A34A", icon: "🛡️", title: "Blockchain Verified", sub: "Every record is cryptographically signed and stored on-chain — tamper-proof forever." },
-  { bg: "#FEFCE8", color: "#CA8A04", icon: "🔒", title: "Secure & Private",     sub: "You own your data. Nothing is public until you choose to share it." },
-  { bg: "#EFF6FF", color: "#2563EB", icon: "✍️", title: "Dual-Signature",       sub: "Both homeowner and contractor must sign every completed job record." },
-  { bg: "#F5F3FF", color: "#7C3AED", icon: "∞",  title: "Internet Computer",    sub: "Built on the ICP blockchain — no servers, no downtime, no single point of failure." },
+  { bg: "#F0FDF4", color: "#16A34A", icon: "🛡️", title: "Blockchain Verified",  sub: "Built on ICP for data permanence" },
+  { bg: "#FEFCE8", color: "#CA8A04", icon: "🔒", title: "Secure & Private",      sub: "You own your data. Always." },
+  { bg: "#EFF6FF", color: "#2563EB", icon: "✍️", title: "Dual-Signature",        sub: "Every job verified by both parties" },
+  { bg: "#F5F3FF", color: "#7C3AED", icon: "∞",  title: "Internet Computer",     sub: "Decentralized. Scalable. Unstoppable." },
 ];
 
 const ROLES = [
   {
-    bg: "#F0FDF4", icon: "🏠", title: "For Homeowners",
-    desc: "Register properties, log maintenance jobs, and build a verified home history that pays off at resale.",
-    link: "/login",
+    bg: "#F0FDF4", icon: "🏘️", title: "For Homeowners",
+    desc: "Track maintenance, manage bills, get quotes, monitor property health, and list FSBO.",
   },
   {
-    bg: "#EFF6FF", icon: "👷", title: "For Contractors",
-    desc: "Sign verified job completions, receive leads from local homeowners, and build your on-chain reputation.",
-    link: "/login",
+    bg: "#FFF7ED", icon: "👷", title: "For Contractors",
+    desc: "Receive quote requests, submit bids, log jobs, build your reputation, and grow your business.",
   },
   {
-    bg: "#FFF7ED", icon: "🏢", title: "For Realtors / Admins",
-    desc: "Access verified property histories to streamline transactions and build buyer trust from day one.",
-    link: "/login",
+    bg: "#EFF6FF", icon: "🛡️", title: "For Admins",
+    desc: "Verify ownership, manage subscriptions, monitor platform health and security.",
   },
 ];
 
 const FEATURES = [
-  { bg: "#F0FDF4", icon: "📅", title: "Smart Maintenance",       desc: "AI-generated seasonal schedules based on your home's age and system history." },
-  { bg: "#EFF6FF", icon: "📡", title: "IoT Integration",         desc: "Connect Nest, Ecobee, Moen Flo, Ring, and 8+ more smart devices automatically." },
-  { bg: "#FFF7ED", icon: "💬", title: "Get Quotes",              desc: "Post a job and receive competing bids from verified, background-checked contractors." },
-  { bg: "#F5F3FF", icon: "✍️", title: "Dual-Signature Jobs",    desc: "Both parties sign every job — creating a tamper-proof, legally credible work record." },
-  { bg: "#FFF1F2", icon: "🏷️", title: "FSBO Listings",          desc: "List your home as FSBO with showing management, sealed-bid offers, and agent matching." },
-  { bg: "#F0FDF4", icon: "🌐", title: "360° Panorama Viewer",   desc: "Attach room-by-room 360° walkthroughs to your FSBO listing for remote buyers." },
-  { bg: "#EFF6FF", icon: "🎤", title: "AI Voice Agent",          desc: "Ask your home anything out loud — maintenance history, upcoming tasks, or repair costs." },
-  { bg: "#FFF7ED", icon: "📋", title: "Immutable Reports",      desc: "Generate a shareable, blockchain-backed home biography that buyers and agents trust." },
+  { bg: "#F0FDF4", icon: "🔧", title: "Smart Maintenance",     desc: "Track history, schedule tasks, and get AI-powered predictive maintenance recommendations." },
+  { bg: "#EFF6FF", icon: "📡", title: "IoT Integration",       desc: "Connect Nest, Ecobee, Moen Flo, Ring Alarm, and 8+ devices for real-time monitoring." },
+  { bg: "#EFF6FF", icon: "💬", title: "Get Quotes",            desc: "Request quotes from trusted contractors and compare bids side-by-side." },
+  { bg: "#EFF6FF", icon: "✍️", title: "Dual-Signature Jobs",  desc: "Jobs are verified by both homeowner and contractor and immutably recorded on ICP." },
+  { bg: "#F0FDF4", icon: "🏠", title: "FSBO Listings",        desc: "List your property for sale, manage sealed-bid offers, and match with verified agents." },
+  { bg: "#FFF7ED", icon: "🌐", title: "360° Panorama Viewer", desc: "Immersive property tours with PlayCanvas-powered 360° panorama viewer." },
+  { bg: "#EFF6FF", icon: "🎤", title: "AI Voice Agent",        desc: "Ask questions, get updates, and manage your property—hands-free with Claude-powered AI." },
+  { bg: "#EFF6FF", icon: "📋", title: "Immutable Reports",    desc: "Generate tamper-proof reports with shareable links for insurance, buyers, or contractors." },
 ];
 
 const PLANS = [
-  { tier: "Basic",          sub: "1 Property",          price: 10, tag: null as string | null,   features: ["1 property", "5 photos/job", "3 open quotes", "Maintenance record", "AI scheduling"] },
-  { tier: "Pro",            sub: "Up to 5 Properties",  price: 20, tag: null,                    features: ["5 properties", "10 photos/job", "10 open quotes", "FSBO listings", "AI Voice Agent"] },
-  { tier: "Premium",        sub: "Up to 20 Properties", price: 40, tag: "Most Popular",          features: ["20 properties", "30 photos/job", "Unlimited quotes", "360° Panorama", "Priority support"] },
-  { tier: "Contractor",     sub: "Free Forever",        price:  0, tag: null,                    features: ["Accept job leads", "Sign work records", "Build reputation", "5 photos/job", "Unlimited quotes"] },
-  { tier: "ContractorPro",  sub: "Unlimited Leads",     price: 30, tag: null,                    features: ["Unlimited properties", "50 photos/job", "Unlimited quotes", "Premium placement", "Analytics"] },
+  {
+    tier: "Basic", sub: "For homeowners getting started", price: 10, tag: null as string | null, cta: "green" as const,
+    features: ["1 Property", "Basic Maintenance Tracking", "Document Storage", "Email Support"],
+  },
+  {
+    tier: "Pro", sub: "For growing homeowners", price: 20, tag: null, cta: "green" as const,
+    features: ["Up to 5 Properties", "Advanced Maintenance", "IoT Integrations", "Priority Support"],
+  },
+  {
+    tier: "Premium", sub: "For power users", price: 40, tag: "Most Popular", cta: "blue" as const,
+    features: ["Up to 20 Properties", "All Insights & Predictions", "360° Viewer", "Premium Support"],
+  },
+  {
+    tier: "Contractor Free", sub: "For contractors starting out", price: 0, tag: null, cta: "green" as const,
+    features: ["Receive Quote Requests", "Submit Bids", "Basic Profile", "Up to 5 Jobs/Month"],
+  },
+  {
+    tier: "Contractor Pro", sub: "For growing contractors", price: 30, tag: null, cta: "blue" as const,
+    features: ["Unlimited Quote Requests", "Priority Placement", "Verified Badge", "Analytics & Insights"],
+  },
 ];
 
-const INTEGRATIONS = ["Nest", "ecobee", "Moen Flo", "Ring", "Schneider Electric", "myQ", "August", "Rachio", "Emporia Vue", "SmartThings", "+8 more"];
+const INTEGRATIONS = ["nest", "ecobee", "MOEN", "ring", "Schneider Electric", "myQ", "August", "+8 more"];
 
+/* ── Component ── */
 export default function LandingPage() {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
@@ -79,7 +263,7 @@ export default function LandingPage() {
     <>
       <Helmet>
         <title>HomeGentic — Verified Home Maintenance Records on ICP</title>
-        <meta name="description" content="HomeGentic gives homeowners a verified, blockchain-backed record of every repair, upgrade, and inspection — boosting home value and buyer confidence." />
+        <meta name="description" content="HomeGentic helps homeowners and contractors manage maintenance, documentation, and transactions with blockchain-verified trust and AI-powered insights." />
         <meta property="og:title" content="HomeGentic — Verified Home Maintenance Records" />
         <meta property="og:description" content="Manage. Maintain. Protect. Your Home. Built on the Internet Computer." />
         <meta property="og:type" content="website" />
@@ -99,9 +283,10 @@ export default function LandingPage() {
 
         {/* ── Nav ───────────────────────────────────────────────────────── */}
         <nav className="hfl-nav">
-          <div style={{ display: "flex", alignItems: "center", gap: "1.5rem" }}>
+          <div style={{ display: "flex", alignItems: "center", gap: "1.25rem" }}>
             <a href="/" className="hfl-logo">
-              <span>🏠</span>Home<span>Gentic</span>
+              <HouseSvg />
+              Home<span>Gentic</span>
             </a>
             <ul className="hfl-nav-links">
               <li><a onClick={(e) => { e.preventDefault(); scrollTo("hfl-features-section"); }}>Features</a></li>
@@ -109,6 +294,7 @@ export default function LandingPage() {
               <li><a onClick={(e) => { e.preventDefault(); scrollTo("hfl-roles-section"); }}>For Contractors</a></li>
               <li><a onClick={(e) => { e.preventDefault(); scrollTo("hfl-pricing-section"); }}>Pricing</a></li>
               <li><a onClick={(e) => { e.preventDefault(); navigate("/invite"); }}>Invite a Neighbor</a></li>
+              <li><a onClick={(e) => e.preventDefault()}>Resources ▾</a></li>
             </ul>
           </div>
           <div className="hfl-nav-actions">
@@ -130,16 +316,15 @@ export default function LandingPage() {
         {/* ── Hero ──────────────────────────────────────────────────────── */}
         <section className="hfl-hero">
           <div>
-            <div className="hfl-hero-badge">
-              ∞ BUILT ON THE INTERNET COMPUTER (ICP)
-            </div>
+            <div className="hfl-hero-badge">BUILT ON THE INTERNET COMPUTER (ICP)</div>
             <h1>
               Manage. Maintain.<br />
               <span className="green">Protect. Your Home.</span>
             </h1>
             <p>
-              HomeGentic is the verified home record platform built on the ICP blockchain.
-              Every repair, upgrade, and inspection — signed, stored, and shareable forever.
+              HomeGentic helps homeowners and contractors manage maintenance,
+              documentation, and transactions with blockchain-verified trust
+              and AI-powered insights.
             </p>
             <div className="hfl-actions">
               <button className="hfl-btn-main" onClick={() => navigate("/login")}>Get Started</button>
@@ -148,9 +333,9 @@ export default function LandingPage() {
               </button>
             </div>
           </div>
-          <div className="hfl-hero-img-wrap">
-            <img src="/hero_home.png" alt="HomeGentic dashboard" className="hfl-hero-img" />
-          </div>
+
+          {/* Dashboard mockup (hidden on mobile via CSS) */}
+          <DashboardMockup />
         </section>
 
         {/* ── Trust Badges ──────────────────────────────────────────────── */}
@@ -173,7 +358,7 @@ export default function LandingPage() {
         {/* ── Roles ─────────────────────────────────────────────────────── */}
         <section id="hfl-roles-section" className="hfl-roles">
           <div className="hfl-section-header">
-            <h2>Built for every role</h2>
+            <h2>Built for every role in your property journey</h2>
           </div>
           <div className="hfl-roles-grid">
             {ROLES.map((r) => (
@@ -181,7 +366,7 @@ export default function LandingPage() {
                 <div className="hfl-role-icon" style={{ background: r.bg }}>{r.icon}</div>
                 <div className="hfl-role-title">{r.title}</div>
                 <div className="hfl-role-desc">{r.desc}</div>
-                <button className="hfl-role-link" onClick={() => navigate(r.link)}>
+                <button className="hfl-role-link" onClick={() => navigate("/login")}>
                   Learn more →
                 </button>
               </div>
@@ -192,14 +377,16 @@ export default function LandingPage() {
         {/* ── Features ──────────────────────────────────────────────────── */}
         <section id="hfl-features-section" className="hfl-features">
           <div className="hfl-section-header">
-            <h2>Everything you need</h2>
+            <h2>Everything you need to protect and grow your property</h2>
           </div>
           <div className="hfl-features-grid">
             {FEATURES.map((f) => (
               <div key={f.title} className="hfl-feat-card">
                 <div className="hfl-feat-icon" style={{ background: f.bg }}>{f.icon}</div>
-                <div className="hfl-feat-title">{f.title}</div>
-                <div className="hfl-feat-desc">{f.desc}</div>
+                <div className="hfl-feat-body">
+                  <div className="hfl-feat-title">{f.title}</div>
+                  <div className="hfl-feat-desc">{f.desc}</div>
+                </div>
               </div>
             ))}
           </div>
@@ -209,28 +396,30 @@ export default function LandingPage() {
         <div className="hfl-strip">
           <div className="hfl-strip-inner">
             <div className="hfl-strip-col">
-              <div className="hfl-strip-logo">🏘️</div>
+              <div className="hfl-strip-logo"><QuorumLogo /></div>
               <div>
                 <div className="hfl-strip-title">Quorum HOA Members</div>
-                <div className="hfl-strip-desc">HOA members on Quorum save 10% on any HomeGentic plan.</div>
-                <div><span className="hfl-strip-code">QUORUM10</span></div>
+                <div className="hfl-strip-desc">Get 10% off any plan</div>
+                <div>Use code: <span className="hfl-strip-code">QUORUM10</span></div>
               </div>
             </div>
             <div className="hfl-strip-col">
-              <div className="hfl-strip-logo">🤝</div>
+              <div className="hfl-strip-logo"><GiftIcon /></div>
               <div>
-                <div className="hfl-strip-title">Invite a Neighbor</div>
-                <div className="hfl-strip-desc">You and your neighbor each earn $10 credit when they join.</div>
+                <div className="hfl-strip-title">Invite a Neighbor, Get Rewarded</div>
+                <div className="hfl-strip-desc">You get $10 credit. They get $10 off.</div>
                 <button className="hfl-strip-link" onClick={() => navigate("/invite")}>
                   Learn how it works →
                 </button>
               </div>
             </div>
             <div className="hfl-strip-col">
-              <div className="hfl-strip-logo">∞</div>
+              <div className="hfl-strip-logo"><IcpLogo size={44} /></div>
               <div>
                 <div className="hfl-strip-title">Built on ICP</div>
-                <div className="hfl-strip-desc">Your records live on the Internet Computer — no servers, no downtime, no middlemen. Yours forever.</div>
+                <div className="hfl-strip-desc">
+                  Your data is yours. Permanently stored. Tamper-proof. Future-proof.
+                </div>
               </div>
             </div>
           </div>
@@ -238,7 +427,7 @@ export default function LandingPage() {
 
         {/* ── Integrations ──────────────────────────────────────────────── */}
         <div className="hfl-integrations">
-          <h3>Works with your smart home devices</h3>
+          <h3>Works with the tools you already use</h3>
           <div className="hfl-integ-logos">
             {INTEGRATIONS.map((name) => (
               <span key={name} className="hfl-integ-logo">{name}</span>
@@ -249,8 +438,8 @@ export default function LandingPage() {
         {/* ── Pricing ───────────────────────────────────────────────────── */}
         <section id="hfl-pricing-section" className="hfl-pricing">
           <div className="hfl-pricing-header">
-            <h2>Simple, transparent pricing</h2>
-            <p>Start at $10/mo. Your verified home record pays for itself at resale.</p>
+            <h2>Simple, transparent pricing for everyone</h2>
+            <p>Choose the plan that fits your needs. All plans include blockchain verification and immutable storage.</p>
           </div>
           <div className="hfl-pricing-grid">
             {PLANS.map((p) => (
@@ -259,21 +448,32 @@ export default function LandingPage() {
                 <div className="hfl-plan-tier">{p.tier}</div>
                 <div className="hfl-plan-sub">{p.sub}</div>
                 <div className="hfl-plan-price">
-                  {p.price === 0 ? "Free" : `$${p.price}`}
-                  {p.price > 0 && <span>/mo</span>}
+                  {p.price === 0 ? "$0" : `$${p.price}`}
+                  <span>/month</span>
                 </div>
                 <ul className="hfl-plan-features">
-                  {p.features.map((f) => <li key={f}>{f}</li>)}
+                  {p.features.map((f) => (
+                    <li key={f}>
+                      <span className="hfl-plan-feat-check">✓</span>
+                      {f}
+                    </li>
+                  ))}
                 </ul>
-                <button className="hfl-plan-cta" onClick={() => navigate("/login")}>
-                  {p.price === 0 ? "Join free" : "Get started"}
+                <button
+                  className={`hfl-plan-cta hfl-plan-cta-${p.cta}`}
+                  onClick={() => navigate("/login")}
+                >
+                  Get Started
                 </button>
               </div>
             ))}
           </div>
-          <p className="hfl-pricing-guarantee">
-            <span>🔒</span> Cancel anytime · Your blockchain records remain yours forever
-          </p>
+          <div className="hfl-pricing-guarantee">
+            <span>🛡</span>
+            <span>30-day money-back guarantee</span>
+            <span className="hfl-pricing-guarantee-sep">•</span>
+            <span>Cancel anytime</span>
+          </div>
         </section>
 
         </main>
@@ -282,26 +482,28 @@ export default function LandingPage() {
         <footer className="hfl-footer">
           <div className="hfl-footer-inner">
             <div className="hfl-footer-left">
-              <div className="hfl-footer-icp-logo">∞</div>
+              <div className="hfl-footer-icp-logo">
+                <IcpLogo size={44} />
+              </div>
               <div>
-                <div className="hfl-footer-icp-title">HomeGentic · Built on ICP</div>
+                <div className="hfl-footer-icp-title">Built on the Internet Computer Protocol (ICP)</div>
                 <div className="hfl-footer-icp-sub">
-                  Verified home records on the Internet Computer blockchain.
-                  No servers. No downtime. Your data lives forever.
-                </div>
-                <div className="hfl-footer-quorum">
-                  Quorum HOA members save 10% ·
-                  <span className="hfl-footer-quorum-code">QUORUM10</span>
+                  Your data is yours. Permanently stored. Tamper-proof. Future-proof.
                 </div>
               </div>
             </div>
-            <div style={{ display: "flex", alignItems: "center", gap: "0.75rem", flexWrap: "wrap" }}>
-              <Link to="/privacy" style={{ fontSize: "0.75rem", color: "rgba(255,255,255,0.45)", textDecoration: "none" }}>Privacy</Link>
-              <Link to="/terms"   style={{ fontSize: "0.75rem", color: "rgba(255,255,255,0.45)", textDecoration: "none" }}>Terms</Link>
-              <button className="hfl-footer-btn" onClick={() => window.open("https://internetcomputer.org", "_blank", "noopener,noreferrer")}>
-                Learn About ICP
-              </button>
+            <div className="hfl-footer-quorum-center">
+              <div className="hfl-footer-quorum-center-title">Quorum HOA members save 10%</div>
+              <div className="hfl-footer-quorum-center-code">
+                Use code: <span className="hfl-footer-quorum-code">QUORUM10</span>
+              </div>
             </div>
+            <button
+              className="hfl-footer-btn"
+              onClick={() => window.open("https://internetcomputer.org", "_blank", "noopener,noreferrer")}
+            >
+              Learn About ICP
+            </button>
           </div>
         </footer>
 

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -2,54 +2,63 @@ import React, { useEffect } from "react";
 import { useNavigate, Link, useSearchParams } from "react-router-dom";
 import { neighborReferralService } from "@/services/neighborReferral";
 import { Helmet } from "react-helmet-async";
-import { TrendingUp, CalendarDays, Archive, Home, Download, Link as LinkIcon, Lock } from "lucide-react";
 import { CSS } from "./landingStyles";
 
+const TRUST_BADGES = [
+  { bg: "#F0FDF4", color: "#16A34A", icon: "🛡️", title: "Blockchain Verified", sub: "Every record is cryptographically signed and stored on-chain — tamper-proof forever." },
+  { bg: "#FEFCE8", color: "#CA8A04", icon: "🔒", title: "Secure & Private",     sub: "You own your data. Nothing is public until you choose to share it." },
+  { bg: "#EFF6FF", color: "#2563EB", icon: "✍️", title: "Dual-Signature",       sub: "Both homeowner and contractor must sign every completed job record." },
+  { bg: "#F5F3FF", color: "#7C3AED", icon: "∞",  title: "Internet Computer",    sub: "Built on the ICP blockchain — no servers, no downtime, no single point of failure." },
+];
+
+const ROLES = [
+  {
+    bg: "#F0FDF4", icon: "🏠", title: "For Homeowners",
+    desc: "Register properties, log maintenance jobs, and build a verified home history that pays off at resale.",
+    link: "/login",
+  },
+  {
+    bg: "#EFF6FF", icon: "👷", title: "For Contractors",
+    desc: "Sign verified job completions, receive leads from local homeowners, and build your on-chain reputation.",
+    link: "/login",
+  },
+  {
+    bg: "#FFF7ED", icon: "🏢", title: "For Realtors / Admins",
+    desc: "Access verified property histories to streamline transactions and build buyer trust from day one.",
+    link: "/login",
+  },
+];
+
+const FEATURES = [
+  { bg: "#F0FDF4", icon: "📅", title: "Smart Maintenance",       desc: "AI-generated seasonal schedules based on your home's age and system history." },
+  { bg: "#EFF6FF", icon: "📡", title: "IoT Integration",         desc: "Connect Nest, Ecobee, Moen Flo, Ring, and 8+ more smart devices automatically." },
+  { bg: "#FFF7ED", icon: "💬", title: "Get Quotes",              desc: "Post a job and receive competing bids from verified, background-checked contractors." },
+  { bg: "#F5F3FF", icon: "✍️", title: "Dual-Signature Jobs",    desc: "Both parties sign every job — creating a tamper-proof, legally credible work record." },
+  { bg: "#FFF1F2", icon: "🏷️", title: "FSBO Listings",          desc: "List your home as FSBO with showing management, sealed-bid offers, and agent matching." },
+  { bg: "#F0FDF4", icon: "🌐", title: "360° Panorama Viewer",   desc: "Attach room-by-room 360° walkthroughs to your FSBO listing for remote buyers." },
+  { bg: "#EFF6FF", icon: "🎤", title: "AI Voice Agent",          desc: "Ask your home anything out loud — maintenance history, upcoming tasks, or repair costs." },
+  { bg: "#FFF7ED", icon: "📋", title: "Immutable Reports",      desc: "Generate a shareable, blockchain-backed home biography that buyers and agents trust." },
+];
+
+const PLANS = [
+  { tier: "Basic",          sub: "1 Property",          price: 10, tag: null as string | null,   features: ["1 property", "5 photos/job", "3 open quotes", "Maintenance record", "AI scheduling"] },
+  { tier: "Pro",            sub: "Up to 5 Properties",  price: 20, tag: null,                    features: ["5 properties", "10 photos/job", "10 open quotes", "FSBO listings", "AI Voice Agent"] },
+  { tier: "Premium",        sub: "Up to 20 Properties", price: 40, tag: "Most Popular",          features: ["20 properties", "30 photos/job", "Unlimited quotes", "360° Panorama", "Priority support"] },
+  { tier: "Contractor",     sub: "Free Forever",        price:  0, tag: null,                    features: ["Accept job leads", "Sign work records", "Build reputation", "5 photos/job", "Unlimited quotes"] },
+  { tier: "ContractorPro",  sub: "Unlimited Leads",     price: 30, tag: null,                    features: ["Unlimited properties", "50 photos/job", "Unlimited quotes", "Premium placement", "Analytics"] },
+];
+
+const INTEGRATIONS = ["Nest", "ecobee", "Moen Flo", "Ring", "Schneider Electric", "myQ", "August", "Rachio", "Emporia Vue", "SmartThings", "+8 more"];
 
 export default function LandingPage() {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const [menuOpen, setMenuOpen] = React.useState(false);
-  const [activeFeature, setActiveFeature] = React.useState(0);
-  const [heroPhase, setHeroPhase] = React.useState(0);
-  const [annual, setAnnual] = React.useState(false);
 
-  const HERO_PHASES = [
-    { icon: "📋", label: "14 records verified", detail: "Share link ready" },
-    { icon: "📊", label: "Score updated", detail: "88 → 91 ↑" },
-    { icon: "📤", label: "Share link copied", detail: "Sent to buyer" },
-  ];
-
-  const FEATURES = [
-    {
-      icon: "📋", kicker: "The Verified Record",
-      heading: <>The Carfax<br /><em>your home deserves</em></>,
-      desc: "Every service, repair, and renovation — documented, signed, and stored permanently on the blockchain. No middlemen, no expiry.",
-      bullets: ["Full ownership & transaction history", "Verified contractor records & warranties", "Permitted renovations on file", "AI agents continuously update your score"],
-      cta: "Build my record",
-    },
-    {
-      icon: "🎤", kicker: "AI Home Intelligence",
-      heading: <>Your home has a voice.<br /><em>So do you.</em></>,
-      desc: "Ask your home anything out loud, and it reaches out first when something needs attention — before you even think to ask.",
-      bullets: ["Voice queries across your full maintenance history", "Proactive alerts before costly failures occur", "Utility bill anomaly & spike detection", "IoT sensor events trigger auto-scheduling"],
-      cta: "Try the AI",
-    },
-    {
-      icon: "⚖️", kicker: "Sell Smarter",
-      heading: <>Make agents compete<br /><em>for your listing</em></>,
-      desc: "Post your listing intent and let verified agents submit competing proposals. Compare commissions and net proceeds side by side — or go FSBO.",
-      bullets: ["Competing agent proposals within 48 hours", "Compare strategy, commissions & estimated net proceeds", "FSBO mode with showing management & offer inbox", "Sealed-bid offer management"],
-      cta: "List your home",
-    },
-    {
-      icon: "👷", kicker: "Service Network",
-      heading: <>Verified contractors,<br /><em>auto-logged work</em></>,
-      desc: "Every contractor in our network is credentialed, reviewed, and bonded. Their completed work is automatically logged to your home's permanent record.",
-      bullets: ["Credentialed & background-checked providers", "Work auto-signed and logged to your record", "Verified receipts & warranties on file", "Rate-limited reviews — real feedback only"],
-      cta: "Browse the network",
-    },
-  ];
+  useEffect(() => {
+    const ref = searchParams.get("ref");
+    if (ref) neighborReferralService.capturePendingRefCode(ref);
+  }, [searchParams]);
 
   useEffect(() => {
     if (!menuOpen) return;
@@ -63,40 +72,16 @@ export default function LandingPage() {
     };
   }, [menuOpen]);
 
-  useEffect(() => {
-    if (!document.getElementById("hf-landing-fonts")) {
-      const link = document.createElement("link");
-      link.id = "hf-landing-fonts";
-      link.rel = "stylesheet";
-      link.href =
-        "https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,300;0,9..144,600;0,9..144,900;1,9..144,300;1,9..144,600;1,9..144,900&family=Plus+Jakarta+Sans:wght@300;400;500;600;700&display=swap";
-      document.head.appendChild(link);
-    }
-    return () => {
-      document.getElementById("hf-landing-fonts")?.remove();
-    };
-  }, []);
-
-  useEffect(() => {
-    const t = setInterval(() => setHeroPhase((p) => (p + 1) % 3), 4000);
-    return () => clearInterval(t);
-  }, []);
-
-  useEffect(() => {
-    const ref = searchParams.get("ref");
-    if (ref) neighborReferralService.capturePendingRefCode(ref);
-  }, [searchParams]);
-
   const scrollTo = (id: string) =>
     document.getElementById(id)?.scrollIntoView({ behavior: "smooth" });
 
   return (
     <>
       <Helmet>
-        <title>HomeGentic — Verified Home Maintenance Records</title>
+        <title>HomeGentic — Verified Home Maintenance Records on ICP</title>
         <meta name="description" content="HomeGentic gives homeowners a verified, blockchain-backed record of every repair, upgrade, and inspection — boosting home value and buyer confidence." />
         <meta property="og:title" content="HomeGentic — Verified Home Maintenance Records" />
-        <meta property="og:description" content="Homes with a verified HomeGentic record sell faster and command a premium. Build your home's complete repair, permit, and service history — shareable in one click." />
+        <meta property="og:description" content="Manage. Maintain. Protect. Your Home. Built on the Internet Computer." />
         <meta property="og:type" content="website" />
         <meta property="og:url" content="https://homegentic.app/" />
         <meta property="og:image" content="https://homegentic.app/og-default.png" />
@@ -106,29 +91,28 @@ export default function LandingPage() {
           "@type": "WebSite",
           "name": "HomeGentic",
           "url": "https://homegentic.app/",
-          "description": "Verified home maintenance records on the blockchain.",
-          "potentialAction": {
-            "@type": "SearchAction",
-            "target": "https://homegentic.app/check?address={search_term_string}",
-            "query-input": "required name=search_term_string"
-          }
+          "description": "Verified home maintenance records on the Internet Computer blockchain.",
         })}</script>
       </Helmet>
       <style>{CSS}</style>
       <div className="hfl">
 
-        {/* ── Nav ─────────────────────────────────────────────────────────── */}
+        {/* ── Nav ───────────────────────────────────────────────────────── */}
         <nav className="hfl-nav">
-          <div style={{ display: "flex", alignItems: "center" }}>
-            <a href="/" className="hfl-logo">Home<span>Gentic</span></a>
-            <ul className={`hfl-nav-links${menuOpen ? " hfl-menu-open" : ""}`}>
-              <li><a onClick={(e) => { e.preventDefault(); setMenuOpen(false); navigate("/demo"); }}>Demo</a></li>
-              <li><a onClick={(e) => { e.preventDefault(); setMenuOpen(false); navigate("/pricing"); }}>Pricing</a></li>
-              <li><a onClick={(e) => { e.preventDefault(); setMenuOpen(false); navigate("/for-pros"); }}>For Pros</a></li>
+          <div style={{ display: "flex", alignItems: "center", gap: "1.5rem" }}>
+            <a href="/" className="hfl-logo">
+              <span>🏠</span>Home<span>Gentic</span>
+            </a>
+            <ul className="hfl-nav-links">
+              <li><a onClick={(e) => { e.preventDefault(); scrollTo("hfl-features-section"); }}>Features</a></li>
+              <li><a onClick={(e) => { e.preventDefault(); scrollTo("hfl-roles-section"); }}>For Homeowners</a></li>
+              <li><a onClick={(e) => { e.preventDefault(); scrollTo("hfl-roles-section"); }}>For Contractors</a></li>
+              <li><a onClick={(e) => { e.preventDefault(); scrollTo("hfl-pricing-section"); }}>Pricing</a></li>
+              <li><a onClick={(e) => { e.preventDefault(); navigate("/invite"); }}>Invite a Neighbor</a></li>
             </ul>
           </div>
           <div className="hfl-nav-actions">
-            <button className="hfl-nav-signin" onClick={() => navigate("/login")}>Sign in</button>
+            <button className="hfl-nav-signin" onClick={() => navigate("/login")}>Log In</button>
             <button className="hfl-nav-pill" onClick={() => navigate("/login")}>Get Started</button>
             <button
               className={`hfl-hamburger${menuOpen ? " hfl-menu-open" : ""}`}
@@ -143,513 +127,180 @@ export default function LandingPage() {
 
         <main>
 
-        {/* ── Social Proof Bar ────────────────────────────────────────────── */}
-        <div className="hfl-proof-bar">
-          <span className="hfl-proof-stars">★★★★★</span>
-          <span className="hfl-proof-sep">·</span>
-          <span className="hfl-proof-quote">"Finally, a Carfax for homes"</span>
-          <span className="hfl-proof-sep">·</span>
-          <span className="hfl-proof-stat">Trusted by 3,400+ homeowners</span>
+        {/* ── Hero ──────────────────────────────────────────────────────── */}
+        <section className="hfl-hero">
+          <div>
+            <div className="hfl-hero-badge">
+              ∞ BUILT ON THE INTERNET COMPUTER (ICP)
+            </div>
+            <h1>
+              Manage. Maintain.<br />
+              <span className="green">Protect. Your Home.</span>
+            </h1>
+            <p>
+              HomeGentic is the verified home record platform built on the ICP blockchain.
+              Every repair, upgrade, and inspection — signed, stored, and shareable forever.
+            </p>
+            <div className="hfl-actions">
+              <button className="hfl-btn-main" onClick={() => navigate("/login")}>Get Started</button>
+              <button className="hfl-btn-soft" onClick={() => scrollTo("hfl-pricing-section")}>
+                ▶ See Plans
+              </button>
+            </div>
+          </div>
+          <div className="hfl-hero-img-wrap">
+            <img src="/hero_home.png" alt="HomeGentic dashboard" className="hfl-hero-img" />
+          </div>
+        </section>
+
+        {/* ── Trust Badges ──────────────────────────────────────────────── */}
+        <div className="hfl-trust">
+          <div className="hfl-trust-inner">
+            {TRUST_BADGES.map((b) => (
+              <div key={b.title} className="hfl-trust-item">
+                <div className="hfl-trust-icon" style={{ background: b.bg, color: b.color }}>
+                  {b.icon}
+                </div>
+                <div>
+                  <div className="hfl-trust-text-title">{b.title}</div>
+                  <div className="hfl-trust-text-sub">{b.sub}</div>
+                </div>
+              </div>
+            ))}
+          </div>
         </div>
 
-        {/* ── Hero ────────────────────────────────────────────────────────── */}
-        <section className="hfl-hero">
-          <div className="hfl-hero-left">
-            <h1>Your home's<br /><em>complete record</em></h1>
-            <ul className="hfl-hero-bullets">
-              <li><span className="hfl-hb-dot">✓</span>Every repair, logged and signed on the blockchain</li>
-              <li><span className="hfl-hb-dot">✓</span>AI reminders before things break</li>
-              <li><span className="hfl-hb-dot">✓</span>Share your full record with buyers in one click</li>
-            </ul>
-            <div className="hfl-actions">
-              <button className="hfl-btn-main" onClick={() => navigate("/login")}>Start my home's record</button>
-              <button className="hfl-btn-soft" onClick={() => window.open("/sample-report", "_blank", "noopener,noreferrer")}>View Sample Report</button>
-            </div>
-          </div>
-
-          <div className="hfl-hero-right">
-            <img src="/hero_home.png" alt="HomeGentic home dashboard" className="hfl-hero-img" />
-          </div>
-        </section>
-
-
-        {/* ── Problem ─────────────────────────────────────────────────────── */}
-        <section className="hfl-problem">
-          <div className="hfl-problem-inner">
-            <div className="hfl-problem-img">
-              <img src="/records_everywhere.png" alt="Records scattered everywhere" />
-            </div>
-            <div className="hfl-problem-text">
-              <h2>Your home's history is<br /><em>scattered and disappearing</em></h2>
-              <p className="hfl-sec-sub">Repair receipts in email. Warranties in a drawer. Permit records at the county office. When it's time to sell — or file an insurance claim — that scattered history costs you thousands.</p>
-            </div>
-          </div>
-        </section>
-
-        {/* ── How It Works ────────────────────────────────────────────────── */}
-        <section id="hfl-features" className="hfl-how">
+        {/* ── Roles ─────────────────────────────────────────────────────── */}
+        <section id="hfl-roles-section" className="hfl-roles">
           <div className="hfl-section-header">
-            <h2>How It Works</h2>
+            <h2>Built for every role</h2>
           </div>
-          <div className="hfl-flow">
-            {[
-              { img: "/setup_your_home.png",        num: "1", title: "Set Up Your Home",       desc: "Add your property and import existing records. AI agents begin organizing your home's history automatically." },
-              { img: "/manage_and_maintain.png",    num: "2", title: "Manage & Maintain",       desc: "Schedule services with verified providers. Every job is logged, receipted, and stored on your permanent record." },
-              { img: "/generate_your_report.png",   num: "3", title: "Generate Your Report",    desc: "Your HomeGentic Report is a tamper-proof property biography. Share it with buyers or attach it to any listing." },
-              { img: "/sell_with_confidence.png",   num: "4", title: "Sell With Confidence",    desc: "List with the agent who wins your bid — or go FSBO with our full suite of seller tools. Your home, your terms." },
-            ].map((s) => (
-              <div key={s.title} className="hfl-step">
-                <div className="hfl-step-num">{s.num}</div>
-                <div className="hfl-step-icon">
-                  <img src={s.img} alt={s.title} />
-                </div>
-                <h3>{s.title}</h3>
-                <p>{s.desc}</p>
+          <div className="hfl-roles-grid">
+            {ROLES.map((r) => (
+              <div key={r.title} className="hfl-role-card">
+                <div className="hfl-role-icon" style={{ background: r.bg }}>{r.icon}</div>
+                <div className="hfl-role-title">{r.title}</div>
+                <div className="hfl-role-desc">{r.desc}</div>
+                <button className="hfl-role-link" onClick={() => navigate(r.link)}>
+                  Learn more →
+                </button>
               </div>
             ))}
           </div>
         </section>
 
-        {/* ── Feature Showcase ────────────────────────────────────────────── */}
-        <section id="hfl-sell" className="hfl-showcase">
-          <div className="hfl-showcase-inner">
-            {/* Tab nav */}
-            <div className="hfl-sc-nav">
-              <div className="hfl-sc-nav-label">Features</div>
-              {FEATURES.map((f, i) => (
-                <button
-                  key={i}
-                  className={`hfl-sc-tab${activeFeature === i ? " hfl-sc-tab-active" : ""}`}
-                  onClick={() => setActiveFeature(i)}
-                >
-                  <div className="hfl-sc-tab-row">
-                    <span className="hfl-sc-tab-title">{f.kicker}</span>
-                  </div>
-                </button>
-              ))}
-            </div>
+        {/* ── Features ──────────────────────────────────────────────────── */}
+        <section id="hfl-features-section" className="hfl-features">
+          <div className="hfl-section-header">
+            <h2>Everything you need</h2>
+          </div>
+          <div className="hfl-features-grid">
+            {FEATURES.map((f) => (
+              <div key={f.title} className="hfl-feat-card">
+                <div className="hfl-feat-icon" style={{ background: f.bg }}>{f.icon}</div>
+                <div className="hfl-feat-title">{f.title}</div>
+                <div className="hfl-feat-desc">{f.desc}</div>
+              </div>
+            ))}
+          </div>
+        </section>
 
-            {/* Content */}
-            <div className="hfl-sc-content">
-              <div className="hfl-sc-slide" key={activeFeature}>
-                <div className="hfl-sc-heading">{FEATURES[activeFeature].heading}</div>
-                <p className="hfl-sc-desc">{FEATURES[activeFeature].desc}</p>
-                {activeFeature === 1 ? (
-                  <div className="hfl-sc-ai-row">
-                    <ul className="hfl-sc-bullets">
-                      {FEATURES[activeFeature].bullets.map((b) => (
-                        <li key={b}><span className="hfl-sc-bullet-dot">✓</span>{b}</li>
-                      ))}
-                    </ul>
-                    <img src="/ai_buddy.png" alt="HomeGentic AI" className="hfl-sc-ai-buddy" />
-                  </div>
-                ) : (
-                  <ul className="hfl-sc-bullets">
-                    {FEATURES[activeFeature].bullets.map((b) => (
-                      <li key={b}><span className="hfl-sc-bullet-dot">✓</span>{b}</li>
-                    ))}
-                  </ul>
-                )}
-                <button className="hfl-sc-cta" onClick={() => navigate("/login")}>
-                  {FEATURES[activeFeature].cta}
+        {/* ── Trust Strip ───────────────────────────────────────────────── */}
+        <div className="hfl-strip">
+          <div className="hfl-strip-inner">
+            <div className="hfl-strip-col">
+              <div className="hfl-strip-logo">🏘️</div>
+              <div>
+                <div className="hfl-strip-title">Quorum HOA Members</div>
+                <div className="hfl-strip-desc">HOA members on Quorum save 10% on any HomeGentic plan.</div>
+                <div><span className="hfl-strip-code">QUORUM10</span></div>
+              </div>
+            </div>
+            <div className="hfl-strip-col">
+              <div className="hfl-strip-logo">🤝</div>
+              <div>
+                <div className="hfl-strip-title">Invite a Neighbor</div>
+                <div className="hfl-strip-desc">You and your neighbor each earn $10 credit when they join.</div>
+                <button className="hfl-strip-link" onClick={() => navigate("/invite")}>
+                  Learn how it works →
                 </button>
               </div>
+            </div>
+            <div className="hfl-strip-col">
+              <div className="hfl-strip-logo">∞</div>
+              <div>
+                <div className="hfl-strip-title">Built on ICP</div>
+                <div className="hfl-strip-desc">Your records live on the Internet Computer — no servers, no downtime, no middlemen. Yours forever.</div>
+              </div>
+            </div>
+          </div>
+        </div>
 
-              {/* Visual panel */}
-              <div className="hfl-sc-visual" key={`v-${activeFeature}`}>
-                <div className="hfl-sc-vis-inner">
-                {activeFeature === 0 && (
-                  <div className="hfl-rec-hdr" style={{ borderRadius: 0 }}>
-                    <div className="hfl-rec-hdr-top">
-                      <span className="hfl-rec-title">HomeGentic Record</span>
-                      <span className="hfl-rec-verified">✓ Verified</span>
-                    </div>
-                    <div className="hfl-rec-addr">327 Keech Street, Daytona Beach FL</div>
-                    <div className="hfl-rec-score-row">
-                      <div className="hfl-rec-score-num">91</div>
-                      <div className="hfl-rec-score-right">
-                        <div className="hfl-rec-score-lbl">HomeGentic Score</div>
-                        <div className="hfl-rec-bar-wrap"><div className="hfl-rec-bar" /></div>
-                      </div>
-                    </div>
-                  </div>
-                )}
-                {activeFeature === 0 && (
-                  <div className="hfl-rec-body">
-                    <div className="hfl-rec-section-lbl">Verified History</div>
-                    <div className="hfl-rec-items">
-                      {[
-                        { icon: "🔨", label: "Roof Replacement", val: "2022 · Signed ✓", cls: "hfl-rec-pass" },
-                        { icon: "❄️", label: "HVAC Full Service", val: "Aug 2024 · Verified ✓", cls: "hfl-rec-pass" },
-                        { icon: "🔌", label: "Electrical Panel",  val: "Permitted 2021 ✓", cls: "hfl-rec-pass" },
-                        { icon: "🚰", label: "Water Heater",      val: "Lifespan: 2 yrs", cls: "hfl-rec-due" },
-                      ].map((r) => (
-                        <div key={r.label} className="hfl-rec-item">
-                          <span className="hfl-rec-item-l"><span>{r.icon}</span>{r.label}</span>
-                          <span className={r.cls}>{r.val}</span>
-                        </div>
-                      ))}
-                    </div>
-                    <div className="hfl-rec-footer" style={{ margin: "16px -26px -20px", padding: "14px 26px" }}>
-                      📋 <span>47 records verified · Link ready</span>
-                    </div>
-                  </div>
-                )}
+        {/* ── Integrations ──────────────────────────────────────────────── */}
+        <div className="hfl-integrations">
+          <h3>Works with your smart home devices</h3>
+          <div className="hfl-integ-logos">
+            {INTEGRATIONS.map((name) => (
+              <span key={name} className="hfl-integ-logo">{name}</span>
+            ))}
+          </div>
+        </div>
 
-                {activeFeature === 1 && (
-                  <div style={{ background: "white" }}>
-                  <div className="hfl-ai-panel-hdr">
-                    <div className="hfl-ai-panel-hdr-l">
-                      <span style={{ fontSize: 16 }}>🏠</span>
-                      <span className="hfl-ai-panel-name">HomeGentic AI</span>
-                    </div>
-                    <div className="hfl-ai-panel-live"><div className="hfl-ai-panel-dot" />Live</div>
-                  </div>
-                  <div className="hfl-ai-panel-body">
-                    <div className="hfl-ai-notice">
-                      <div className="hfl-ai-notice-tag"><span>⚡</span> HomeGentic noticed</div>
-                      <p>Your water heater (2013) is past average lifespan. Want a verified quote before winter?</p>
-                      <button className="hfl-ai-notice-btn">Yes, get me quotes</button>
-                    </div>
-                    <div className="hfl-ai-user-msg">
-                      <div className="hfl-ai-user-icon">🎤</div>
-                      <p>"What's my biggest maintenance risk this winter?"</p>
-                    </div>
-                    <div className="hfl-ai-reply">
-                      <div className="hfl-ai-reply-tag">HomeGentic AI</div>
-                      <p>Your roof was last inspected in 2021 and your furnace filter is 3 months overdue. I'd prioritize both. Want me to schedule?</p>
-                    </div>
-                  </div>
-                  <div className="hfl-ai-panel-footer">
-                    <div className="hfl-ai-mic">🎤</div>
-                    <span className="hfl-ai-mic-hint">Tap to ask anything…</span>
-                  </div>
-                  </div>
-                )}
-
-                {activeFeature === 2 && (<>
-                  <div className="hfl-compete-hdr">
-                    <div className="hfl-compete-title">Agent Proposals</div>
-                    <div className="hfl-compete-sub">327 Keech Street · 5 received</div>
-                  </div>
-                  <div className="hfl-compete-body">
-                    {[
-                      { avi: "/female_agent.png",  name: "Lisa Chen · Keller Williams", detail: "2.4% · Est. net $487k · 18 days", comm: "2.4%", best: true },
-                      { avi: "/male_agent.png",    name: "Marcus Rivera · RE/MAX",      detail: "2.8% · Est. net $481k · 22 days", comm: "2.8%", best: false },
-                      { avi: "/male_agent_2.png",  name: "Priya Nair · Compass",        detail: "3.0% · Est. net $479k · 25 days", comm: "3.0%", best: false },
-                    ].map((a, i) => (
-                      <div key={i} className={`hfl-compete-agent${a.best ? " hfl-compete-agent-featured" : ""}`}>
-                        <div className="hfl-compete-avi">
-                          <img src={a.avi} alt={a.name} />
-                        </div>
-                        <div className="hfl-compete-info">
-                          <div className="hfl-compete-name">{a.name}</div>
-                          <div className="hfl-compete-detail">{a.detail}</div>
-                          {a.best && <span className="hfl-compete-best">✦ Best offer</span>}
-                        </div>
-                        <div className="hfl-compete-comm">{a.comm}</div>
-                      </div>
-                    ))}
-                  </div>
-                  <div className="hfl-compete-footer">⚖️ <span>All verified HomeGentic partners</span></div>
-                </>)}
-
-                {activeFeature === 3 && (<>
-                  <div style={{ background: "var(--plum)", padding: "18px 22px", borderBottom: "1px solid rgba(253,252,250,0.08)" }}>
-                    <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 8 }}>
-                      <span style={{ fontFamily: "'Fraunces',serif", fontSize: 15, fontWeight: 700, color: "white" }}>Service Network</span>
-                      <span style={{ fontSize: 10, fontWeight: 700, color: "#A8DCA5", background: "rgba(122,175,118,0.25)", border: "1px solid rgba(122,175,118,0.4)", borderRadius: 100, padding: "3px 9px" }}>247 providers nearby</span>
-                    </div>
-                    <div style={{ fontSize: 12, color: "rgba(255,255,255,0.5)" }}>Daytona Beach, FL · All trades</div>
-                  </div>
-                  <div style={{ padding: "16px 22px", display: "flex", flexDirection: "column" as const, gap: 10 }}>
-                    {[
-                      { emoji: "🔧", name: "Mike's HVAC Pro",      rating: "4.9★", jobs: "32 jobs on HomeGentic", verified: true },
-                      { emoji: "🔌", name: "Coastal Electric",      rating: "4.8★", jobs: "18 jobs on HomeGentic", verified: true },
-                      { emoji: "🔨", name: "Sunrise Roofing Co.",   rating: "5.0★", jobs: "41 jobs on HomeGentic", verified: true },
-                    ].map((c) => (
-                      <div key={c.name} style={{ background: "var(--sage-light)", borderRadius: 10, padding: "10px 14px", display: "flex", alignItems: "center", gap: 12, fontSize: 12 }}>
-                        <span style={{ fontSize: 20 }}>{c.emoji}</span>
-                        <div style={{ flex: 1 }}>
-                          <div style={{ fontWeight: 700, color: "var(--plum)", marginBottom: 2 }}>{c.name}</div>
-                          <div style={{ color: "var(--plum-mid)" }}>{c.jobs}</div>
-                        </div>
-                        <div style={{ textAlign: "right" as const }}>
-                          <div style={{ fontWeight: 700, color: "var(--plum)" }}>{c.rating}</div>
-                          {c.verified && <div style={{ fontSize: 10, color: "var(--sage-text)", fontWeight: 700 }}>✓ Verified</div>}
-                        </div>
-                      </div>
-                    ))}
-                    {/* Contractor bid snippet */}
-                    <div style={{ background: "var(--butter)", border: "1px solid rgba(46,37,64,0.1)", borderRadius: 10, padding: "12px 14px" }}>
-                      <div style={{ fontSize: 10, fontWeight: 700, color: "var(--plum)", letterSpacing: "1.5px", textTransform: "uppercase" as const, marginBottom: 6 }}>⚡ Open Quote Request</div>
-                      <div style={{ fontSize: 12, fontWeight: 600, color: "var(--plum)", marginBottom: 4 }}>Roof inspection + repair estimate</div>
-                      <div style={{ fontSize: 11, color: "var(--plum-mid)", marginBottom: 8 }}>3 contractors have submitted bids · Closes in 48 hrs</div>
-                      <div style={{ display: "flex", gap: 6 }}>
-                        <span style={{ fontSize: 11, fontWeight: 700, color: "var(--plum)", background: "rgba(46,37,64,0.08)", borderRadius: 100, padding: "3px 10px" }}>$420</span>
-                        <span style={{ fontSize: 11, fontWeight: 700, color: "var(--plum)", background: "rgba(46,37,64,0.08)", borderRadius: 100, padding: "3px 10px" }}>$395</span>
-                        <span style={{ fontSize: 11, fontWeight: 700, color: "var(--sage-text)", background: "rgba(122,175,118,0.2)", borderRadius: 100, padding: "3px 10px" }}>$380 ✦ lowest</span>
-                      </div>
-                    </div>
-                    <div style={{ fontSize: 11, color: "var(--plum-mid)", fontWeight: 600, padding: "4px 0 0", display: "flex", alignItems: "center", gap: 8 }}>
-                      👷 <span>Work auto-logged to your HomeGentic Record</span>
-                    </div>
-                  </div>
-                </>)}
+        {/* ── Pricing ───────────────────────────────────────────────────── */}
+        <section id="hfl-pricing-section" className="hfl-pricing">
+          <div className="hfl-pricing-header">
+            <h2>Simple, transparent pricing</h2>
+            <p>Start at $10/mo. Your verified home record pays for itself at resale.</p>
+          </div>
+          <div className="hfl-pricing-grid">
+            {PLANS.map((p) => (
+              <div key={p.tier} className={`hfl-plan-card${p.tag ? " hfl-plan-featured" : ""}`}>
+                {p.tag && <div className="hfl-plan-badge">{p.tag}</div>}
+                <div className="hfl-plan-tier">{p.tier}</div>
+                <div className="hfl-plan-sub">{p.sub}</div>
+                <div className="hfl-plan-price">
+                  {p.price === 0 ? "Free" : `$${p.price}`}
+                  {p.price > 0 && <span>/mo</span>}
                 </div>
-
+                <ul className="hfl-plan-features">
+                  {p.features.map((f) => <li key={f}>{f}</li>)}
+                </ul>
+                <button className="hfl-plan-cta" onClick={() => navigate("/login")}>
+                  {p.price === 0 ? "Join free" : "Get started"}
+                </button>
               </div>
-            </div>
+            ))}
           </div>
-        </section>
-
-        {/* ── Report CTA ──────────────────────────────────────────────────── */}
-        <section id="hfl-report" className="hfl-report">
-          <div className="hfl-report-card">
-            <div className="hfl-report-img-col">
-              <img src="/sample_report.png" alt="Sample HomeGentic Report" />
-            </div>
-            <div className="hfl-report-body">
-              <div className="hfl-rc-label">The HomeGentic Report</div>
-              <h2>Your Home's Verified<br /><em>Biography</em></h2>
-              <p>
-                When it's time to sell, your HomeGentic Report is a tamper-proof document showing
-                every owner, every service, every improvement. Buyers love it. Agents share it.
-                Homes with it sell first.
-              </p>
-              <div className="hfl-rc-actions">
-                <button className="hfl-rc-btn" onClick={() => navigate("/login")}>Start Journey</button>
-                <button className="hfl-btn-soft" onClick={() => window.open("/sample-report", "_blank", "noopener,noreferrer")}>View Sample Report</button>
-              </div>
-            </div>
-          </div>
-        </section>
-
-        {/* ── Feature Deep Dive ───────────────────────────────────────────── */}
-        <section className="hfl-fdd">
-          <div className="hfl-fdd-inner">
-            <div className="hfl-fdd-header">
-              <h2>Built for the moments<br /><em>that actually matter</em></h2>
-              <p>Most home apps give you a checklist. HomeGentic gives you documentation that works for you at resale, during insurance claims, and before emergencies happen.</p>
-            </div>
-            <div className="hfl-fdd-cols">
-              {([
-                { icon: TrendingUp,   title: "Market Intelligence",         tagline: "Know which renovations actually pay off in your zip code.",       desc: "Uses remodeling data to rank projects by ROI for your area. Compares your score to similar nearby properties so you see exactly where you stand." },
-                  { icon: CalendarDays, title: "5-Year Maintenance Calendar", tagline: "Budget for the future instead of being blindsided.",             desc: "Based on your home's system ages and service history, HomeGentic generates a personalized 5-year schedule with projected costs for every task." },
-                { icon: Archive,      title: "Warranty Wallet",             tagline: "Every warranty, receipt, and manual — attached to your home.",   desc: "Store appliance warranties, installation receipts, and product manuals tied to the exact job they belong to. Linked to your blockchain record, not buried in your email." },
-              ] as const).map((f) => {
-                const Icon = f.icon;
-                return (
-                  <div key={f.title} className="hfl-fdd-row">
-                    <div className="hfl-fdd-icon-wrap">
-                      <Icon size={18} color="white" />
-                    </div>
-                    <div className="hfl-fdd-text">
-                      <div className="hfl-fdd-title">{f.title}</div>
-                      <div className="hfl-fdd-desc">{f.desc}</div>
-                    </div>
-                  </div>
-                );
-              })}
-            </div>
-          </div>
-        </section>
-
-        {/* ── Testimonials ────────────────────────────────────────────────── */}
-        <section className="hfl-testimonials">
-          <div className="hfl-tcard">
-            <div className="hfl-tcard-img">
-              <img src="/testimonial_image.png" alt="Homeowners celebrating their sale" />
-            </div>
-            <div className="hfl-tcard-body">
-              <div className="hfl-tcard-openquote">"</div>
-              <div className="hfl-tcard-headline">We got <span className="hfl-tcard-green">$7K</span><br />over asking.</div>
-              <p className="hfl-tcard-text">Our buyers said the HomeGentic Report was the reason they felt comfortable waiving the inspection contingency. It's a game changer."</p>
-              <div className="hfl-tcard-meta">
-                <span className="hfl-tcard-stars">★★★★★</span>
-                <span className="hfl-tcard-verified">✓ VERIFIED SELLER</span>
-              </div>
-              <div className="hfl-tcard-author">
-                <span className="hfl-tcard-name">Micah R.</span>
-                <span className="hfl-tcard-divider" />
-                <span className="hfl-tcard-location">Winter Park, FL</span>
-              </div>
-            </div>
-          </div>
-        </section>
-
-        {/* ── Pricing ─────────────────────────────────────────────────────── */}
-        <section className="hfl-pricing">
-          <div className="hfl-pricing-inner">
-            <div className="hfl-pricing-header">
-              <h2>Start for {annual ? "$100/yr" : "$10/mo"}.<br /><em>Your home earns it back.</em></h2>
-              <p className="hfl-sec-sub">A verified maintenance record pays for itself the first time a buyer negotiates. Pick the plan that fits your homeownership stage.</p>
-            </div>
-
-            {/* Billing toggle */}
-            <div style={{ display: "flex", alignItems: "center", gap: "0.75rem", marginBottom: "2.5rem" }}>
-              <span style={{ fontFamily: "'Plus Jakarta Sans', sans-serif", fontSize: "0.65rem", letterSpacing: "0.06em", textTransform: "uppercase" as const, color: annual ? "var(--plum-mid)" : "var(--plum)", fontWeight: annual ? 400 : 700 }}>Monthly</span>
-              <button
-                onClick={() => setAnnual((v) => !v)}
-                aria-label="Toggle annual billing"
-                style={{
-                  width: "2.5rem", height: "1.375rem", borderRadius: 100,
-                  border: "none", cursor: "pointer",
-                  background: annual ? "var(--sage)" : "var(--rule)",
-                  position: "relative", transition: "background 0.2s",
-                  flexShrink: 0,
-                }}
-              >
-                <span style={{
-                  position: "absolute", top: "3px",
-                  left: annual ? "calc(100% - 1.125rem)" : "3px",
-                  width: "1rem", height: "1rem", borderRadius: "50%",
-                  background: "white", transition: "left 0.2s",
-                  boxShadow: "0 1px 3px rgba(0,0,0,0.2)",
-                }} />
-              </button>
-              <span style={{ fontFamily: "'Plus Jakarta Sans', sans-serif", fontSize: "0.65rem", letterSpacing: "0.06em", textTransform: "uppercase" as const, color: annual ? "var(--plum)" : "var(--plum-mid)", fontWeight: annual ? 700 : 400 }}>Annual</span>
-              {annual && (
-                <span style={{ background: "var(--sage)", color: "white", padding: "2px 10px", borderRadius: 100, fontFamily: "'Plus Jakarta Sans', sans-serif", fontSize: "0.6rem", fontWeight: 700, letterSpacing: "0.06em" }}>
-                  Save 2 months
-                </span>
-              )}
-            </div>
-
-            <div className="hfl-pricing-grid">
-              {([
-                { tier: "Basic",   monthly: 10, annual: 100, tag: null as string | null, properties: "1 property",   photos: "5 photos/job",  quotes: "3 open quotes" },
-                { tier: "Pro",     monthly: 20, annual: 200, tag: "Most Popular",        properties: "5 properties", photos: "10 photos/job", quotes: "10 open quotes" },
-                { tier: "Premium", monthly: 40, annual: 400, tag: null as string | null, properties: "20 properties", photos: "30 photos/job", quotes: "Unlimited quotes" },
-              ]).map((plan) => (
-                <div key={plan.tier} className={`hfl-plan-card${plan.tag ? " hfl-plan-featured" : ""}`}>
-                  {plan.tag && <div className="hfl-plan-badge">{plan.tag}</div>}
-                  <div className="hfl-plan-tier">{plan.tier}</div>
-                  <div className="hfl-plan-price">
-                    ${annual ? plan.annual : plan.monthly}<span className="hfl-plan-period">/{annual ? "yr" : "mo"}</span>
-                  </div>
-                  {annual && (
-                    <div style={{ fontFamily: "'Plus Jakarta Sans', sans-serif", fontSize: "0.7rem", color: "var(--sage-text)", marginTop: "-20px", marginBottom: "20px", fontWeight: 600 }}>
-                      ${(plan.annual / 12).toFixed(2)}/mo billed annually
-                    </div>
-                  )}
-                  <ul className="hfl-plan-features">
-                    <li>✓ {plan.properties}</li>
-                    <li>✓ {plan.photos}</li>
-                    <li>✓ {plan.quotes}</li>
-                    <li>✓ Verified maintenance record</li>
-                    <li>✓ AI home intelligence</li>
-                  </ul>
-                  <button className="hfl-plan-cta" onClick={() => navigate("/login")}>Get started</button>
-                </div>
-              ))}
-            </div>
-            <p style={{ textAlign: "center", fontFamily: "'Plus Jakarta Sans', sans-serif", fontSize: "0.9rem", color: "var(--plum-mid)", marginTop: "1.5rem", lineHeight: 1.7 }}>
-              {annual
-                ? "* Billed annually upfront. Cancel anytime — subscription access ends at the close of your current billing year. Your blockchain records remain yours forever."
-                : "* Billed monthly. Cancel anytime — subscription access ends at the close of your current billing period. Your blockchain records remain yours forever."}
-            </p>
-          </div>
-        </section>
-
-        {/* ── Final CTA ───────────────────────────────────────────────────── */}
-        <section className="hfl-final-cta">
-          <div className="hfl-final-cta-inner">
-            <div className="hfl-kicker" style={{ color: "rgba(253,252,250,0.45)" }}>✦ Start Today</div>
-            <h2>Your home's history is being<br /><em>lost every day it goes unrecorded.</em></h2>
-            <p className="hfl-final-cta-sub">3,400+ homeowners have already started building their record. The best time to start was the day you moved in. The second best time is now.</p>
-            <button className="hfl-final-cta-btn" onClick={() => navigate("/login")}>Start my home's record</button>
-            <div className="hfl-final-cta-fine">From $10/mo · Cancel anytime · Your records live on the blockchain forever</div>
-          </div>
-        </section>
-
-        {/* ── Your Data ───────────────────────────────────────────────────── */}
-        <section id="hfl-data" className="hfl-data">
-          <div className="hfl-data-inner">
-            <div>
-              <h2>Your records.<br /><em>Forever yours.</em></h2>
-              <p className="hfl-data-lead">
-                Most apps keep your data on their servers. If they shut down, your records disappear.
-                HomeGentic is different — every record you log lives on a public blockchain that no one
-                controls, including us. You own it completely.
-              </p>
-            </div>
-            <div className="hfl-data-cards">
-              {[
-                { Icon: Home,     title: "Your home, your history", body: "Every repair, permit, and inspection you log is yours to keep — whether you stay with HomeGentic for one year or ten." },
-                { Icon: Download, title: "Download anytime",        body: "Export your full record as a PDF or raw data file whenever you want. No hoops, no waiting, no fees." },
-                { Icon: LinkIcon,  title: "Survives us",             body: "Even if HomeGentic ever closed tomorrow, your records would still be readable by anyone with the address. That's the promise." },
-                { Icon: Lock,     title: "Private by default",      body: "Only you decide who sees what. Sharing a HomeGentic Report with a buyer is your choice — nothing is public until you say so." },
-              ].map((card) => (
-                <div key={card.title} className="hfl-data-card">
-                  <div className="hfl-data-card-icon"><card.Icon size={22} strokeWidth={1.5} /></div>
-                  <div>
-                    <div className="hfl-data-card-title">{card.title}</div>
-                    <div className="hfl-data-card-body">{card.body}</div>
-                  </div>
-                </div>
-              ))}
-            </div>
-          </div>
+          <p className="hfl-pricing-guarantee">
+            <span>🔒</span> Cancel anytime · Your blockchain records remain yours forever
+          </p>
         </section>
 
         </main>
 
-        {/* ── Footer ──────────────────────────────────────────────────────── */}
+        {/* ── Footer ────────────────────────────────────────────────────── */}
         <footer className="hfl-footer">
-          <div className="hfl-footer-top">
-            <div>
-              <span className="hfl-footer-logo">Home<span>Gentic</span></span>
-              <p className="hfl-footer-tagline">
-                The verified maintenance record that makes your home worth more and easier to sell.
-              </p>
-              <div className="hfl-footer-social">
-                <a href="#" aria-label="HomeGentic on X" rel="noopener noreferrer">
-                  <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-                    <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.747l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
-                  </svg>
-                </a>
+          <div className="hfl-footer-inner">
+            <div className="hfl-footer-left">
+              <div className="hfl-footer-icp-logo">∞</div>
+              <div>
+                <div className="hfl-footer-icp-title">HomeGentic · Built on ICP</div>
+                <div className="hfl-footer-icp-sub">
+                  Verified home records on the Internet Computer blockchain.
+                  No servers. No downtime. Your data lives forever.
+                </div>
+                <div className="hfl-footer-quorum">
+                  Quorum HOA members save 10% ·
+                  <span className="hfl-footer-quorum-code">QUORUM10</span>
+                </div>
               </div>
             </div>
-            <div>
-              <div className="hfl-footer-col-title">Product</div>
-              <ul className="hfl-footer-col-links">
-                <li><a onClick={(e) => { e.preventDefault(); scrollTo("hfl-features"); }}>For Homeowners</a></li>
-                <li><a onClick={(e) => { e.preventDefault(); scrollTo("hfl-features"); }}>Service Network</a></li>
-                <li><a onClick={(e) => { e.preventDefault(); scrollTo("hfl-report"); }}>HomeGentic Report</a></li>
-                <li><a onClick={(e) => { e.preventDefault(); scrollTo("hfl-sell"); }}>Sell Smarter</a></li>
-                <li><a onClick={() => navigate("/demo")}>Interactive Demo</a></li>
-                <li><a onClick={() => navigate("/pricing")}>Pricing</a></li>
-              </ul>
-            </div>
-            <div>
-              <div className="hfl-footer-col-title">Free Tools</div>
-              <ul className="hfl-footer-col-links">
-                <li><a href="/check">Report Lookup</a></li>
-                <li><a href="/instant-forecast">System Forecast</a></li>
-                <li><a href="/prices">Price Lookup</a></li>
-                <li><a href="/home-systems">Systems Estimator</a></li>
-                <li><a href="/truth-kit">Buyer's Truth Kit</a></li>
-              </ul>
-            </div>
-            <div>
-              <div className="hfl-footer-col-title">Company</div>
-              <ul className="hfl-footer-col-links">
-                <li><Link to="/faq">FAQ</Link></li>
-                <li><Link to="/gift">Gift a Subscription</Link></li>
-                <li><Link to="/privacy">Privacy Policy</Link></li>
-                <li><Link to="/terms">Terms of Service</Link></li>
-                <li><Link to="/support">Support</Link></li>
-                <li><a onClick={(e) => { e.preventDefault(); scrollTo("hfl-data"); }}>Your Data</a></li>
-              </ul>
-            </div>
-          </div>
-          <div className="hfl-footer-bottom">
-            <span>© 2026 HomeGentic Inc.</span>
-            <div className="hfl-footer-bottom-links">
-              <Link to="/privacy">Privacy</Link>
-              <Link to="/terms">Terms</Link>
-              <Link to="/support">Support</Link>
+            <div style={{ display: "flex", alignItems: "center", gap: "0.75rem", flexWrap: "wrap" }}>
+              <Link to="/privacy" style={{ fontSize: "0.75rem", color: "rgba(255,255,255,0.45)", textDecoration: "none" }}>Privacy</Link>
+              <Link to="/terms"   style={{ fontSize: "0.75rem", color: "rgba(255,255,255,0.45)", textDecoration: "none" }}>Terms</Link>
+              <button className="hfl-footer-btn" onClick={() => window.open("https://internetcomputer.org", "_blank", "noopener,noreferrer")}>
+                Learn About ICP
+              </button>
             </div>
           </div>
         </footer>

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -83,7 +83,7 @@ function DashboardMockup() {
     { dot: "hfl-dm-act-dot-orange", title: "New quote received",             sub: "Kitchen sink repair",                      date: "May 2" },
   ];
   return (
-    <div className="hfl-dm">
+    <div className="hfl-dm" aria-hidden="true">
       {/* Top bar */}
       <div className="hfl-dm-topbar">
         <div className="hfl-dm-topbar-logo">

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { useAuth } from "@/contexts/AuthContext";
 import { useAuthStore } from "@/store/authStore";
@@ -64,41 +64,7 @@ function IcpInfinityIcon({ size = 20 }: { size?: number }) {
   );
 }
 
-function MailIcon() {
-  return (
-    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
-      <rect x="1" y="3" width="14" height="10" rx="1.5" stroke="#94A3B8" strokeWidth="1.5" fill="none"/>
-      <path d="M1 4.5L8 9.5L15 4.5" stroke="#94A3B8" strokeWidth="1.5" strokeLinecap="round"/>
-    </svg>
-  );
-}
-
-function LockIcon() {
-  return (
-    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
-      <rect x="3" y="7" width="10" height="8" rx="1.5" stroke="#94A3B8" strokeWidth="1.5" fill="none"/>
-      <path d="M5 7V5a3 3 0 0 1 6 0v2" stroke="#94A3B8" strokeWidth="1.5" strokeLinecap="round"/>
-      <circle cx="8" cy="11" r="1" fill="#94A3B8"/>
-    </svg>
-  );
-}
-
-function EyeIcon({ open }: { open: boolean }) {
-  return open ? (
-    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
-      <path d="M1 8C2.5 5 5 3 8 3s5.5 2 7 5c-1.5 3-4 5-7 5S2.5 11 1 8z" stroke="#94A3B8" strokeWidth="1.5" fill="none"/>
-      <circle cx="8" cy="8" r="2" stroke="#94A3B8" strokeWidth="1.5" fill="none"/>
-    </svg>
-  ) : (
-    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
-      <path d="M1 8C2.5 5 5 3 8 3s5.5 2 7 5c-1.5 3-4 5-7 5S2.5 11 1 8z" stroke="#94A3B8" strokeWidth="1.5" fill="none"/>
-      <circle cx="8" cy="8" r="2" stroke="#94A3B8" strokeWidth="1.5" fill="none"/>
-      <line x1="2" y1="2" x2="14" y2="14" stroke="#94A3B8" strokeWidth="1.5" strokeLinecap="round"/>
-    </svg>
-  );
-}
-
-// ─── Colours (local to this page) ──────────────────────────────────────────────
+// ─── Colours ───────────────────────────────────────────────────────────────────
 
 const C = {
   navy:       "#0A1628",
@@ -118,10 +84,10 @@ const C = {
 };
 
 const FEATURES = [
-  { bg: C.greenBg,  color: C.green,  emoji: "🛡️", title: "Secure & Private",       sub: "Your data is encrypted and stored on the Internet Computer (ICP)." },
-  { bg: C.purpleBg, color: C.purple, emoji: "✓",  title: "Blockchain Verified",    sub: "Immutable records you can trust. Verified by ICP." },
-  { bg: C.blueBg,   color: C.blue,   emoji: "🧠", title: "AI-Powered Insights",    sub: "Get answers, recommendations, and insights about your home." },
-  { bg: C.orangeBg, color: C.orange, emoji: "👥", title: "Built for Homeowners",   sub: "Everything you need to maintain, protect, and grow your property value." },
+  { bg: C.greenBg,  color: C.green,  emoji: "🛡️", title: "Secure & Private",    sub: "Your data is encrypted and stored on the Internet Computer (ICP)." },
+  { bg: C.purpleBg, color: C.purple, emoji: "✓",  title: "Blockchain Verified", sub: "Immutable records you can trust. Verified by ICP." },
+  { bg: C.blueBg,   color: C.blue,   emoji: "🧠", title: "AI-Powered Insights", sub: "Get answers, recommendations, and insights about your home." },
+  { bg: C.orangeBg, color: C.orange, emoji: "👥", title: "Built for Homeowners", sub: "Everything you need to maintain, protect, and grow your property value." },
 ];
 
 // ─── Component ─────────────────────────────────────────────────────────────────
@@ -130,9 +96,6 @@ export default function LoginPage() {
   const { login, devLogin } = useAuth();
   const { isLoading } = useAuthStore();
   const navigate = useNavigate();
-
-  const [showPassword, setShowPassword] = useState(false);
-  const [rememberMe, setRememberMe] = useState(false);
 
   return (
     <div style={{ minHeight: "100vh", background: C.bg, fontFamily: "'Inter', 'IBM Plex Sans', sans-serif", display: "flex", flexDirection: "column" }}>
@@ -224,12 +187,7 @@ export default function LoginPage() {
           </div>
 
           {/* House image */}
-          <div style={{
-            borderRadius: "16px",
-            overflow: "hidden",
-            position: "relative",
-            maxHeight: "260px",
-          }}>
+          <div style={{ borderRadius: "16px", overflow: "hidden", position: "relative", maxHeight: "260px" }}>
             <img
               src="/hero_home.png"
               alt="A well-maintained home"
@@ -259,157 +217,41 @@ export default function LoginPage() {
           <h2 style={{ fontWeight: 700, fontSize: "1.5rem", color: C.navy, textAlign: "center", marginBottom: "0.375rem" }}>
             Log in to your account
           </h2>
-          <p style={{ fontSize: "0.875rem", color: C.muted, textAlign: "center", marginBottom: "1.75rem" }}>
-            Enter your credentials to access your dashboard
+          <p style={{ fontSize: "0.875rem", color: C.muted, textAlign: "center", marginBottom: "2rem" }}>
+            Select your preferred sign-in method. No password needed — secured by Internet Identity.
           </p>
 
-          {/* Email */}
-          <div style={{ marginBottom: "1rem" }}>
-            <label style={{ display: "block", fontSize: "0.875rem", fontWeight: 500, color: C.navyMid, marginBottom: "0.375rem" }}>
-              Email address
-            </label>
-            <div style={{ position: "relative" }}>
-              <div style={{ position: "absolute", left: "12px", top: "50%", transform: "translateY(-50%)" }}>
-                <MailIcon />
-              </div>
-              <input
-                type="email"
-                placeholder="you@example.com"
-                style={{
-                  width: "100%",
-                  padding: "0.625rem 0.875rem 0.625rem 2.25rem",
-                  border: `1.5px solid ${C.border}`,
-                  borderRadius: "8px",
-                  fontSize: "0.9375rem",
-                  color: C.navyMid,
-                  background: C.white,
-                  outline: "none",
-                  boxSizing: "border-box",
-                }}
-              />
-            </div>
-          </div>
-
-          {/* Password */}
-          <div style={{ marginBottom: "0.875rem" }}>
-            <label style={{ display: "block", fontSize: "0.875rem", fontWeight: 500, color: C.navyMid, marginBottom: "0.375rem" }}>
-              Password
-            </label>
-            <div style={{ position: "relative" }}>
-              <div style={{ position: "absolute", left: "12px", top: "50%", transform: "translateY(-50%)" }}>
-                <LockIcon />
-              </div>
-              <input
-                type={showPassword ? "text" : "password"}
-                placeholder="Enter your password"
-                style={{
-                  width: "100%",
-                  padding: "0.625rem 2.5rem 0.625rem 2.25rem",
-                  border: `1.5px solid ${C.border}`,
-                  borderRadius: "8px",
-                  fontSize: "0.9375rem",
-                  color: C.navyMid,
-                  background: C.white,
-                  outline: "none",
-                  boxSizing: "border-box",
-                }}
-              />
-              <button
-                type="button"
-                onClick={() => setShowPassword(!showPassword)}
-                style={{
-                  position: "absolute",
-                  right: "12px",
-                  top: "50%",
-                  transform: "translateY(-50%)",
-                  background: "none",
-                  border: "none",
-                  cursor: "pointer",
-                  padding: 0,
-                  display: "flex",
-                }}
-              >
-                <EyeIcon open={showPassword} />
-              </button>
-            </div>
-          </div>
-
-          {/* Remember me + Forgot password */}
-          <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: "1.25rem" }}>
-            <label style={{ display: "flex", alignItems: "center", gap: "0.5rem", cursor: "pointer" }}>
-              <input
-                type="checkbox"
-                checked={rememberMe}
-                onChange={(e) => setRememberMe(e.target.checked)}
-                style={{ accentColor: C.blue, width: "15px", height: "15px" }}
-              />
-              <span style={{ fontSize: "0.875rem", color: C.muted }}>Remember me</span>
-            </label>
-            <span
-              onClick={login}
-              style={{ fontSize: "0.875rem", color: C.blue, fontWeight: 500, cursor: "pointer" }}
-            >
-              Forgot password?
-            </span>
-          </div>
-
-          {/* Log In button */}
-          <button
-            onClick={login}
-            disabled={isLoading}
-            data-tid="login-button"
-            style={{
-              width: "100%",
-              padding: "0.75rem",
-              background: isLoading ? "#93C5FD" : C.blue,
-              color: C.white,
-              border: "none",
-              borderRadius: "8px",
-              fontSize: "1rem",
-              fontWeight: 600,
-              cursor: isLoading ? "not-allowed" : "pointer",
-              marginBottom: "1.25rem",
-              transition: "background 0.15s",
-            }}
-          >
-            {isLoading ? "Connecting…" : "Log In"}
-          </button>
-
-          {/* Divider */}
-          <div style={{ display: "flex", alignItems: "center", gap: "0.75rem", marginBottom: "1rem" }}>
-            <div style={{ flex: 1, height: "1px", background: C.border }} />
-            <span style={{ fontSize: "0.8125rem", color: C.muted }}>or</span>
-            <div style={{ flex: 1, height: "1px", background: C.border }} />
-          </div>
-
-          {/* Social / ICP buttons */}
+          {/* Provider buttons — all open Internet Identity (which handles Google/Apple/WebAuthn) */}
           {[
-            { icon: <GoogleIcon />,     label: "Continue with Google" },
-            { icon: <AppleIcon />,      label: "Continue with Apple" },
+            { icon: <GoogleIcon />,              label: "Continue with Google" },
+            { icon: <AppleIcon />,               label: "Continue with Apple" },
             { icon: <IcpInfinityIcon size={22} />, label: "Continue with Internet Computer" },
           ].map(({ icon, label }) => (
             <button
               key={label}
               onClick={login}
+              disabled={isLoading}
+              data-tid={label === "Continue with Internet Computer" ? "login-button" : undefined}
               style={{
                 width: "100%",
                 display: "flex",
                 alignItems: "center",
                 justifyContent: "center",
                 gap: "0.625rem",
-                padding: "0.65rem",
+                padding: "0.75rem",
                 border: `1.5px solid ${C.border}`,
                 borderRadius: "8px",
                 background: C.white,
                 fontSize: "0.9375rem",
                 fontWeight: 500,
                 color: C.navyMid,
-                cursor: "pointer",
-                marginBottom: "0.625rem",
+                cursor: isLoading ? "not-allowed" : "pointer",
+                marginBottom: "0.75rem",
                 transition: "background 0.12s",
+                opacity: isLoading ? 0.6 : 1,
               }}
-              onMouseEnter={(e) => (e.currentTarget.style.background = C.bg)}
-              onMouseLeave={(e) => (e.currentTarget.style.background = C.white)}
+              onMouseEnter={(e) => { if (!isLoading) e.currentTarget.style.background = C.bg; }}
+              onMouseLeave={(e) => { e.currentTarget.style.background = C.white; }}
             >
               {icon}
               {label}
@@ -417,7 +259,7 @@ export default function LoginPage() {
           ))}
 
           {/* Sign up link */}
-          <p style={{ textAlign: "center", fontSize: "0.875rem", color: C.muted, marginTop: "1rem" }}>
+          <p style={{ textAlign: "center", fontSize: "0.875rem", color: C.muted, marginTop: "1.25rem" }}>
             Don't have an account?{" "}
             <span
               onClick={() => navigate("/register")}
@@ -426,6 +268,20 @@ export default function LoginPage() {
               Get Started
             </span>
           </p>
+
+          {/* Security note */}
+          <div style={{
+            marginTop: "1.5rem",
+            paddingTop: "1.25rem",
+            borderTop: `1px solid ${C.border}`,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            gap: "0.5rem",
+          }}>
+            <span style={{ fontSize: "0.75rem", color: C.muted }}>🔒</span>
+            <span style={{ fontSize: "0.75rem", color: C.muted }}>Secured by Internet Identity — no passwords stored</span>
+          </div>
 
           {import.meta.env.DEV && (
             <div style={{ marginTop: "1.25rem", borderTop: `1px solid ${C.border}`, paddingTop: "1.25rem" }}>
@@ -460,13 +316,7 @@ export default function LoginPage() {
         <h3 style={{ fontWeight: 700, fontSize: "1.25rem", color: C.navy, marginBottom: "1.75rem" }}>
           Your trust is our foundation
         </h3>
-        <div style={{
-          display: "flex",
-          justifyContent: "center",
-          gap: "3rem",
-          marginBottom: "2.5rem",
-          flexWrap: "wrap",
-        }}>
+        <div style={{ display: "flex", justifyContent: "center", gap: "3rem", marginBottom: "2.5rem", flexWrap: "wrap" }}>
           {[
             { icon: "🛡️", title: "Built on ICP",          sub: "Decentralized.\nScalable. Unstoppable." },
             { icon: "🔒", title: "Your Data, Yours",       sub: "You own your data.\nAlways." },

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -114,7 +114,7 @@ export default function LoginPage() {
         <Link to="/" style={{ display: "flex", alignItems: "center", gap: "0.625rem", textDecoration: "none" }}>
           <NavHouseLogo />
           <span style={{ fontWeight: 700, fontSize: "1.125rem", color: C.navy, letterSpacing: "-0.3px" }}>
-            Home<span style={{ color: C.green }}>Gentic</span>
+            Home<span style={{ color: "#15803D" }}>Gentic</span>
           </span>
         </Link>
         <div style={{ display: "flex", alignItems: "center", gap: "1rem" }}>
@@ -408,7 +408,7 @@ export default function LoginPage() {
             <span key={t} style={{ fontSize: "0.8125rem", color: "#94A3B8", cursor: "pointer" }}>{t}</span>
           ))}
         </div>
-        <span style={{ fontSize: "0.8125rem", color: "#64748B" }}>© 2025 HomeGentic. All rights reserved.</span>
+        <span style={{ fontSize: "0.8125rem", color: "#94A3B8" }}>© 2025 HomeGentic. All rights reserved.</span>
       </div>
     </div>
   );

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,12 +1,32 @@
-import React from "react";
-import { Link } from "react-router-dom";
-import { Fingerprint, Lock } from "lucide-react";
-import { Button } from "@/components/Button";
+import React, { useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
 import { useAuth } from "@/contexts/AuthContext";
 import { useAuthStore } from "@/store/authStore";
-import { COLORS, FONTS, RADIUS, SHADOWS } from "@/theme";
 
-// Simple inline SVG icons for auth providers
+// ─── SVG Assets ────────────────────────────────────────────────────────────────
+
+function HouseLogoSvg({ size = 56 }: { size?: number }) {
+  return (
+    <svg width={size} height={size * 0.85} viewBox="0 0 56 48" fill="none" aria-label="HomeGentic">
+      <polygon points="28,2 54,22 2,22" fill="#16A34A" />
+      <rect x="2" y="22" width="24" height="24" fill="#F97316" />
+      <rect x="26" y="22" width="28" height="24" fill="#2563EB" />
+      <rect x="21" y="30" width="14" height="16" fill="white" fillOpacity="0.9" />
+    </svg>
+  );
+}
+
+function NavHouseLogo() {
+  return (
+    <svg width="32" height="28" viewBox="0 0 32 28" fill="none" aria-hidden="true">
+      <polygon points="16,1 31,13 1,13" fill="#16A34A" />
+      <rect x="1" y="13" width="14" height="14" fill="#F97316" />
+      <rect x="15" y="13" width="16" height="14" fill="#2563EB" />
+      <rect x="12" y="18" width="8" height="9" fill="white" fillOpacity="0.9" />
+    </svg>
+  );
+}
+
 function GoogleIcon() {
   return (
     <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden="true">
@@ -27,148 +47,519 @@ function AppleIcon() {
   );
 }
 
+function IcpInfinityIcon({ size = 20 }: { size?: number }) {
+  const id = `icp-login-${size}`;
+  return (
+    <svg width={size} height={size * 0.6} viewBox="0 0 60 36" fill="none" aria-hidden="true">
+      <defs>
+        <linearGradient id={id} x1="0%" y1="0%" x2="100%" y2="0%">
+          <stop offset="0%" stopColor="#8B5CF6" />
+          <stop offset="50%" stopColor="#F97316" />
+          <stop offset="100%" stopColor="#EAB308" />
+        </linearGradient>
+      </defs>
+      <path d="M30 18C30 18 20 2 10 2C2 2 2 18 10 18C2 18 2 34 10 34C20 34 30 18 30 18Z" fill={`url(#${id})`} />
+      <path d="M30 18C30 18 40 2 50 2C58 2 58 18 50 18C58 18 58 34 50 34C40 34 30 18 30 18Z" fill={`url(#${id})`} />
+    </svg>
+  );
+}
+
+function MailIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+      <rect x="1" y="3" width="14" height="10" rx="1.5" stroke="#94A3B8" strokeWidth="1.5" fill="none"/>
+      <path d="M1 4.5L8 9.5L15 4.5" stroke="#94A3B8" strokeWidth="1.5" strokeLinecap="round"/>
+    </svg>
+  );
+}
+
+function LockIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+      <rect x="3" y="7" width="10" height="8" rx="1.5" stroke="#94A3B8" strokeWidth="1.5" fill="none"/>
+      <path d="M5 7V5a3 3 0 0 1 6 0v2" stroke="#94A3B8" strokeWidth="1.5" strokeLinecap="round"/>
+      <circle cx="8" cy="11" r="1" fill="#94A3B8"/>
+    </svg>
+  );
+}
+
+function EyeIcon({ open }: { open: boolean }) {
+  return open ? (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+      <path d="M1 8C2.5 5 5 3 8 3s5.5 2 7 5c-1.5 3-4 5-7 5S2.5 11 1 8z" stroke="#94A3B8" strokeWidth="1.5" fill="none"/>
+      <circle cx="8" cy="8" r="2" stroke="#94A3B8" strokeWidth="1.5" fill="none"/>
+    </svg>
+  ) : (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+      <path d="M1 8C2.5 5 5 3 8 3s5.5 2 7 5c-1.5 3-4 5-7 5S2.5 11 1 8z" stroke="#94A3B8" strokeWidth="1.5" fill="none"/>
+      <circle cx="8" cy="8" r="2" stroke="#94A3B8" strokeWidth="1.5" fill="none"/>
+      <line x1="2" y1="2" x2="14" y2="14" stroke="#94A3B8" strokeWidth="1.5" strokeLinecap="round"/>
+    </svg>
+  );
+}
+
+// ─── Colours (local to this page) ──────────────────────────────────────────────
+
+const C = {
+  navy:       "#0A1628",
+  navyMid:    "#1E293B",
+  green:      "#16A34A",
+  greenBg:    "#F0FDF4",
+  blue:       "#1D4ED8",
+  blueBg:     "#EFF6FF",
+  muted:      "#64748B",
+  border:     "#E2E8F0",
+  bg:         "#F8FAFC",
+  white:      "#FFFFFF",
+  purple:     "#7C3AED",
+  purpleBg:   "#F5F3FF",
+  orange:     "#EA580C",
+  orangeBg:   "#FFF7ED",
+};
+
+const FEATURES = [
+  { bg: C.greenBg,  color: C.green,  emoji: "🛡️", title: "Secure & Private",       sub: "Your data is encrypted and stored on the Internet Computer (ICP)." },
+  { bg: C.purpleBg, color: C.purple, emoji: "✓",  title: "Blockchain Verified",    sub: "Immutable records you can trust. Verified by ICP." },
+  { bg: C.blueBg,   color: C.blue,   emoji: "🧠", title: "AI-Powered Insights",    sub: "Get answers, recommendations, and insights about your home." },
+  { bg: C.orangeBg, color: C.orange, emoji: "👥", title: "Built for Homeowners",   sub: "Everything you need to maintain, protect, and grow your property value." },
+];
+
+// ─── Component ─────────────────────────────────────────────────────────────────
+
 export default function LoginPage() {
   const { login, devLogin } = useAuth();
   const { isLoading } = useAuthStore();
+  const navigate = useNavigate();
+
+  const [showPassword, setShowPassword] = useState(false);
+  const [rememberMe, setRememberMe] = useState(false);
 
   return (
-    <main style={{
-      minHeight: "100vh",
-      display: "flex",
-      alignItems: "center",
-      justifyContent: "center",
-      background: COLORS.sageLight,
-      padding: "1.5rem",
-      fontFamily: FONTS.sans,
-    }}>
-      <div style={{ width: "100%", maxWidth: "26rem" }}>
-        {/* Logo */}
-        <div style={{ marginBottom: "2rem", textAlign: "center" }}>
-          <div style={{ fontFamily: "'Fraunces', serif", fontWeight: 900, fontSize: "1.5rem", letterSpacing: "-0.5px", color: COLORS.plum }}>
-            Home<span style={{ color: COLORS.sageText, fontStyle: "italic", fontWeight: 300 }}>Gentic</span>
-          </div>
+    <div style={{ minHeight: "100vh", background: C.bg, fontFamily: "'Inter', 'IBM Plex Sans', sans-serif", display: "flex", flexDirection: "column" }}>
+
+      {/* ── Nav ── */}
+      <nav style={{
+        background: C.white,
+        borderBottom: `1px solid ${C.border}`,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        padding: "0 2.5rem",
+        height: "64px",
+        flexShrink: 0,
+      }}>
+        <Link to="/" style={{ display: "flex", alignItems: "center", gap: "0.625rem", textDecoration: "none" }}>
+          <NavHouseLogo />
+          <span style={{ fontWeight: 700, fontSize: "1.125rem", color: C.navy, letterSpacing: "-0.3px" }}>
+            Home<span style={{ color: C.green }}>Gentic</span>
+          </span>
+        </Link>
+        <div style={{ display: "flex", alignItems: "center", gap: "1rem" }}>
+          <span style={{ fontSize: "0.875rem", color: C.muted }}>New to HomeGentic?</span>
+          <button
+            onClick={() => navigate("/register")}
+            style={{
+              padding: "0.5rem 1.125rem",
+              border: `1.5px solid ${C.blue}`,
+              borderRadius: "6px",
+              background: "transparent",
+              color: C.blue,
+              fontSize: "0.875rem",
+              fontWeight: 600,
+              cursor: "pointer",
+            }}
+          >
+            Get Started
+          </button>
         </div>
+      </nav>
 
-        {/* Card */}
-        <div style={{
-          borderRadius: RADIUS.card,
-          padding: "2.5rem",
-          background: COLORS.white,
-          boxShadow: SHADOWS.modal,
-          border: `1px solid ${COLORS.rule}`,
-        }}>
-          {/* Eyebrow */}
-          <div style={{
-            display: "inline-flex",
-            alignItems: "center",
-            gap: "8px",
-            background: COLORS.butter,
-            color: COLORS.plum,
-            padding: "5px 14px",
-            borderRadius: 100,
-            fontSize: "0.75rem",
-            fontWeight: 600,
-            marginBottom: "1.25rem",
-            border: `1px solid rgba(46,37,64,0.1)`,
-          }}>
-            <span style={{ width: 7, height: 7, background: COLORS.sage, borderRadius: "50%" }} />
-            Sign In
-          </div>
+      {/* ── Main two-column ── */}
+      <div style={{
+        flex: 1,
+        display: "grid",
+        gridTemplateColumns: "5fr 6fr",
+        maxWidth: "1200px",
+        margin: "0 auto",
+        width: "100%",
+        padding: "3rem 2.5rem",
+        gap: "3rem",
+        alignItems: "start",
+      }}>
 
-          <h1 style={{ fontFamily: FONTS.serif, fontWeight: 900, fontSize: "2rem", lineHeight: 1.1, marginBottom: "0.75rem", color: COLORS.plum }}>
-            Welcome back.
+        {/* ── Left column ── */}
+        <div>
+          <h1 style={{ fontWeight: 700, fontSize: "2.25rem", color: C.navy, lineHeight: 1.15, marginBottom: "0.25rem" }}>
+            Welcome back!
           </h1>
-          <p style={{ fontWeight: 300, fontSize: "0.9rem", lineHeight: 1.7, color: COLORS.plumMid, marginBottom: "1.75rem" }}>
-            Sign in securely — no password needed.
-            Use your Google account, Apple ID, or your device's built-in biometrics.
+          <h2 style={{ fontWeight: 700, fontSize: "2.25rem", color: C.green, lineHeight: 1.15, marginBottom: "1.25rem" }}>
+            Let's protect what<br />matters most.
+          </h2>
+          <p style={{ fontSize: "0.9375rem", color: C.muted, lineHeight: 1.7, marginBottom: "2rem", maxWidth: "360px" }}>
+            Log in to manage your property, track maintenance, access important documents, and get AI-powered insights — all in one secure place.
           </p>
 
-          {/* Provider hints */}
-          <div style={{
-            display: "flex",
-            gap: "0.625rem",
-            marginBottom: "1.75rem",
-          }}>
-            {[
-              { icon: <GoogleIcon />, label: "Google" },
-              { icon: <AppleIcon />, label: "Apple" },
-              { icon: <Fingerprint size={17} color={COLORS.plumMid} />, label: "Touch ID / Face ID" },
-            ].map(({ icon, label }) => (
-              <div
-                key={label}
-                title={label}
-                style={{
-                  flex: 1,
+          <div style={{ display: "flex", flexDirection: "column", gap: "1.125rem", marginBottom: "2.5rem" }}>
+            {FEATURES.map((f) => (
+              <div key={f.title} style={{ display: "flex", alignItems: "flex-start", gap: "0.875rem" }}>
+                <div style={{
+                  width: "44px",
+                  height: "44px",
+                  borderRadius: "50%",
+                  background: f.bg,
                   display: "flex",
-                  flexDirection: "column",
                   alignItems: "center",
-                  gap: "0.4rem",
-                  padding: "0.625rem 0.5rem",
-                  border: `1px solid ${COLORS.rule}`,
-                  borderRadius: RADIUS.sm,
-                  color: COLORS.plumMid,
-                  fontSize: "0.65rem",
-                  fontFamily: FONTS.sans,
-                  letterSpacing: "0.05em",
-                  textTransform: "uppercase",
-                  userSelect: "none",
-                }}
-              >
-                {icon}
-                <span style={{ lineHeight: 1.2, textAlign: "center" }}>{label}</span>
+                  justifyContent: "center",
+                  fontSize: "1.125rem",
+                  flexShrink: 0,
+                }}>
+                  <span style={{ color: f.color }}>{f.emoji}</span>
+                </div>
+                <div>
+                  <div style={{ fontWeight: 600, fontSize: "0.9375rem", color: C.navy, marginBottom: "0.2rem" }}>{f.title}</div>
+                  <div style={{ fontSize: "0.8125rem", color: C.muted, lineHeight: 1.5 }}>{f.sub}</div>
+                </div>
               </div>
             ))}
           </div>
 
-          <Button size="lg" loading={isLoading} onClick={login} data-tid="login-button" style={{ width: "100%", marginBottom: "1rem" }}>
-            Continue →
-          </Button>
+          {/* House image */}
+          <div style={{
+            borderRadius: "16px",
+            overflow: "hidden",
+            position: "relative",
+            maxHeight: "260px",
+          }}>
+            <img
+              src="/hero_home.png"
+              alt="A well-maintained home"
+              style={{ width: "100%", height: "260px", objectFit: "cover", display: "block" }}
+            />
+            <div style={{
+              position: "absolute",
+              inset: 0,
+              background: "linear-gradient(to bottom, transparent 50%, rgba(248,250,252,0.6) 100%)",
+            }} />
+          </div>
+        </div>
 
-          <p style={{ fontFamily: FONTS.sans, fontSize: "0.8rem", color: COLORS.plumMid, textAlign: "center" }}>
-            No account?{" "}
-            <span onClick={login} style={{ color: COLORS.sageText, fontWeight: 600, cursor: "pointer" }}>
-              Create one free →
+        {/* ── Right column — login card ── */}
+        <div style={{
+          background: C.white,
+          border: `1px solid ${C.border}`,
+          borderRadius: "16px",
+          padding: "2.5rem",
+          boxShadow: "0 4px 24px rgba(0,0,0,0.06)",
+        }}>
+          {/* Logo */}
+          <div style={{ display: "flex", justifyContent: "center", marginBottom: "1.5rem" }}>
+            <HouseLogoSvg size={56} />
+          </div>
+
+          <h2 style={{ fontWeight: 700, fontSize: "1.5rem", color: C.navy, textAlign: "center", marginBottom: "0.375rem" }}>
+            Log in to your account
+          </h2>
+          <p style={{ fontSize: "0.875rem", color: C.muted, textAlign: "center", marginBottom: "1.75rem" }}>
+            Enter your credentials to access your dashboard
+          </p>
+
+          {/* Email */}
+          <div style={{ marginBottom: "1rem" }}>
+            <label style={{ display: "block", fontSize: "0.875rem", fontWeight: 500, color: C.navyMid, marginBottom: "0.375rem" }}>
+              Email address
+            </label>
+            <div style={{ position: "relative" }}>
+              <div style={{ position: "absolute", left: "12px", top: "50%", transform: "translateY(-50%)" }}>
+                <MailIcon />
+              </div>
+              <input
+                type="email"
+                placeholder="you@example.com"
+                style={{
+                  width: "100%",
+                  padding: "0.625rem 0.875rem 0.625rem 2.25rem",
+                  border: `1.5px solid ${C.border}`,
+                  borderRadius: "8px",
+                  fontSize: "0.9375rem",
+                  color: C.navyMid,
+                  background: C.white,
+                  outline: "none",
+                  boxSizing: "border-box",
+                }}
+              />
+            </div>
+          </div>
+
+          {/* Password */}
+          <div style={{ marginBottom: "0.875rem" }}>
+            <label style={{ display: "block", fontSize: "0.875rem", fontWeight: 500, color: C.navyMid, marginBottom: "0.375rem" }}>
+              Password
+            </label>
+            <div style={{ position: "relative" }}>
+              <div style={{ position: "absolute", left: "12px", top: "50%", transform: "translateY(-50%)" }}>
+                <LockIcon />
+              </div>
+              <input
+                type={showPassword ? "text" : "password"}
+                placeholder="Enter your password"
+                style={{
+                  width: "100%",
+                  padding: "0.625rem 2.5rem 0.625rem 2.25rem",
+                  border: `1.5px solid ${C.border}`,
+                  borderRadius: "8px",
+                  fontSize: "0.9375rem",
+                  color: C.navyMid,
+                  background: C.white,
+                  outline: "none",
+                  boxSizing: "border-box",
+                }}
+              />
+              <button
+                type="button"
+                onClick={() => setShowPassword(!showPassword)}
+                style={{
+                  position: "absolute",
+                  right: "12px",
+                  top: "50%",
+                  transform: "translateY(-50%)",
+                  background: "none",
+                  border: "none",
+                  cursor: "pointer",
+                  padding: 0,
+                  display: "flex",
+                }}
+              >
+                <EyeIcon open={showPassword} />
+              </button>
+            </div>
+          </div>
+
+          {/* Remember me + Forgot password */}
+          <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: "1.25rem" }}>
+            <label style={{ display: "flex", alignItems: "center", gap: "0.5rem", cursor: "pointer" }}>
+              <input
+                type="checkbox"
+                checked={rememberMe}
+                onChange={(e) => setRememberMe(e.target.checked)}
+                style={{ accentColor: C.blue, width: "15px", height: "15px" }}
+              />
+              <span style={{ fontSize: "0.875rem", color: C.muted }}>Remember me</span>
+            </label>
+            <span
+              onClick={login}
+              style={{ fontSize: "0.875rem", color: C.blue, fontWeight: 500, cursor: "pointer" }}
+            >
+              Forgot password?
+            </span>
+          </div>
+
+          {/* Log In button */}
+          <button
+            onClick={login}
+            disabled={isLoading}
+            data-tid="login-button"
+            style={{
+              width: "100%",
+              padding: "0.75rem",
+              background: isLoading ? "#93C5FD" : C.blue,
+              color: C.white,
+              border: "none",
+              borderRadius: "8px",
+              fontSize: "1rem",
+              fontWeight: 600,
+              cursor: isLoading ? "not-allowed" : "pointer",
+              marginBottom: "1.25rem",
+              transition: "background 0.15s",
+            }}
+          >
+            {isLoading ? "Connecting…" : "Log In"}
+          </button>
+
+          {/* Divider */}
+          <div style={{ display: "flex", alignItems: "center", gap: "0.75rem", marginBottom: "1rem" }}>
+            <div style={{ flex: 1, height: "1px", background: C.border }} />
+            <span style={{ fontSize: "0.8125rem", color: C.muted }}>or</span>
+            <div style={{ flex: 1, height: "1px", background: C.border }} />
+          </div>
+
+          {/* Social / ICP buttons */}
+          {[
+            { icon: <GoogleIcon />,     label: "Continue with Google" },
+            { icon: <AppleIcon />,      label: "Continue with Apple" },
+            { icon: <IcpInfinityIcon size={22} />, label: "Continue with Internet Computer" },
+          ].map(({ icon, label }) => (
+            <button
+              key={label}
+              onClick={login}
+              style={{
+                width: "100%",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                gap: "0.625rem",
+                padding: "0.65rem",
+                border: `1.5px solid ${C.border}`,
+                borderRadius: "8px",
+                background: C.white,
+                fontSize: "0.9375rem",
+                fontWeight: 500,
+                color: C.navyMid,
+                cursor: "pointer",
+                marginBottom: "0.625rem",
+                transition: "background 0.12s",
+              }}
+              onMouseEnter={(e) => (e.currentTarget.style.background = C.bg)}
+              onMouseLeave={(e) => (e.currentTarget.style.background = C.white)}
+            >
+              {icon}
+              {label}
+            </button>
+          ))}
+
+          {/* Sign up link */}
+          <p style={{ textAlign: "center", fontSize: "0.875rem", color: C.muted, marginTop: "1rem" }}>
+            Don't have an account?{" "}
+            <span
+              onClick={() => navigate("/register")}
+              style={{ color: C.blue, fontWeight: 600, cursor: "pointer" }}
+            >
+              Get Started
             </span>
           </p>
 
-          {/* Security note */}
-          <div style={{
-            display: "flex",
-            alignItems: "center",
-            gap: "0.5rem",
-            justifyContent: "center",
-            marginTop: "1.5rem",
-            paddingTop: "1.25rem",
-            borderTop: `1px solid ${COLORS.rule}`,
-          }}>
-            <Lock size={11} color={COLORS.plumMid} />
-            <p style={{ fontFamily: FONTS.sans, fontSize: "0.75rem", fontWeight: 300, color: COLORS.plumMid, margin: 0 }}>
-              Secured by Internet Identity — no passwords stored
-            </p>
-          </div>
-
           {import.meta.env.DEV && (
-            <div style={{ marginTop: "1.25rem", borderTop: `1px solid ${COLORS.rule}`, paddingTop: "1.25rem" }}>
-              <p style={{ fontFamily: FONTS.sans, fontSize: "0.75rem", fontWeight: 300, color: COLORS.plumMid, marginBottom: "0.625rem" }}>
-                Local dev only
-              </p>
-              <Button
-                variant="outline"
+            <div style={{ marginTop: "1.25rem", borderTop: `1px solid ${C.border}`, paddingTop: "1.25rem" }}>
+              <p style={{ fontSize: "0.75rem", color: C.muted, marginBottom: "0.5rem", textAlign: "center" }}>Local dev only</p>
+              <button
                 onClick={devLogin}
-                style={{ width: "100%" }}
+                style={{
+                  width: "100%",
+                  padding: "0.625rem",
+                  border: `1.5px solid ${C.border}`,
+                  borderRadius: "8px",
+                  background: C.white,
+                  fontSize: "0.875rem",
+                  color: C.muted,
+                  cursor: "pointer",
+                }}
               >
                 ⚡ Dev Login (skip Internet Identity)
-              </Button>
+              </button>
             </div>
           )}
         </div>
+      </div>
 
-        <div style={{ marginTop: "1.25rem", textAlign: "center" }}>
-          <Link to="/" style={{ fontFamily: FONTS.sans, fontSize: "0.8rem", color: COLORS.plumMid, textDecoration: "none" }}>
-            ← Back to HomeGentic
-          </Link>
+      {/* ── Trust section ── */}
+      <div style={{
+        background: C.white,
+        borderTop: `1px solid ${C.border}`,
+        padding: "3rem 2.5rem",
+        textAlign: "center",
+      }}>
+        <h3 style={{ fontWeight: 700, fontSize: "1.25rem", color: C.navy, marginBottom: "1.75rem" }}>
+          Your trust is our foundation
+        </h3>
+        <div style={{
+          display: "flex",
+          justifyContent: "center",
+          gap: "3rem",
+          marginBottom: "2.5rem",
+          flexWrap: "wrap",
+        }}>
+          {[
+            { icon: "🛡️", title: "Built on ICP",          sub: "Decentralized.\nScalable. Unstoppable." },
+            { icon: "🔒", title: "Your Data, Yours",       sub: "You own your data.\nAlways." },
+            { icon: "✓",  title: "Verified & Immutable",  sub: "Every important record\nis permanently verified." },
+          ].map((b) => (
+            <div key={b.title} style={{ display: "flex", alignItems: "flex-start", gap: "0.75rem", maxWidth: "220px", textAlign: "left" }}>
+              <div style={{
+                width: "36px", height: "36px",
+                border: `1.5px solid ${C.border}`,
+                borderRadius: "8px",
+                display: "flex", alignItems: "center", justifyContent: "center",
+                fontSize: "1rem",
+                flexShrink: 0,
+              }}>
+                <span style={{ color: C.blue }}>{b.icon}</span>
+              </div>
+              <div>
+                <div style={{ fontWeight: 600, fontSize: "0.875rem", color: C.navy }}>{b.title}</div>
+                <div style={{ fontSize: "0.8125rem", color: C.muted, whiteSpace: "pre-line", lineHeight: 1.5 }}>{b.sub}</div>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {/* Testimonial */}
+        <div style={{ maxWidth: "540px", margin: "0 auto", textAlign: "left" }}>
+          <div style={{ fontSize: "2rem", color: C.blue, lineHeight: 1, marginBottom: "0.5rem" }}>"</div>
+          <p style={{ fontSize: "1rem", color: C.navyMid, lineHeight: 1.7, fontStyle: "italic", marginBottom: "0.75rem" }}>
+            HomeGentic gives me peace of mind knowing my home is protected and my records are secure.
+          </p>
+          <p style={{ fontSize: "0.875rem", color: C.muted, fontWeight: 500 }}>— Austin Homeowner</p>
         </div>
       </div>
-    </main>
+
+      {/* ── Footer ── */}
+      <footer style={{
+        background: "#0A1628",
+        padding: "1.5rem 2.5rem",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        flexWrap: "wrap",
+        gap: "1rem",
+      }}>
+        <div style={{ display: "flex", alignItems: "center", gap: "1rem" }}>
+          <IcpInfinityIcon size={32} />
+          <div>
+            <div style={{ color: C.white, fontWeight: 600, fontSize: "0.9375rem" }}>Built on the Internet Computer Protocol (ICP)</div>
+            <div style={{ color: "#94A3B8", fontSize: "0.8125rem" }}>Your data is yours. Permanently stored. Tamper-proof. Future-proof.</div>
+          </div>
+        </div>
+        <div style={{ textAlign: "center" }}>
+          <div style={{ color: C.white, fontWeight: 600, fontSize: "0.9375rem" }}>Quorum HOA members save 10%</div>
+          <div style={{ color: "#94A3B8", fontSize: "0.8125rem" }}>
+            Use code:{" "}
+            <span style={{ color: "#F97316", fontWeight: 700, letterSpacing: "0.05em" }}>QUORUM10</span>
+          </div>
+        </div>
+        <button
+          onClick={() => window.open("https://internetcomputer.org", "_blank", "noopener,noreferrer")}
+          style={{
+            padding: "0.625rem 1.25rem",
+            border: "1.5px solid #334155",
+            borderRadius: "8px",
+            background: "transparent",
+            color: C.white,
+            fontSize: "0.875rem",
+            fontWeight: 500,
+            cursor: "pointer",
+          }}
+        >
+          Learn More
+        </button>
+      </footer>
+
+      {/* ── Sub-footer ── */}
+      <div style={{
+        background: "#0A1628",
+        borderTop: "1px solid #1E293B",
+        padding: "1rem 2.5rem",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        flexWrap: "wrap",
+        gap: "0.5rem",
+      }}>
+        <div style={{ display: "flex", gap: "1.5rem" }}>
+          {["Security", "Privacy", "Terms of Service", "Contact Us"].map((t) => (
+            <span key={t} style={{ fontSize: "0.8125rem", color: "#94A3B8", cursor: "pointer" }}>{t}</span>
+          ))}
+        </div>
+        <span style={{ fontSize: "0.8125rem", color: "#64748B" }}>© 2025 HomeGentic. All rights reserved.</span>
+      </div>
+    </div>
   );
 }

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -218,7 +218,7 @@ export default function LoginPage() {
             Log in to your account
           </h2>
           <p style={{ fontSize: "0.875rem", color: C.muted, textAlign: "center", marginBottom: "2rem" }}>
-            Select your preferred sign-in method. No password needed — secured by Internet Identity.
+            Select your preferred sign-in method.
           </p>
 
           {/* Provider buttons — all open Internet Identity (which handles Google/Apple/WebAuthn) */}

--- a/frontend/src/pages/landingStyles.ts
+++ b/frontend/src/pages/landingStyles.ts
@@ -16,12 +16,12 @@ export const CSS = `
 }
 .hfl-logo {
   font-size:1.1rem; font-weight:800; color:var(--lp-navy);
-  text-decoration:none; display:flex; align-items:center; gap:6px;
+  text-decoration:none; display:flex; align-items:center; gap:7px;
   flex-shrink:0;
 }
 .hfl-logo span { color:var(--lp-green); }
 .hfl-nav-links {
-  display:flex; align-items:center; gap:0; list-style:none;
+  display:flex; align-items:center; list-style:none;
   margin:0; padding:0;
 }
 .hfl-nav-links li a {
@@ -41,7 +41,7 @@ export const CSS = `
 .hfl-nav-pill {
   font-size:0.82rem; font-weight:600; color:white;
   background:var(--lp-blue); border:none;
-  padding:0.45rem 1rem; border-radius:6px; cursor:pointer;
+  padding:0.45rem 1.1rem; border-radius:6px; cursor:pointer;
   transition:opacity 0.15s;
 }
 .hfl-nav-pill:hover { opacity:0.9; }
@@ -52,30 +52,29 @@ export const CSS = `
 .hfl-hamburger span {
   display:block; width:20px; height:2px;
   background:var(--lp-text); border-radius:2px;
-  transition:transform 0.2s, opacity 0.2s;
 }
 
 /* ── Hero ───────────────────────────────────────────────────────────────── */
 .hfl-hero {
-  display:grid; grid-template-columns:1fr 1fr;
+  display:grid; grid-template-columns:2fr 3fr;
   align-items:center; gap:3rem;
   padding:4rem 2rem 3rem; max-width:1160px; margin:0 auto;
 }
 .hfl-hero-badge {
   display:inline-flex; align-items:center; gap:6px;
-  font-size:0.65rem; font-weight:700; letter-spacing:0.1em;
+  font-size:0.65rem; font-weight:700; letter-spacing:0.08em;
   text-transform:uppercase; color:#1E40AF;
   background:#EFF6FF; border:1px solid #BFDBFE;
   padding:4px 12px; border-radius:100px; margin-bottom:1.25rem;
 }
 .hfl-hero h1 {
-  font-size:clamp(2rem,4vw,2.75rem); font-weight:800; line-height:1.15;
+  font-size:clamp(2rem,3.5vw,2.75rem); font-weight:800; line-height:1.15;
   color:var(--lp-navy); margin:0 0 1rem;
 }
-.hfl-hero h1 .green { color:var(--lp-green); }
+.hfl-hero h1 .green { color:var(--lp-green); display:block; }
 .hfl-hero p {
-  font-size:1rem; color:var(--lp-muted); line-height:1.7;
-  max-width:480px; margin:0 0 1.75rem;
+  font-size:0.95rem; color:var(--lp-muted); line-height:1.7;
+  margin:0 0 1.75rem;
 }
 .hfl-actions {
   display:flex; align-items:center; gap:0.75rem; flex-wrap:wrap;
@@ -95,15 +94,10 @@ export const CSS = `
   transition:border-color 0.15s;
 }
 .hfl-btn-soft:hover { border-color:#94A3B8; }
-.hfl-hero-img-wrap {
-  border-radius:12px; overflow:hidden;
-  box-shadow:0 20px 60px rgba(0,0,0,0.12);
-}
-.hfl-hero-img { display:block; width:100%; height:auto; }
 
 /* ── Trust Badges ───────────────────────────────────────────────────────── */
 .hfl-trust {
-  background:var(--lp-light); border-top:1px solid var(--lp-rule);
+  background:var(--lp-white); border-top:1px solid var(--lp-rule);
   border-bottom:1px solid var(--lp-rule);
 }
 .hfl-trust-inner {
@@ -116,7 +110,7 @@ export const CSS = `
 }
 .hfl-trust-item:last-child { border-right:none; }
 .hfl-trust-icon {
-  width:36px; height:36px; border-radius:8px;
+  width:38px; height:38px; border-radius:8px;
   display:flex; align-items:center; justify-content:center;
   font-size:1.1rem; flex-shrink:0;
 }
@@ -124,19 +118,19 @@ export const CSS = `
   font-size:0.82rem; font-weight:700; color:var(--lp-navy); margin-bottom:2px;
 }
 .hfl-trust-text-sub {
-  font-size:0.74rem; color:var(--lp-muted); line-height:1.5;
+  font-size:0.73rem; color:var(--lp-muted); line-height:1.5;
 }
 
 /* ── Roles ──────────────────────────────────────────────────────────────── */
 .hfl-roles { padding:4rem 2rem; background:var(--lp-white); }
 .hfl-section-header { text-align:center; margin-bottom:2.5rem; }
 .hfl-section-header h2 {
-  font-size:clamp(1.4rem,3vw,1.85rem); font-weight:700;
+  font-size:clamp(1.4rem,2.5vw,1.75rem); font-weight:700;
   color:var(--lp-navy); margin:0;
 }
 .hfl-roles-grid {
   display:grid; grid-template-columns:repeat(3,1fr);
-  gap:1.5rem; max-width:960px; margin:0 auto;
+  gap:1.25rem; max-width:960px; margin:0 auto;
 }
 .hfl-role-card {
   border:1px solid var(--lp-rule); border-radius:10px; padding:1.5rem;
@@ -147,10 +141,10 @@ export const CSS = `
   font-size:1.3rem; margin-bottom:0.875rem;
 }
 .hfl-role-title {
-  font-size:0.95rem; font-weight:700; color:var(--lp-navy); margin-bottom:0.5rem;
+  font-size:0.95rem; font-weight:700; color:var(--lp-navy); margin-bottom:0.4rem;
 }
 .hfl-role-desc {
-  font-size:0.82rem; color:var(--lp-muted); line-height:1.6; margin-bottom:0.875rem;
+  font-size:0.8rem; color:var(--lp-muted); line-height:1.6; margin-bottom:0.875rem;
 }
 .hfl-role-link {
   font-size:0.8rem; font-weight:600; color:var(--lp-blue);
@@ -170,22 +164,23 @@ export const CSS = `
 .hfl-feat-card {
   background:var(--lp-white); border:1px solid var(--lp-rule);
   border-radius:10px; padding:1.25rem;
+  display:flex; align-items:flex-start; gap:0.875rem;
 }
 .hfl-feat-icon {
-  width:38px; height:38px; border-radius:8px;
+  width:38px; height:38px; border-radius:8px; flex-shrink:0;
   display:flex; align-items:center; justify-content:center;
-  font-size:1.1rem; margin-bottom:0.75rem;
+  font-size:1.1rem;
 }
+.hfl-feat-body { }
 .hfl-feat-title {
-  font-size:0.85rem; font-weight:700; color:var(--lp-navy); margin-bottom:0.35rem;
+  font-size:0.85rem; font-weight:700; color:var(--lp-navy); margin-bottom:0.3rem;
 }
 .hfl-feat-desc { font-size:0.75rem; color:var(--lp-muted); line-height:1.55; }
 
 /* ── Trust Strip ────────────────────────────────────────────────────────── */
 .hfl-strip {
-  background:var(--lp-light);
+  background:var(--lp-white);
   border-top:1px solid var(--lp-rule); border-bottom:1px solid var(--lp-rule);
-  padding:0;
 }
 .hfl-strip-inner {
   display:grid; grid-template-columns:repeat(3,1fr);
@@ -193,15 +188,15 @@ export const CSS = `
 }
 .hfl-strip-col {
   display:flex; align-items:flex-start; gap:0.875rem;
-  padding:1.5rem; border-right:1px solid var(--lp-rule);
+  padding:1.5rem 2rem; border-right:1px solid var(--lp-rule);
 }
 .hfl-strip-col:last-child { border-right:none; }
 .hfl-strip-logo {
-  width:40px; height:40px; flex-shrink:0;
-  display:flex; align-items:center; justify-content:center; font-size:1.4rem;
+  width:44px; height:44px; flex-shrink:0;
+  display:flex; align-items:center; justify-content:center;
 }
 .hfl-strip-title {
-  font-size:0.82rem; font-weight:700; color:var(--lp-navy); margin-bottom:0.3rem;
+  font-size:0.85rem; font-weight:700; color:var(--lp-navy); margin-bottom:0.25rem;
 }
 .hfl-strip-desc {
   font-size:0.75rem; color:var(--lp-muted); line-height:1.55; margin-bottom:0.3rem;
@@ -214,7 +209,7 @@ export const CSS = `
 .hfl-strip-code {
   display:inline-block; font-size:0.7rem; font-weight:700; letter-spacing:0.05em;
   color:var(--lp-green); background:#F0FDF4; border:1px solid #BBF7D0;
-  padding:2px 8px; border-radius:4px; margin-top:3px;
+  padding:2px 8px; border-radius:4px;
 }
 
 /* ── Integrations ───────────────────────────────────────────────────────── */
@@ -237,15 +232,15 @@ export const CSS = `
 
 /* ── Pricing ────────────────────────────────────────────────────────────── */
 .hfl-pricing { padding:5rem 2rem; background:var(--lp-white); }
-.hfl-pricing-header { text-align:center; margin-bottom:3rem; }
+.hfl-pricing-header { text-align:center; margin-bottom:2.5rem; }
 .hfl-pricing-header h2 {
-  font-size:clamp(1.4rem,3vw,1.85rem); font-weight:700;
+  font-size:clamp(1.4rem,2.5vw,1.75rem); font-weight:700;
   color:var(--lp-navy); margin:0 0 0.5rem;
 }
-.hfl-pricing-header p { font-size:0.9rem; color:var(--lp-muted); margin:0; }
+.hfl-pricing-header p { font-size:0.875rem; color:var(--lp-muted); margin:0; }
 .hfl-pricing-grid {
   display:grid; grid-template-columns:repeat(5,1fr);
-  gap:1rem; max-width:1160px; margin:0 auto 1.25rem;
+  gap:1rem; max-width:1160px; margin:0 auto 1.5rem;
 }
 .hfl-plan-card {
   border:1.5px solid var(--lp-rule); border-radius:10px;
@@ -261,66 +256,144 @@ export const CSS = `
   padding:3px 10px; border-radius:100px; white-space:nowrap;
 }
 .hfl-plan-tier {
-  font-size:0.78rem; font-weight:700; color:var(--lp-blue);
-  text-transform:uppercase; letter-spacing:0.06em; margin-bottom:0.25rem;
+  font-size:0.85rem; font-weight:700; color:var(--lp-blue);
+  margin-bottom:0.2rem;
 }
 .hfl-plan-sub { font-size:0.72rem; color:var(--lp-muted); margin-bottom:0.875rem; }
 .hfl-plan-price {
-  font-size:1.75rem; font-weight:800; color:var(--lp-navy);
-  margin-bottom:0.25rem; line-height:1;
+  font-size:2rem; font-weight:800; color:var(--lp-navy);
+  margin-bottom:0.875rem; line-height:1;
 }
 .hfl-plan-price span { font-size:0.9rem; font-weight:500; color:var(--lp-muted); }
 .hfl-plan-features {
-  list-style:none; padding:0; margin:0.875rem 0 1.25rem;
+  list-style:none; padding:0; margin:0 0 1.25rem;
   display:flex; flex-direction:column; gap:0.4rem;
 }
 .hfl-plan-features li {
   font-size:0.75rem; color:var(--lp-text);
-  display:flex; align-items:flex-start; gap:5px;
+  display:flex; align-items:flex-start; gap:6px;
 }
-.hfl-plan-features li::before {
-  content:"✓"; color:var(--lp-green); font-weight:700; flex-shrink:0;
-}
+.hfl-plan-feat-check { color:var(--lp-green); font-weight:700; flex-shrink:0; }
 .hfl-plan-cta {
-  width:100%; font-size:0.8rem; font-weight:600;
-  padding:0.55rem; border-radius:6px; cursor:pointer;
+  width:100%; font-size:0.82rem; font-weight:600;
+  padding:0.6rem; border-radius:6px; cursor:pointer;
   border:1.5px solid var(--lp-rule); background:var(--lp-white); color:var(--lp-navy);
-  transition:background 0.15s;
+  transition:opacity 0.15s;
 }
-.hfl-plan-featured .hfl-plan-cta {
+.hfl-plan-cta-green {
+  background:var(--lp-green); border-color:var(--lp-green); color:white;
+}
+.hfl-plan-cta-green:hover { opacity:0.9; }
+.hfl-plan-cta-blue {
   background:var(--lp-blue); border-color:var(--lp-blue); color:white;
 }
-.hfl-plan-cta:hover { background:var(--lp-light); }
-.hfl-plan-featured .hfl-plan-cta:hover { opacity:0.9; background:var(--lp-blue); }
+.hfl-plan-cta-blue:hover { opacity:0.9; }
 .hfl-pricing-guarantee {
   text-align:center; font-size:0.8rem; color:var(--lp-muted);
-  display:flex; align-items:center; justify-content:center; gap:0.4rem;
+  display:flex; align-items:center; justify-content:center; gap:0.75rem;
 }
+.hfl-pricing-guarantee-sep { color:var(--lp-rule); }
+
+/* ── Dashboard Mockup ───────────────────────────────────────────────────── */
+.hfl-dm {
+  background:white; border:1px solid #E2E8F0; border-radius:12px;
+  overflow:hidden; width:100%;
+  box-shadow:0 20px 60px rgba(0,0,0,0.14),0 4px 16px rgba(0,0,0,0.07);
+  font-family:'Inter','Segoe UI',system-ui,sans-serif;
+}
+.hfl-dm-topbar {
+  display:flex; align-items:center; justify-content:space-between;
+  padding:8px 14px; border-bottom:1px solid #F1F5F9; background:white;
+}
+.hfl-dm-topbar-logo {
+  display:flex; align-items:center; gap:5px;
+  font-size:12px; font-weight:800; color:#0F172A;
+}
+.hfl-dm-topbar-logo .green { color:#16A34A; }
+.hfl-dm-topbar-icons { display:flex; gap:8px; color:#94A3B8; font-size:14px; }
+.hfl-dm-body { display:flex; }
+.hfl-dm-sidebar {
+  width:118px; flex-shrink:0; background:#F8FAFC;
+  border-right:1px solid #F1F5F9; padding:8px 0;
+}
+.hfl-dm-nav {
+  padding:5px 10px; font-size:9.5px; color:#64748B;
+  display:flex; align-items:center; gap:5px;
+  overflow:hidden; white-space:nowrap; text-overflow:ellipsis;
+}
+.hfl-dm-nav-active {
+  background:#EFF6FF; color:#2563EB; font-weight:600;
+  border-right:2px solid #2563EB;
+}
+.hfl-dm-main { flex:1; padding:10px 12px; overflow:hidden; min-width:0; }
+.hfl-dm-welcome { font-size:12px; font-weight:700; color:#0F172A; margin-bottom:8px; }
+.hfl-dm-cards-row { display:flex; gap:8px; margin-bottom:8px; }
+.hfl-dm-score-card,.hfl-dm-maint-card {
+  flex:1; background:#F8FAFC; border:1px solid #E2E8F0; border-radius:7px; padding:8px; min-width:0;
+}
+.hfl-dm-card-label { font-size:8.5px; color:#64748B; font-weight:600; margin-bottom:6px; }
+.hfl-dm-score-wrap { display:flex; align-items:center; gap:8px; }
+.hfl-dm-score-ring {
+  width:42px; height:42px; border-radius:50%; flex-shrink:0;
+  background:conic-gradient(#16A34A 0% 82%,#E2E8F0 82% 100%);
+  display:flex; align-items:center; justify-content:center; position:relative;
+}
+.hfl-dm-score-ring::before {
+  content:""; position:absolute; inset:7px; border-radius:50%; background:#F8FAFC;
+}
+.hfl-dm-score-val { position:relative; z-index:1; font-size:13px; font-weight:800; color:#0F172A; }
+.hfl-dm-score-delta { font-size:8px; color:#16A34A; font-weight:600; }
+.hfl-dm-score-sub { font-size:7px; color:#94A3B8; }
+.hfl-dm-maint-nums { display:flex; gap:14px; padding-top:2px; }
+.hfl-dm-maint-num { font-size:20px; font-weight:800; color:#0F172A; line-height:1; }
+.hfl-dm-maint-lbl { font-size:7.5px; color:#64748B; margin-top:2px; }
+.hfl-dm-stats-row { display:flex; gap:6px; margin-bottom:8px; }
+.hfl-dm-stat {
+  flex:1; background:#F8FAFC; border:1px solid #E2E8F0;
+  border-radius:6px; padding:5px 6px; text-align:center; min-width:0;
+}
+.hfl-dm-stat-label { font-size:7px; color:#64748B; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+.hfl-dm-stat-val { font-size:15px; font-weight:800; color:#0F172A; line-height:1.1; }
+.hfl-dm-stat-link { font-size:7.5px; color:#2563EB; font-weight:600; }
+.hfl-dm-activity-label {
+  font-size:7.5px; font-weight:700; color:#94A3B8;
+  text-transform:uppercase; letter-spacing:0.07em; margin-bottom:5px;
+}
+.hfl-dm-act-item {
+  display:flex; align-items:flex-start; gap:6px;
+  padding:4px 0; border-top:1px solid #F1F5F9;
+}
+.hfl-dm-act-dot { width:6px; height:6px; border-radius:50%; flex-shrink:0; margin-top:3px; }
+.hfl-dm-act-dot-green  { background:#16A34A; }
+.hfl-dm-act-dot-blue   { background:#2563EB; }
+.hfl-dm-act-dot-orange { background:#F97316; }
+.hfl-dm-act-body { flex:1; min-width:0; }
+.hfl-dm-act-title { font-size:8.5px; font-weight:600; color:#1E293B; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+.hfl-dm-act-sub   { font-size:7px; color:#94A3B8; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+.hfl-dm-act-date  { font-size:7.5px; color:#94A3B8; flex-shrink:0; white-space:nowrap; }
 
 /* ── Footer ─────────────────────────────────────────────────────────────── */
-.hfl-footer { background:var(--lp-navy); padding:2rem; }
+.hfl-footer { background:var(--lp-navy); padding:1.5rem 2rem; }
 .hfl-footer-inner {
   display:flex; align-items:center; justify-content:space-between;
-  gap:2rem; max-width:1160px; margin:0 auto; flex-wrap:wrap;
+  gap:2rem; max-width:1160px; margin:0 auto;
 }
-.hfl-footer-left { display:flex; align-items:flex-start; gap:1rem; }
+.hfl-footer-left { display:flex; align-items:flex-start; gap:0.875rem; flex:1; min-width:0; }
 .hfl-footer-icp-logo {
-  font-size:1.75rem; color:white; flex-shrink:0;
+  font-size:2rem; flex-shrink:0;
   display:flex; align-items:center; justify-content:center;
-  width:40px; height:40px;
+  width:44px; height:44px;
 }
-.hfl-footer-icp-title {
-  font-size:0.82rem; font-weight:700; color:white; margin-bottom:2px;
-}
-.hfl-footer-icp-sub {
-  font-size:0.72rem; color:rgba(255,255,255,0.5); line-height:1.5; margin-bottom:6px;
-}
-.hfl-footer-quorum { font-size:0.72rem; color:rgba(255,255,255,0.55); }
+.hfl-footer-icp-title { font-size:0.85rem; font-weight:700; color:white; margin-bottom:3px; }
+.hfl-footer-icp-sub   { font-size:0.72rem; color:rgba(255,255,255,0.5); line-height:1.5; }
+.hfl-footer-quorum-center { text-align:center; flex-shrink:0; }
+.hfl-footer-quorum-center-title { font-size:0.82rem; color:rgba(255,255,255,0.8); margin-bottom:3px; }
+.hfl-footer-quorum-center-code  { font-size:0.78rem; color:rgba(255,255,255,0.5); }
 .hfl-footer-quorum-code {
-  font-size:0.7rem; font-weight:700; letter-spacing:0.05em;
+  font-size:0.75rem; font-weight:700; letter-spacing:0.05em;
   color:#4ADE80; background:rgba(74,222,128,0.12);
   border:1px solid rgba(74,222,128,0.3);
-  padding:1px 7px; border-radius:4px; margin-left:4px;
+  padding:1px 7px; border-radius:4px;
 }
 .hfl-footer-btn {
   font-size:0.8rem; font-weight:600; color:white;
@@ -339,7 +412,7 @@ export const CSS = `
   .hfl-nav-links { display:none; }
   .hfl-hamburger { display:flex; }
   .hfl-hero { grid-template-columns:1fr; }
-  .hfl-hero-img-wrap { display:none; }
+  .hfl-dm { display:none; }
   .hfl-trust-inner { grid-template-columns:repeat(2,1fr); }
   .hfl-trust-item:nth-child(2) { border-right:none; }
   .hfl-trust-item:nth-child(3) { border-top:1px solid var(--lp-rule); }
@@ -351,6 +424,7 @@ export const CSS = `
   .hfl-strip-col:last-child { border-bottom:none; }
   .hfl-pricing-grid { grid-template-columns:1fr 1fr; }
   .hfl-footer-inner { flex-direction:column; align-items:flex-start; }
+  .hfl-footer-quorum-center { text-align:left; }
 }
 @media(max-width:480px){
   .hfl-hero { padding:2.5rem 1rem 2rem; }

--- a/frontend/src/pages/landingStyles.ts
+++ b/frontend/src/pages/landingStyles.ts
@@ -1,1085 +1,365 @@
 export const CSS = `
-  .hfl * { margin: 0; padding: 0; box-sizing: border-box; }
-  .hfl {
-    --sage: #7AAF76; --sage-text: #3D7339; --sage-light: #E5F0E4; --sage-mid: #C4DCC2;
-    --blush: #F0CDBA; --sky: #BAD5E8; --butter: #F5E9BB;
-    --plum: #2E2540; --plum-mid: #6B5B7B; --plum-light: #3D3254;
-    --white: #FDFCFA; --charcoal: #1E1928; --rule: rgba(46,37,64,0.1);
-    background: var(--white); color: var(--charcoal);
-    font-family: 'Plus Jakarta Sans', sans-serif; overflow-x: hidden;
-  }
+/* ── Reset / Variables ──────────────────────────────────────────────────── */
+.hfl { --lp-navy:#0F172A; --lp-text:#1E293B; --lp-muted:#64748B;
+  --lp-rule:#E2E8F0; --lp-light:#F8FAFC; --lp-green:#16A34A;
+  --lp-blue:#2563EB; --lp-white:#FFFFFF;
+  font-family:'Inter','Segoe UI',system-ui,sans-serif;
+  color:var(--lp-text); background:var(--lp-white);
+}
 
-  /* ── NAV ──────────────────────────────────────────────────────────────── */
-  .hfl-nav {
-    position: fixed; top: 0; left: 0; right: 0; z-index: 100;
-    display: flex; align-items: center; justify-content: space-between;
-    padding: 0 56px; height: 70px;
-    background: rgba(253,252,250,0.96); backdrop-filter: blur(16px);
-  }
-  .hfl-logo {
-    font-family: 'Fraunces', serif; font-size: 22px; font-weight: 900;
-    color: var(--plum); text-decoration: none; letter-spacing: -0.5px; flex-shrink: 0;
-  }
-  .hfl-logo span { color: var(--sage-text); font-style: italic; font-weight: 300; }
-  .hfl-nav-links {
-    display: flex; gap: 24px; list-style: none;
-    margin-left: 32px;
-  }
-  .hfl-nav-links a {
-    font-size: 15px; color: var(--plum-mid); text-decoration: none;
-    font-weight: 500; cursor: pointer; padding: 6px 2px; border-radius: 4px;
-    transition: color .15s;
-  }
-  .hfl-nav-links a:hover { color: var(--plum); }
-  .hfl-nav-actions { display: flex; align-items: center; gap: 8px; flex-shrink: 0; }
-  .hfl-nav-signin {
-    font-size: 14px; font-weight: 600; color: var(--plum-mid);
-    background: none; border: none; cursor: pointer;
-    font-family: 'Plus Jakarta Sans', sans-serif; padding: 8px 14px;
-    transition: color .15s; border-radius: 8px;
-  }
-  .hfl-nav-signin:hover { color: var(--plum); background: rgba(46,37,64,0.05); }
-  .hfl-nav-pill {
-    display: flex; align-items: center; gap: 6px;
-    background: var(--plum); color: white; padding: 10px 22px;
-    border-radius: 100px; font-size: 14px; font-weight: 600;
-    border: none; cursor: pointer; font-family: 'Plus Jakarta Sans', sans-serif;
-    transition: transform .2s, box-shadow .2s;
-  }
-  .hfl-nav-pill:hover { transform: translateY(-1px); box-shadow: 0 6px 18px rgba(46,37,64,0.25); }
-  .hfl-hamburger {
-    display: none; background: none; border: none; cursor: pointer; padding: 4px;
-  }
-  .hfl-hamburger span {
-    display: block; width: 22px; height: 2px; background: var(--plum);
-    margin: 5px 0; border-radius: 2px; transition: transform .2s, opacity .2s;
-  }
+/* ── Nav ────────────────────────────────────────────────────────────────── */
+.hfl-nav {
+  position:sticky; top:0; z-index:100;
+  background:var(--lp-white); border-bottom:1px solid var(--lp-rule);
+  display:flex; align-items:center; justify-content:space-between;
+  padding:0 2rem; height:60px;
+}
+.hfl-logo {
+  font-size:1.1rem; font-weight:800; color:var(--lp-navy);
+  text-decoration:none; display:flex; align-items:center; gap:6px;
+  flex-shrink:0;
+}
+.hfl-logo span { color:var(--lp-green); }
+.hfl-nav-links {
+  display:flex; align-items:center; gap:0; list-style:none;
+  margin:0; padding:0;
+}
+.hfl-nav-links li a {
+  font-size:0.82rem; font-weight:500; color:var(--lp-text);
+  text-decoration:none; padding:0.5rem 0.75rem; cursor:pointer;
+  white-space:nowrap; transition:color 0.15s;
+}
+.hfl-nav-links li a:hover { color:var(--lp-blue); }
+.hfl-nav-actions {
+  display:flex; align-items:center; gap:0.5rem; flex-shrink:0;
+}
+.hfl-nav-signin {
+  font-size:0.82rem; font-weight:500; color:var(--lp-text);
+  background:none; border:none; padding:0.4rem 0.75rem; cursor:pointer;
+}
+.hfl-nav-signin:hover { color:var(--lp-blue); }
+.hfl-nav-pill {
+  font-size:0.82rem; font-weight:600; color:white;
+  background:var(--lp-blue); border:none;
+  padding:0.45rem 1rem; border-radius:6px; cursor:pointer;
+  transition:opacity 0.15s;
+}
+.hfl-nav-pill:hover { opacity:0.9; }
+.hfl-hamburger {
+  display:none; flex-direction:column; gap:4px; background:none;
+  border:none; cursor:pointer; padding:6px;
+}
+.hfl-hamburger span {
+  display:block; width:20px; height:2px;
+  background:var(--lp-text); border-radius:2px;
+  transition:transform 0.2s, opacity 0.2s;
+}
 
-  /* ── HERO ─────────────────────────────────────────────────────────────── */
-  .hfl-hero {
-    min-height: 100vh; padding: 70px 56px 0;
-    display: grid; grid-template-columns: 1fr 1.4fr; gap: 48px;
-    align-items: center; position: relative; overflow: hidden;
-  }
-  .hfl-hero::before {
-    content: ''; position: absolute; top: -10%; right: -8%; width: 54%; height: 110%;
-    pointer-events: none; z-index: 0;
-    background: radial-gradient(ellipse at 65% 35%, var(--sage-light) 0%, var(--sage-mid) 28%, var(--sky) 55%, transparent 70%);
-    opacity: 0.6;
-  }
-  .hfl-hero-left { position: relative; z-index: 1; padding-bottom: 56px; }
-  .hfl-eyebrow {
-    display: inline-flex; align-items: center; gap: 10px;
-    background: var(--butter); color: var(--plum); padding: 7px 18px;
-    border-radius: 100px; font-size: 13px; font-weight: 600; margin-bottom: 28px;
-    border: 1px solid rgba(46,37,64,0.1);
-    animation: hfl-fadeUp .5s ease both;
-  }
-  .hfl-dot {
-    width: 8px; height: 8px; background: var(--sage); border-radius: 50%;
-    animation: hfl-pulse 2s infinite;
-  }
-  @keyframes hfl-pulse { 0%,100%{transform:scale(1);opacity:1} 50%{transform:scale(1.4);opacity:0.7} }
-  .hfl h1 {
-    font-family: 'Fraunces', serif;
-    font-size: clamp(52px, 6vw, 84px);
-    font-weight: 900; line-height: 1.01; letter-spacing: -2.5px; margin-bottom: 24px;
-    animation: hfl-fadeUp .5s .1s ease both;
-  }
-  .hfl h1 em { font-style: italic; color: var(--sage-text); font-weight: 300; }
-  .hfl-sub {
-    font-size: 18px; line-height: 1.75; color: var(--plum-mid);
-    max-width: 480px; margin-bottom: 40px;
-    animation: hfl-fadeUp .5s .2s ease both;
-  }
-  .hfl-actions {
-    display: flex; gap: 14px; align-items: center; flex-wrap: wrap; margin-bottom: 44px;
-    animation: hfl-fadeUp .5s .3s ease both;
-  }
-  .hfl-btn-main {
-    background: var(--plum); color: white; padding: 17px 38px; border-radius: 100px;
-    font-size: 16px; font-weight: 700; border: none; cursor: pointer;
-    font-family: 'Plus Jakarta Sans', sans-serif;
-    transition: transform .2s, box-shadow .2s;
-  }
-  .hfl-btn-main:hover { transform: translateY(-3px); box-shadow: 0 14px 36px rgba(46,37,64,0.28); }
-  .hfl-btn-soft {
-    background: transparent; color: var(--plum); padding: 17px 30px; border-radius: 100px;
-    font-size: 16px; font-weight: 600; cursor: pointer;
-    font-family: 'Plus Jakarta Sans', sans-serif;
-    border: 2px solid var(--sage-mid); transition: border-color .2s, background .2s;
-  }
-  .hfl-btn-soft:hover { border-color: var(--sage); background: var(--sage-light); }
-  .hfl-hero-trust {
-    display: flex; align-items: center; gap: 10px; flex-wrap: wrap;
-    animation: hfl-fadeUp .5s .4s ease both;
-  }
-  .hfl-hero-trust-lbl { font-size: 13px; color: var(--plum-mid); font-weight: 500; }
-  .hfl-hero-city {
-    display: flex; align-items: center; gap: 5px;
-    background: white; border: 1px solid var(--rule); border-radius: 100px;
-    padding: 5px 14px; font-size: 12px; font-weight: 700; color: var(--plum);
-    box-shadow: 0 2px 8px rgba(46,37,64,0.06);
-  }
+/* ── Hero ───────────────────────────────────────────────────────────────── */
+.hfl-hero {
+  display:grid; grid-template-columns:1fr 1fr;
+  align-items:center; gap:3rem;
+  padding:4rem 2rem 3rem; max-width:1160px; margin:0 auto;
+}
+.hfl-hero-badge {
+  display:inline-flex; align-items:center; gap:6px;
+  font-size:0.65rem; font-weight:700; letter-spacing:0.1em;
+  text-transform:uppercase; color:#1E40AF;
+  background:#EFF6FF; border:1px solid #BFDBFE;
+  padding:4px 12px; border-radius:100px; margin-bottom:1.25rem;
+}
+.hfl-hero h1 {
+  font-size:clamp(2rem,4vw,2.75rem); font-weight:800; line-height:1.15;
+  color:var(--lp-navy); margin:0 0 1rem;
+}
+.hfl-hero h1 .green { color:var(--lp-green); }
+.hfl-hero p {
+  font-size:1rem; color:var(--lp-muted); line-height:1.7;
+  max-width:480px; margin:0 0 1.75rem;
+}
+.hfl-actions {
+  display:flex; align-items:center; gap:0.75rem; flex-wrap:wrap;
+}
+.hfl-btn-main {
+  font-size:0.9rem; font-weight:600; color:white;
+  background:var(--lp-blue); border:none;
+  padding:0.65rem 1.5rem; border-radius:8px; cursor:pointer;
+  transition:opacity 0.15s;
+}
+.hfl-btn-main:hover { opacity:0.9; }
+.hfl-btn-soft {
+  font-size:0.9rem; font-weight:500; color:var(--lp-text);
+  background:none; border:1.5px solid var(--lp-rule);
+  padding:0.62rem 1.25rem; border-radius:8px; cursor:pointer;
+  display:flex; align-items:center; gap:6px;
+  transition:border-color 0.15s;
+}
+.hfl-btn-soft:hover { border-color:#94A3B8; }
+.hfl-hero-img-wrap {
+  border-radius:12px; overflow:hidden;
+  box-shadow:0 20px 60px rgba(0,0,0,0.12);
+}
+.hfl-hero-img { display:block; width:100%; height:auto; }
 
-  /* HERO VISUAL */
-  .hfl-hero-right {
-    position: relative; z-index: 1; display: flex; align-items: center;
-    justify-content: center; padding: 40px 0;
-  }
-  .hfl-hero-img {
-    width: 100%; height: auto; display: block;
-    mix-blend-mode: multiply;
-  }
-  .hfl-blob-wrap {
-    position: relative; width: 440px; height: 500px;
-    display: flex; align-items: center; justify-content: center;
-    animation: hfl-fadeUp .7s .15s ease both;
-  }
-  .hfl-blob-bg {
-    position: absolute; inset: 0;
-    background: radial-gradient(circle at 35% 45%, var(--blush) 0%, var(--butter) 40%, var(--sky) 80%);
-    border-radius: 58% 42% 52% 48% / 46% 54% 46% 54%;
-    animation: hfl-morph 9s ease-in-out infinite;
-  }
-  @keyframes hfl-morph {
-    0%,100%{border-radius:58% 42% 52% 48%/46% 54% 46% 54%}
-    33%{border-radius:40% 60% 60% 40%/60% 38% 62% 40%}
-    66%{border-radius:52% 48% 42% 58%/48% 58% 42% 52%}
-  }
-  .hfl-dash-card {
-    position: relative; z-index: 2; background: white; width: 340px;
-    box-shadow: 0 32px 80px rgba(46,37,64,0.2); overflow: hidden;
-    border: 1px solid var(--rule);
-  }
-  .hfl-dc-header { background: var(--plum); padding: 20px 24px; }
-  .hfl-dc-top { display: flex; align-items: center; justify-content: space-between; margin-bottom: 12px; }
-  .hfl-dc-title { font-family: 'Fraunces', serif; font-size: 15px; font-weight: 700; color: white; }
-  .hfl-dc-ver {
-    display: flex; align-items: center; gap: 5px;
-    background: rgba(122,175,118,0.3); border: 1px solid rgba(122,175,118,0.5);
-    border-radius: 100px; padding: 4px 10px; font-size: 10px; color: #A8DCA5; font-weight: 600; letter-spacing: 0.5px;
-  }
-  .hfl-dc-addr { font-size: 12px; color: rgba(255,255,255,0.6); }
-  .hfl-dc-score-row { display: flex; align-items: center; gap: 14px; margin-top: 12px; }
-  .hfl-dc-num { font-family: 'Fraunces', serif; font-size: 44px; font-weight: 900; color: var(--sage); line-height: 1; }
-  .hfl-dc-score-lbl { font-size: 10px; color: rgba(255,255,255,0.5); text-transform: uppercase; letter-spacing: 1px; margin-bottom: 2px; }
-  .hfl-dc-bar-wrap { flex: 1; height: 6px; background: rgba(255,255,255,0.15); border-radius: 100px; overflow: hidden; }
-  .hfl-dc-bar { height: 100%; width: 91%; background: linear-gradient(90deg, var(--sage), #A8E8A0); border-radius: 100px; }
-  .hfl-dc-body { padding: 18px 22px; }
-  .hfl-dc-sec-lbl { font-size: 10px; font-weight: 700; letter-spacing: 2px; text-transform: uppercase; color: var(--plum-mid); margin-bottom: 12px; }
-  .hfl-dc-items { display: flex; flex-direction: column; gap: 8px; margin-bottom: 16px; }
-  .hfl-dc-item { display: flex; align-items: center; justify-content: space-between; padding: 9px 12px; background: var(--sage-light); border-radius: 10px; font-size: 12px; }
-  .hfl-dc-item-l { display: flex; align-items: center; gap: 8px; color: var(--plum); font-weight: 500; }
-  .hfl-status-done { font-size: 11px; font-weight: 600; color: var(--sage-text); }
-  .hfl-status-due  { font-size: 11px; font-weight: 600; color: #D4843A; }
-  .hfl-status-ok   { font-size: 11px; font-weight: 600; color: var(--plum-mid); }
-  .hfl-dc-ver-row {
-    background: var(--sage-light); border: 1px solid var(--sage-mid);
-    border-radius: 10px; padding: 10px 12px; display: flex; align-items: center; gap: 10px;
-  }
-  .hfl-dc-ver-text { font-size: 11px; line-height: 1.4; color: var(--plum-mid); }
-  .hfl-dc-ver-text strong { color: var(--plum); }
-  .hfl-badge {
-    position: absolute; z-index: 3; background: white;
-    box-shadow: 0 8px 28px rgba(46,37,64,0.14); padding: 11px 16px;
-    display: flex; align-items: center; gap: 8px; font-size: 12px; font-weight: 700; color: var(--plum);
-    white-space: nowrap; border: 1px solid var(--rule);
-  }
-  .hfl-badge-1 { top: 8%; right: -20px; }
-  .hfl-badge-2 { bottom: 12%; left: -24px; }
-  .hfl-badge-icon { font-size: 18px; }
+/* ── Trust Badges ───────────────────────────────────────────────────────── */
+.hfl-trust {
+  background:var(--lp-light); border-top:1px solid var(--lp-rule);
+  border-bottom:1px solid var(--lp-rule);
+}
+.hfl-trust-inner {
+  display:grid; grid-template-columns:repeat(4,1fr);
+  max-width:1160px; margin:0 auto;
+}
+.hfl-trust-item {
+  display:flex; align-items:flex-start; gap:0.75rem;
+  padding:1.25rem 1.5rem; border-right:1px solid var(--lp-rule);
+}
+.hfl-trust-item:last-child { border-right:none; }
+.hfl-trust-icon {
+  width:36px; height:36px; border-radius:8px;
+  display:flex; align-items:center; justify-content:center;
+  font-size:1.1rem; flex-shrink:0;
+}
+.hfl-trust-text-title {
+  font-size:0.82rem; font-weight:700; color:var(--lp-navy); margin-bottom:2px;
+}
+.hfl-trust-text-sub {
+  font-size:0.74rem; color:var(--lp-muted); line-height:1.5;
+}
 
-  /* ── TRUST STRIP ──────────────────────────────────────────────────────── */
-  .hfl-trust-strip {
-    padding: 20px 56px; border-top: 1px solid var(--rule); border-bottom: 1px solid var(--rule);
-    display: flex; align-items: center; gap: 28px;
-    background: rgba(122,175,118,0.04);
-  }
-  .hfl-trust-label {
-    font-size: 11px; font-weight: 700; color: var(--plum-mid); letter-spacing: 1.5px;
-    text-transform: uppercase; white-space: nowrap; flex-shrink: 0;
-  }
-  .hfl-trust-divider { width: 1px; height: 20px; background: var(--rule); flex-shrink: 0; }
-  .hfl-trust-cities { display: flex; flex: 1; }
-  .hfl-trust-city {
-    font-size: 13px; font-weight: 600; color: var(--plum); padding: 0 18px;
-    border-right: 1px solid var(--rule); white-space: nowrap;
-  }
-  .hfl-trust-city:first-child { padding-left: 0; }
-  .hfl-trust-city:last-child { border-right: none; }
-  .hfl-trust-rating {
-    margin-left: auto; display: flex; align-items: center; gap: 8px;
-    font-size: 13px; font-weight: 700; color: var(--plum); flex-shrink: 0;
-  }
-  .hfl-trust-stars { color: #F4B942; letter-spacing: 1px; }
+/* ── Roles ──────────────────────────────────────────────────────────────── */
+.hfl-roles { padding:4rem 2rem; background:var(--lp-white); }
+.hfl-section-header { text-align:center; margin-bottom:2.5rem; }
+.hfl-section-header h2 {
+  font-size:clamp(1.4rem,3vw,1.85rem); font-weight:700;
+  color:var(--lp-navy); margin:0;
+}
+.hfl-roles-grid {
+  display:grid; grid-template-columns:repeat(3,1fr);
+  gap:1.5rem; max-width:960px; margin:0 auto;
+}
+.hfl-role-card {
+  border:1px solid var(--lp-rule); border-radius:10px; padding:1.5rem;
+}
+.hfl-role-icon {
+  width:44px; height:44px; border-radius:10px;
+  display:flex; align-items:center; justify-content:center;
+  font-size:1.3rem; margin-bottom:0.875rem;
+}
+.hfl-role-title {
+  font-size:0.95rem; font-weight:700; color:var(--lp-navy); margin-bottom:0.5rem;
+}
+.hfl-role-desc {
+  font-size:0.82rem; color:var(--lp-muted); line-height:1.6; margin-bottom:0.875rem;
+}
+.hfl-role-link {
+  font-size:0.8rem; font-weight:600; color:var(--lp-blue);
+  text-decoration:none; cursor:pointer; background:none; border:none; padding:0;
+}
+.hfl-role-link:hover { text-decoration:underline; }
 
-  /* ── HOW IT WORKS ─────────────────────────────────────────────────────── */
-  .hfl-how { padding: 9px 56px 100px; display: flex; flex-direction: column; align-items: center; }
-  .hfl-section-header { max-width: 600px; margin-bottom: 72px; }
-  .hfl-how > .hfl-section-header { padding-left: 0; text-align: center; margin-left: auto; margin-right: auto; }
-  .hfl-kicker {
-    font-size: 12px; font-weight: 700; color: var(--sage-text);
-    letter-spacing: 2px; text-transform: uppercase; margin-bottom: 16px;
-  }
-  .hfl h2 {
-    font-family: 'Fraunces', serif; font-size: clamp(36px, 4.5vw, 56px);
-    font-weight: 900; letter-spacing: -1.5px; line-height: 1.04; margin-bottom: 18px;
-    color: var(--plum);
-  }
-  .hfl h2 em { font-style: italic; font-weight: 300; color: var(--sage-text); }
-  .hfl-feat-2 .hfl-feat-text h2 em { color: var(--sage); }
-  .hfl-sec-sub { font-size: 17px; color: var(--plum-mid); line-height: 1.7; }
-  .hfl-flow { display: grid; grid-template-columns: repeat(4, 1fr); gap: 0 24px; position: relative; width: 100%; }
-  .hfl-flow::before {
-    content: ''; position: absolute;
-    top: 110px; left: 12.5%; right: 12.5%;
-    height: 2px; background: var(--sage); z-index: 0;
-  }
-  .hfl-step { text-align: center; position: relative; z-index: 1; padding: 0 8px; }
-  .hfl-step-num {
-    position: absolute; top: -14px; left: 50%; transform: translateX(-50%);
-    font-size: 14px; font-weight: 800; letter-spacing: 1px; color: white;
-    background: var(--sage); border-radius: 100px; padding: 4px 12px; z-index: 2;
-  }
-  .hfl-step-icon {
-    width: 220px; height: 220px; margin: 0 auto 20px;
-    position: relative; z-index: 1;
-  }
-  .hfl-step-icon img {
-    width: 100%; height: 100%; object-fit: contain; display: block;
-  }
-  .hfl-step h3 {
-    font-family: 'Fraunces', serif; font-size: 20px; font-weight: 700;
-    margin-bottom: 10px; color: var(--plum);
-  }
-  .hfl-step p { font-size: 14px; color: var(--plum-mid); line-height: 1.65; }
+/* ── Features Grid ──────────────────────────────────────────────────────── */
+.hfl-features {
+  padding:4rem 2rem; background:var(--lp-light);
+  border-top:1px solid var(--lp-rule);
+}
+.hfl-features-grid {
+  display:grid; grid-template-columns:repeat(4,1fr);
+  gap:1rem; max-width:1160px; margin:0 auto;
+}
+.hfl-feat-card {
+  background:var(--lp-white); border:1px solid var(--lp-rule);
+  border-radius:10px; padding:1.25rem;
+}
+.hfl-feat-icon {
+  width:38px; height:38px; border-radius:8px;
+  display:flex; align-items:center; justify-content:center;
+  font-size:1.1rem; margin-bottom:0.75rem;
+}
+.hfl-feat-title {
+  font-size:0.85rem; font-weight:700; color:var(--lp-navy); margin-bottom:0.35rem;
+}
+.hfl-feat-desc { font-size:0.75rem; color:var(--lp-muted); line-height:1.55; }
 
-  /* ── FEATURE SECTIONS ─────────────────────────────────────────────────── */
-  .hfl-feat {
-    padding: 100px 56px;
-    display: grid; grid-template-columns: 1fr 1fr; gap: 72px; align-items: center;
-  }
-  .hfl-feat-2 { background: var(--plum); }
-  .hfl-feat-2 .hfl-feat-text { order: 2; }
-  .hfl-feat-2 .hfl-feat-visual { order: 1; }
-  .hfl-feat-eyebrow {
-    display: inline-flex; align-items: center; gap: 8px;
-    background: var(--butter); color: var(--plum); padding: 6px 16px;
-    border-radius: 100px; font-size: 12px; font-weight: 700; letter-spacing: 0.5px;
-    margin-bottom: 24px; border: 1px solid rgba(46,37,64,0.1);
-  }
-  .hfl-feat-2 .hfl-feat-eyebrow {
-    background: rgba(122,175,118,0.2); color: var(--sage); border-color: rgba(122,175,118,0.3);
-  }
-  .hfl-feat-text h2 { color: var(--plum); margin-bottom: 20px; }
-  .hfl-feat-2 .hfl-feat-text h2 { color: white; }
-  .hfl-feat-lead {
-    font-size: 17px; color: var(--plum-mid); line-height: 1.75; margin-bottom: 32px;
-  }
-  .hfl-feat-2 .hfl-feat-lead { color: rgba(253,252,250,0.65); }
-  .hfl-feat-checklist {
-    list-style: none; display: flex; flex-direction: column; gap: 12px; margin-bottom: 38px;
-  }
-  .hfl-feat-checklist li {
-    display: flex; align-items: flex-start; gap: 12px;
-    font-size: 15px; color: var(--plum); line-height: 1.5;
-  }
-  .hfl-feat-2 .hfl-feat-checklist li { color: rgba(253,252,250,0.85); }
-  .hfl-feat-check {
-    width: 22px; height: 22px; background: var(--sage-light); border-radius: 50%;
-    display: flex; align-items: center; justify-content: center;
-    font-size: 11px; color: var(--sage-text); flex-shrink: 0; margin-top: 1px; font-weight: 700;
-  }
-  .hfl-feat-2 .hfl-feat-check { color: var(--sage); }
-  .hfl-feat-2 .hfl-feat-check { background: rgba(122,175,118,0.25); }
-  .hfl-feat-cta {
-    display: inline-flex; align-items: center; gap: 8px;
-    font-size: 15px; font-weight: 700; color: var(--plum);
-    border: 2px solid var(--plum); border-radius: 100px; padding: 14px 28px;
-    cursor: pointer; background: transparent; font-family: 'Plus Jakarta Sans', sans-serif;
-    transition: background .2s, color .2s;
-  }
-  .hfl-feat-cta:hover { background: var(--plum); color: white; }
-  .hfl-feat-2 .hfl-feat-cta { border-color: var(--sage); color: var(--sage); }
-  .hfl-feat-2 .hfl-feat-cta:hover { background: var(--sage); color: var(--plum); }
+/* ── Trust Strip ────────────────────────────────────────────────────────── */
+.hfl-strip {
+  background:var(--lp-light);
+  border-top:1px solid var(--lp-rule); border-bottom:1px solid var(--lp-rule);
+  padding:0;
+}
+.hfl-strip-inner {
+  display:grid; grid-template-columns:repeat(3,1fr);
+  max-width:960px; margin:0 auto;
+}
+.hfl-strip-col {
+  display:flex; align-items:flex-start; gap:0.875rem;
+  padding:1.5rem; border-right:1px solid var(--lp-rule);
+}
+.hfl-strip-col:last-child { border-right:none; }
+.hfl-strip-logo {
+  width:40px; height:40px; flex-shrink:0;
+  display:flex; align-items:center; justify-content:center; font-size:1.4rem;
+}
+.hfl-strip-title {
+  font-size:0.82rem; font-weight:700; color:var(--lp-navy); margin-bottom:0.3rem;
+}
+.hfl-strip-desc {
+  font-size:0.75rem; color:var(--lp-muted); line-height:1.55; margin-bottom:0.3rem;
+}
+.hfl-strip-link {
+  font-size:0.75rem; font-weight:600; color:var(--lp-blue);
+  background:none; border:none; padding:0; cursor:pointer;
+}
+.hfl-strip-link:hover { text-decoration:underline; }
+.hfl-strip-code {
+  display:inline-block; font-size:0.7rem; font-weight:700; letter-spacing:0.05em;
+  color:var(--lp-green); background:#F0FDF4; border:1px solid #BBF7D0;
+  padding:2px 8px; border-radius:4px; margin-top:3px;
+}
 
-  /* Feature visual panels */
-  .hfl-feat-panel {
-    background: white; overflow: hidden;
-    box-shadow: 0 32px 80px rgba(46,37,64,0.14);
-    border: 1px solid var(--rule);
-  }
-  .hfl-feat-2 .hfl-feat-panel {
-    background: rgba(253,252,250,0.06); border: 1px solid rgba(253,252,250,0.12);
-    box-shadow: none;
-  }
-  /* Record panel */
-  .hfl-rec-hdr { background: var(--plum); padding: 22px 26px; }
-  .hfl-rec-hdr-top { display: flex; align-items: center; justify-content: space-between; margin-bottom: 8px; }
-  .hfl-rec-title { font-family: 'Fraunces', serif; font-size: 16px; font-weight: 700; color: white; }
-  .hfl-rec-verified { display: flex; align-items: center; gap: 5px; background: rgba(122,175,118,0.3); border: 1px solid rgba(122,175,118,0.5); border-radius: 100px; padding: 3px 10px; font-size: 10px; color: #A8DCA5; font-weight: 700; }
-  .hfl-rec-addr { font-size: 12px; color: rgba(255,255,255,0.55); }
-  .hfl-rec-score-row { display: flex; align-items: center; gap: 14px; margin-top: 14px; }
-  .hfl-rec-score-num { font-family: 'Fraunces', serif; font-size: 48px; font-weight: 900; color: var(--sage); line-height: 1; }
-  .hfl-rec-score-right { flex: 1; }
-  .hfl-rec-score-lbl { font-size: 10px; color: rgba(255,255,255,0.5); text-transform: uppercase; letter-spacing: 1px; margin-bottom: 4px; }
-  .hfl-rec-bar-wrap { height: 6px; background: rgba(255,255,255,0.15); border-radius: 100px; overflow: hidden; }
-  .hfl-rec-bar { height: 100%; width: 91%; background: linear-gradient(90deg, var(--sage), #A8E8A0); border-radius: 100px; }
-  .hfl-rec-body { padding: 20px 26px; }
-  .hfl-rec-section-lbl { font-size: 10px; font-weight: 700; letter-spacing: 2px; text-transform: uppercase; color: var(--plum-mid); margin-bottom: 12px; }
-  .hfl-rec-items { display: flex; flex-direction: column; gap: 8px; margin-bottom: 16px; }
-  .hfl-rec-item { display: flex; align-items: center; justify-content: space-between; padding: 10px 14px; background: var(--sage-light); border-radius: 10px; font-size: 12px; }
-  .hfl-rec-item-l { display: flex; align-items: center; gap: 8px; color: var(--plum); font-weight: 600; }
-  .hfl-rec-pass { font-size: 11px; font-weight: 700; color: var(--sage-text); }
-  .hfl-rec-due { font-size: 11px; font-weight: 700; color: #D4843A; }
-  .hfl-rec-footer { padding: 14px 26px; background: var(--sage-light); border-top: 1px solid var(--sage-mid); font-size: 11px; color: var(--plum-mid); font-weight: 600; display: flex; align-items: center; gap: 8px; }
-  /* AI panel */
-  .hfl-ai-panel-hdr {
-    background: rgba(46,37,64,0.04); padding: 16px 22px;
-    display: flex; align-items: center; justify-content: space-between;
-    border-bottom: 1px solid rgba(46,37,64,0.1);
-  }
-  .hfl-ai-panel-hdr-l { display: flex; align-items: center; gap: 10px; }
-  .hfl-ai-panel-name { font-size: 14px; font-weight: 700; color: var(--plum); }
-  .hfl-ai-panel-live { display: flex; align-items: center; gap: 5px; font-size: 11px; color: var(--sage-text); font-weight: 600; }
-  .hfl-ai-panel-dot { width: 6px; height: 6px; background: var(--sage); border-radius: 50%; animation: hfl-pulse 2s infinite; }
-  .hfl-ai-panel-body { padding: 22px; display: flex; flex-direction: column; gap: 16px; }
-  .hfl-ai-notice {
-    background: var(--butter); border: 1px solid rgba(200,160,80,0.3);
-    border-radius: 14px; padding: 16px;
-  }
-  .hfl-ai-notice-tag { font-size: 10px; font-weight: 700; color: var(--plum); letter-spacing: 1.5px; text-transform: uppercase; margin-bottom: 8px; display: flex; align-items: center; gap: 6px; }
-  .hfl-ai-notice p { font-size: 13px; color: var(--plum); line-height: 1.6; margin-bottom: 12px; }
-  .hfl-ai-notice-btn { background: var(--sage); color: var(--plum); font-size: 12px; font-weight: 700; padding: 7px 16px; border-radius: 100px; border: none; cursor: pointer; font-family: 'Plus Jakarta Sans', sans-serif; }
-  .hfl-ai-user-msg { display: flex; align-items: flex-start; gap: 10px; }
-  .hfl-ai-user-icon { width: 30px; height: 30px; background: rgba(46,37,64,0.08); border-radius: 50%; display: flex; align-items: center; justify-content: center; font-size: 14px; flex-shrink: 0; margin-top: 2px; }
-  .hfl-ai-user-msg p { font-size: 13px; color: var(--plum-mid); line-height: 1.55; font-style: italic; }
-  .hfl-ai-reply { background: var(--sage-light); border-radius: 14px; padding: 14px 16px; }
-  .hfl-ai-reply-tag { font-size: 10px; font-weight: 700; color: var(--sage-text); letter-spacing: 1.5px; text-transform: uppercase; margin-bottom: 8px; }
-  .hfl-ai-reply p { font-size: 13px; color: var(--plum); line-height: 1.6; }
-  .hfl-ai-panel-footer {
-    padding: 14px 22px; border-top: 1px solid rgba(46,37,64,0.1);
-    display: flex; align-items: center; gap: 12px;
-  }
-  .hfl-ai-mic { width: 40px; height: 40px; background: var(--sage); border-radius: 50%; flex-shrink: 0; display: flex; align-items: center; justify-content: center; font-size: 16px; box-shadow: 0 0 0 8px rgba(122,175,118,0.15); }
-  .hfl-ai-mic-hint { font-size: 12px; color: var(--plum-mid); }
-  /* Agent compete panel */
-  .hfl-compete-hdr { background: var(--plum); padding: 22px 26px; }
-  .hfl-compete-title { font-family: 'Fraunces', serif; font-size: 16px; font-weight: 700; color: white; margin-bottom: 4px; }
-  .hfl-compete-sub { font-size: 12px; color: rgba(255,255,255,0.5); }
-  .hfl-compete-body { padding: 20px 26px; display: flex; flex-direction: column; gap: 12px; }
-  .hfl-compete-agent {
-    background: var(--sage-light); border-radius: 14px; padding: 14px 16px;
-    display: flex; align-items: center; gap: 14px;
-  }
-  .hfl-compete-agent-featured {
-    background: var(--butter); border: 2px solid rgba(46,37,64,0.12);
-  }
-  .hfl-compete-avi { width: 40px; height: 40px; border-radius: 50%; background: white; overflow: hidden; flex-shrink: 0; }
-  .hfl-compete-avi img { width: 100%; height: 100%; object-fit: cover; display: block; }
-  .hfl-compete-info { flex: 1; }
-  .hfl-compete-name { font-size: 13px; font-weight: 700; color: var(--plum); margin-bottom: 2px; }
-  .hfl-compete-detail { font-size: 11px; color: var(--plum-mid); line-height: 1.4; }
-  .hfl-compete-comm { font-family: 'Fraunces', serif; font-size: 22px; font-weight: 900; color: var(--plum); flex-shrink: 0; }
-  .hfl-compete-best {
-    display: inline-flex; align-items: center; gap: 4px; margin-top: 4px;
-    background: var(--sage); color: var(--plum); font-size: 10px; font-weight: 700;
-    padding: 3px 8px; border-radius: 100px;
-  }
-  .hfl-compete-footer { padding: 14px 26px; background: var(--sage-light); border-top: 1px solid var(--sage-mid); font-size: 11px; color: var(--plum-mid); font-weight: 600; display: flex; align-items: center; gap: 8px; }
+/* ── Integrations ───────────────────────────────────────────────────────── */
+.hfl-integrations {
+  padding:2.5rem 2rem; background:var(--lp-white);
+  border-bottom:1px solid var(--lp-rule);
+}
+.hfl-integrations h3 {
+  text-align:center; font-size:0.78rem; font-weight:600;
+  color:var(--lp-muted); text-transform:uppercase; letter-spacing:0.08em;
+  margin:0 0 1.5rem;
+}
+.hfl-integ-logos {
+  display:flex; align-items:center; justify-content:center;
+  gap:2.5rem; flex-wrap:wrap; max-width:900px; margin:0 auto;
+}
+.hfl-integ-logo {
+  font-size:0.82rem; font-weight:700; color:#94A3B8; white-space:nowrap;
+}
 
-  /* ── REPORT CTA ───────────────────────────────────────────────────────── */
-  .hfl-report { padding: 0 56px 100px; }
-  .hfl-report-card {
-    display: flex; align-items: stretch; min-height: 480px;
-    border: 1px solid var(--rule); overflow: hidden; background: white;
-  }
-  .hfl-report-img-col { flex: 0 0 60%; }
-  .hfl-report-img-col img { width: 100%; height: 100%; object-fit: cover; display: block; }
-  .hfl-report-body {
-    flex: 1; padding: 52px 48px; display: flex; flex-direction: column; justify-content: center;
-  }
-  .hfl-rc-label { font-size: 11px; font-weight: 700; letter-spacing: 3px; text-transform: uppercase; color: var(--plum); margin-bottom: 18px; }
-  .hfl-report h2 { color: var(--plum); margin-bottom: 18px; }
-  .hfl-report h2 em { color: var(--sage-text); font-style: italic; font-weight: 300; }
-  .hfl-report p { font-size: 16px; color: rgba(46,37,64,0.7); line-height: 1.7; margin-bottom: 36px; }
-  .hfl-rc-actions { display: flex; gap: 14px; flex-wrap: wrap; }
-  .hfl-rc-btn {
-    background: var(--plum); color: white; padding: 16px 32px; border-radius: 100px;
-    font-weight: 700; font-size: 15px; border: none; cursor: pointer;
-    font-family: 'Plus Jakarta Sans', sans-serif; transition: transform .2s, box-shadow .2s;
-  }
-  .hfl-rc-btn:hover { transform: translateY(-2px); box-shadow: 0 10px 24px rgba(46,37,64,0.3); }
-  .hfl-rc-ghost {
-    background: rgba(46,37,64,0.08); color: var(--plum); padding: 16px 24px; border-radius: 100px;
-    font-weight: 600; font-size: 15px; border: 1px solid rgba(46,37,64,0.2); cursor: pointer;
-    font-family: 'Plus Jakarta Sans', sans-serif; transition: background .2s;
-  }
-  .hfl-rc-ghost:hover { background: rgba(46,37,64,0.14); }
+/* ── Pricing ────────────────────────────────────────────────────────────── */
+.hfl-pricing { padding:5rem 2rem; background:var(--lp-white); }
+.hfl-pricing-header { text-align:center; margin-bottom:3rem; }
+.hfl-pricing-header h2 {
+  font-size:clamp(1.4rem,3vw,1.85rem); font-weight:700;
+  color:var(--lp-navy); margin:0 0 0.5rem;
+}
+.hfl-pricing-header p { font-size:0.9rem; color:var(--lp-muted); margin:0; }
+.hfl-pricing-grid {
+  display:grid; grid-template-columns:repeat(5,1fr);
+  gap:1rem; max-width:1160px; margin:0 auto 1.25rem;
+}
+.hfl-plan-card {
+  border:1.5px solid var(--lp-rule); border-radius:10px;
+  padding:1.5rem 1.25rem; position:relative;
+}
+.hfl-plan-card.hfl-plan-featured {
+  border-color:var(--lp-blue); box-shadow:0 0 0 3px rgba(37,99,235,0.1);
+}
+.hfl-plan-badge {
+  position:absolute; top:-12px; left:50%; transform:translateX(-50%);
+  font-size:0.62rem; font-weight:700; letter-spacing:0.06em;
+  text-transform:uppercase; color:white; background:var(--lp-blue);
+  padding:3px 10px; border-radius:100px; white-space:nowrap;
+}
+.hfl-plan-tier {
+  font-size:0.78rem; font-weight:700; color:var(--lp-blue);
+  text-transform:uppercase; letter-spacing:0.06em; margin-bottom:0.25rem;
+}
+.hfl-plan-sub { font-size:0.72rem; color:var(--lp-muted); margin-bottom:0.875rem; }
+.hfl-plan-price {
+  font-size:1.75rem; font-weight:800; color:var(--lp-navy);
+  margin-bottom:0.25rem; line-height:1;
+}
+.hfl-plan-price span { font-size:0.9rem; font-weight:500; color:var(--lp-muted); }
+.hfl-plan-features {
+  list-style:none; padding:0; margin:0.875rem 0 1.25rem;
+  display:flex; flex-direction:column; gap:0.4rem;
+}
+.hfl-plan-features li {
+  font-size:0.75rem; color:var(--lp-text);
+  display:flex; align-items:flex-start; gap:5px;
+}
+.hfl-plan-features li::before {
+  content:"✓"; color:var(--lp-green); font-weight:700; flex-shrink:0;
+}
+.hfl-plan-cta {
+  width:100%; font-size:0.8rem; font-weight:600;
+  padding:0.55rem; border-radius:6px; cursor:pointer;
+  border:1.5px solid var(--lp-rule); background:var(--lp-white); color:var(--lp-navy);
+  transition:background 0.15s;
+}
+.hfl-plan-featured .hfl-plan-cta {
+  background:var(--lp-blue); border-color:var(--lp-blue); color:white;
+}
+.hfl-plan-cta:hover { background:var(--lp-light); }
+.hfl-plan-featured .hfl-plan-cta:hover { opacity:0.9; background:var(--lp-blue); }
+.hfl-pricing-guarantee {
+  text-align:center; font-size:0.8rem; color:var(--lp-muted);
+  display:flex; align-items:center; justify-content:center; gap:0.4rem;
+}
 
-  /* ── FEATURE DEEP DIVE ───────────────────────────────────────────────── */
-  .hfl-fdd { padding: 0 56px 100px; }
-  .hfl-fdd-inner {
-    background: var(--sage-light);
-    border: 1px solid var(--sage-mid);
-    padding: 64px 72px 40px;
-    position: relative; overflow: hidden;
-    display: grid; grid-template-columns: 340px 1fr; gap: 72px; align-items: start;
-  }
-  .hfl-fdd-inner::before {
-    content: "";
-    position: absolute; top: -100px; right: -100px;
-    width: 480px; height: 480px; border-radius: 50%;
-    background: radial-gradient(circle, rgba(122,175,118,0.25) 0%, transparent 65%);
-    pointer-events: none;
-  }
-  .hfl-fdd-inner::after {
-    content: "";
-    position: absolute; bottom: -80px; left: -80px;
-    width: 320px; height: 320px; border-radius: 50%;
-    background: radial-gradient(circle, rgba(186,213,232,0.18) 0%, transparent 65%);
-    pointer-events: none;
-  }
-  .hfl-fdd-header { position: relative; }
-  .hfl-fdd-header h2 { color: var(--plum); margin-bottom: 16px; }
-  .hfl-fdd-header h2 em { color: var(--sage-text); }
-  .hfl-fdd-header p { font-size: 16px; color: var(--plum-mid); line-height: 1.7; }
-  .hfl-fdd-cols {
-    display: flex; flex-direction: column; position: relative;
-  }
-  .hfl-fdd-row {
-    display: flex; align-items: flex-start; gap: 20px;
-    padding: 26px 0; border-bottom: 1px solid rgba(46,37,64,0.1);
-    transition: opacity .2s;
-  }
-  .hfl-fdd-row:last-child { border-bottom: none; }
-  .hfl-fdd-row:hover .hfl-fdd-icon-wrap { background: rgba(122,175,118,0.45); border-color: var(--sage); }
-  .hfl-fdd-icon-wrap {
-    width: 44px; height: 44px; border-radius: 50%;
-    background: rgba(122,175,118,0.25);
-    border: 1px solid rgba(122,175,118,0.55);
-    display: flex; align-items: center; justify-content: center;
-    flex-shrink: 0; margin-top: 2px;
-    transition: background .2s, border-color .2s;
-  }
-  .hfl-fdd-text { display: flex; flex-direction: column; gap: 4px; }
-  .hfl-fdd-title {
-    font-family: 'Fraunces', serif; font-size: 17px; font-weight: 700;
-    color: var(--plum); line-height: 1.2; margin-bottom: 2px;
-  }
-  .hfl-fdd-tagline {
-    font-family: 'IBM Plex Mono', monospace; font-size: 10px; font-weight: 700;
-    letter-spacing: 1.5px; text-transform: uppercase; color: var(--sage-text);
-    margin-bottom: 6px;
-  }
-  .hfl-fdd-desc { font-size: 13px; color: var(--plum-mid); line-height: 1.65; }
+/* ── Footer ─────────────────────────────────────────────────────────────── */
+.hfl-footer { background:var(--lp-navy); padding:2rem; }
+.hfl-footer-inner {
+  display:flex; align-items:center; justify-content:space-between;
+  gap:2rem; max-width:1160px; margin:0 auto; flex-wrap:wrap;
+}
+.hfl-footer-left { display:flex; align-items:flex-start; gap:1rem; }
+.hfl-footer-icp-logo {
+  font-size:1.75rem; color:white; flex-shrink:0;
+  display:flex; align-items:center; justify-content:center;
+  width:40px; height:40px;
+}
+.hfl-footer-icp-title {
+  font-size:0.82rem; font-weight:700; color:white; margin-bottom:2px;
+}
+.hfl-footer-icp-sub {
+  font-size:0.72rem; color:rgba(255,255,255,0.5); line-height:1.5; margin-bottom:6px;
+}
+.hfl-footer-quorum { font-size:0.72rem; color:rgba(255,255,255,0.55); }
+.hfl-footer-quorum-code {
+  font-size:0.7rem; font-weight:700; letter-spacing:0.05em;
+  color:#4ADE80; background:rgba(74,222,128,0.12);
+  border:1px solid rgba(74,222,128,0.3);
+  padding:1px 7px; border-radius:4px; margin-left:4px;
+}
+.hfl-footer-btn {
+  font-size:0.8rem; font-weight:600; color:white;
+  background:none; border:1.5px solid rgba(255,255,255,0.3);
+  padding:0.5rem 1.1rem; border-radius:6px; cursor:pointer;
+  white-space:nowrap; transition:border-color 0.15s; flex-shrink:0;
+}
+.hfl-footer-btn:hover { border-color:rgba(255,255,255,0.6); }
 
-  /* ── TESTIMONIALS ─────────────────────────────────────────────────────── */
-  .hfl-testimonials { padding: 0 56px 100px; }
-  .hfl-tcard {
-    display: flex; align-items: stretch; min-height: 480px;
-    border: 1px solid var(--rule); overflow: hidden; background: white;
-  }
-  .hfl-tcard-img { flex: 0 0 60%; }
-  .hfl-tcard-img img { width: 100%; height: 100%; object-fit: cover; display: block; }
-  .hfl-tcard-body {
-    flex: 1; padding: 52px 48px; display: flex; flex-direction: column; justify-content: center;
-  }
-  .hfl-tcard-openquote {
-    font-family: 'Fraunces', serif; font-size: 88px; line-height: 0.65;
-    color: var(--sage-mid); margin-bottom: 20px; font-weight: 900;
-  }
-  .hfl-tcard-headline {
-    font-family: 'Fraunces', serif; font-size: clamp(26px, 2.8vw, 36px); font-weight: 900;
-    color: var(--plum); line-height: 1.15; margin-bottom: 18px;
-  }
-  .hfl-tcard-green { color: var(--sage-text); }
-  .hfl-tcard-text { font-size: 15px; color: var(--plum-mid); line-height: 1.75; margin-bottom: 28px; }
-  .hfl-tcard-meta { display: flex; align-items: center; gap: 14px; margin-bottom: 16px; }
-  .hfl-tcard-stars { color: #F4B942; font-size: 17px; letter-spacing: 2px; }
-  .hfl-tcard-verified {
-    font-size: 10px; font-weight: 700; letter-spacing: 1.5px; text-transform: uppercase;
-    color: var(--sage-text); border: 1px solid var(--sage-mid); padding: 3px 9px;
-  }
-  .hfl-tcard-author { display: flex; align-items: center; gap: 12px; }
-  .hfl-tcard-name { font-size: 14px; font-weight: 700; color: var(--plum); }
-  .hfl-tcard-divider { width: 1px; height: 14px; background: var(--rule); flex-shrink: 0; }
-  .hfl-tcard-location { font-size: 13px; color: var(--plum-mid); }
-  .hfl-featured-quote {
-    background: linear-gradient(135deg, var(--blush), var(--butter)); padding: 52px 60px;
-    margin-bottom: 22px; position: relative; overflow: hidden;
-    border: 1px solid rgba(46,37,64,0.1);
-  }
-  .hfl-featured-quote-text {
-    font-family: 'Fraunces', serif; font-size: clamp(20px, 2.5vw, 28px);
-    font-weight: 600; color: var(--plum); line-height: 1.5; margin-bottom: 32px;
-    position: relative;
-  }
-  .hfl-featured-quote-text em { color: var(--plum); font-style: italic; font-weight: 900; }
-  .hfl-featured-author { display: flex; align-items: center; gap: 16px; }
-  .hfl-featured-avi {
-    width: 52px; height: 52px; border-radius: 50%; background: rgba(46,37,64,0.1);
-    display: flex; align-items: center; justify-content: center; font-size: 26px;
-    border: 2px solid rgba(46,37,64,0.15); flex-shrink: 0;
-  }
-  .hfl-featured-name { font-size: 15px; font-weight: 700; color: var(--plum); margin-bottom: 3px; }
-  .hfl-featured-role { font-size: 13px; color: var(--plum-mid); }
-  .hfl-featured-result { margin-left: auto; text-align: right; flex-shrink: 0; }
-  .hfl-featured-result-num {
-    font-family: 'Fraunces', serif; font-size: 38px; font-weight: 900;
-    color: var(--plum); line-height: 1; margin-bottom: 4px;
-  }
-  .hfl-featured-result-lbl { font-size: 12px; color: var(--plum-mid); }
-  .hfl-test-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 18px; }
-  .hfl-test-card {
-    background: white; padding: 30px;
-    border: 1.5px solid rgba(122,175,118,0.2); transition: border-color .2s, box-shadow .2s;
-  }
-  .hfl-test-card:hover { border-color: var(--sage); box-shadow: 0 8px 32px rgba(122,175,118,0.15); }
-  .hfl-stars { color: #F4B942; font-size: 16px; margin-bottom: 14px; }
-  .hfl-test-card blockquote { font-size: 14px; line-height: 1.75; color: var(--plum-mid); margin-bottom: 20px; font-style: italic; }
-  .hfl-test-author { display: flex; align-items: center; gap: 12px; }
-  .hfl-avi { width: 40px; height: 40px; border-radius: 50%; display: flex; align-items: center; justify-content: center; font-size: 20px; }
-  .hfl-avi-1 { background: var(--blush); }
-  .hfl-avi-2 { background: var(--sky); }
-  .hfl-avi-3 { background: var(--butter); }
-  .hfl-test-name { font-weight: 700; font-size: 13px; color: var(--plum); }
-  .hfl-test-role { font-size: 11px; color: var(--plum-mid); }
-
-  /* ── PERSONA CTA ──────────────────────────────────────────────────────── */
-  .hfl-cta { padding: 0 56px 100px; }
-  .hfl-cta-inner {
-    background: var(--sage-light); border-radius: 28px; padding: 80px;
-    text-align: center; border: 2px solid var(--sage-mid); position: relative; overflow: hidden;
-  }
-  .hfl-cta-blob1 { position: absolute; top: -60px; right: -60px; width: 300px; height: 300px; background: radial-gradient(circle, var(--blush), transparent 70%); pointer-events: none; }
-  .hfl-cta-blob2 { position: absolute; bottom: -80px; left: -40px; width: 280px; height: 280px; background: radial-gradient(circle, var(--sky), transparent 70%); pointer-events: none; }
-  .hfl-cta h2 { letter-spacing: -2px; margin-bottom: 14px; position: relative; }
-  .hfl-cta-sub { font-size: 18px; color: var(--plum-mid); margin-bottom: 52px; max-width: 480px; margin-left: auto; margin-right: auto; line-height: 1.65; position: relative; }
-  .hfl-personas { display: grid; grid-template-columns: repeat(4, 1fr); gap: 16px; max-width: 1020px; margin: 0 auto; position: relative; }
-  .hfl-persona {
-    background: white; border-radius: 20px; padding: 32px 24px;
-    border: 2px solid transparent; transition: border-color .2s, box-shadow .2s, transform .2s;
-    text-align: left; cursor: pointer;
-  }
-  .hfl-persona:hover { border-color: var(--sage); box-shadow: 0 12px 36px rgba(46,37,64,0.12); transform: translateY(-4px); }
-  .hfl-persona-icon { font-size: 36px; margin-bottom: 16px; }
-  .hfl-persona-role { font-size: 11px; font-weight: 700; letter-spacing: 2px; text-transform: uppercase; color: var(--sage-text); margin-bottom: 8px; }
-  .hfl-persona-title { font-family: 'Fraunces', serif; font-size: 20px; font-weight: 700; color: var(--plum); margin-bottom: 10px; }
-  .hfl-persona-desc { font-size: 13px; color: var(--plum-mid); line-height: 1.6; margin-bottom: 22px; }
-  .hfl-persona-cta { font-size: 14px; font-weight: 700; color: var(--plum); display: flex; align-items: center; gap: 6px; }
-  .hfl-persona-arrow { transition: transform .2s; display: inline-block; }
-  .hfl-persona:hover .hfl-persona-arrow { transform: translateX(4px); }
-
-  /* ── DATA SECTION ─────────────────────────────────────────────────────── */
-  .hfl-data { padding: 0 56px 100px; }
-  .hfl-data-inner {
-    background: var(--white);
-    padding: 72px 80px;
-    display: grid; grid-template-columns: 1fr 1fr; gap: 80px; align-items: center;
-  }
-  .hfl-data-eyebrow {
-    display: inline-flex; align-items: center; gap: 8px;
-    background: rgba(122,175,118,0.18); color: var(--sage-text);
-    padding: 6px 16px; border-radius: 100px;
-    font-size: 12px; font-weight: 700; letter-spacing: 1.5px; text-transform: uppercase;
-    margin-bottom: 24px;
-  }
-  .hfl-data h2 { color: var(--plum); letter-spacing: -1px; margin-bottom: 20px; }
-  .hfl-data h2 em { color: var(--sage-text); }
-  .hfl-data-lead { font-size: 17px; color: var(--plum-mid); line-height: 1.7; margin-bottom: 36px; }
-  .hfl-data-cards { display: flex; flex-direction: column; gap: 14px; }
-  .hfl-data-card {
-    background: var(--sage-light); border: 1px solid var(--sage-mid);
-    padding: 22px 24px; display: flex; gap: 18px; align-items: flex-start;
-    transition: background .2s, border-color .2s;
-  }
-  .hfl-data-card:hover { background: var(--sage-mid); border-color: var(--sage); }
-  .hfl-data-card-icon { display: flex; align-items: center; justify-content: center; flex-shrink: 0; margin-top: 2px; color: var(--plum); }
-  .hfl-data-card-img { width: 48px; height: 48px; object-fit: contain; flex-shrink: 0; mix-blend-mode: multiply; }
-  .hfl-data-card-title { font-weight: 700; color: var(--plum); font-size: 15px; margin-bottom: 4px; }
-  .hfl-data-card-body { font-size: 13px; color: var(--plum-mid); line-height: 1.6; }
-  .hfl-data-note {
-    margin-top: 28px; font-size: 12px; color: rgba(253,252,250,0.35);
-    display: flex; align-items: center; gap: 8px;
-  }
-  .hfl-data-note::before { content: ""; display: block; width: 20px; height: 1px; background: rgba(253,252,250,0.2); }
-
-  /* ── FREE TOOLS ───────────────────────────────────────────────────────── */
-  .hfl-tools { padding: 0 56px 100px; }
-  .hfl-tools-inner {
-    background: var(--sage-light); padding: 64px 72px;
-    border: 2px solid var(--sage-mid); position: relative; overflow: hidden;
-  }
-  .hfl-tools-header { text-align: center; margin-bottom: 48px; }
-  .hfl-tools-eyebrow {
-    display: inline-flex; align-items: center; gap: 8px;
-    background: var(--sage-mid); color: var(--plum); padding: 5px 16px;
-    border-radius: 100px; font-size: 12px; font-weight: 700; letter-spacing: 0.04em;
-    margin-bottom: 16px;
-  }
-  .hfl-tools h2 { font-size: clamp(28px, 4vw, 42px); color: var(--plum); }
-  .hfl-tools-sub { font-size: 16px; color: var(--plum-mid); margin-top: 12px; line-height: 1.7; }
-  .hfl-tools-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(220px, 1fr)); gap: 16px; position: relative; z-index: 1; }
-  .hfl-tool-card {
-    background: white; padding: 28px 24px;
-    display: flex; flex-direction: column; gap: 12px;
-    border: 1.5px solid var(--sage-mid); cursor: pointer;
-    transition: transform .2s, box-shadow .2s; text-decoration: none; color: inherit;
-  }
-  .hfl-tool-card:hover { transform: translateY(-4px); box-shadow: 0 12px 32px rgba(46,37,64,0.1); }
-  .hfl-tool-icon { font-size: 28px; }
-  .hfl-tool-label { font-size: 10px; font-weight: 700; letter-spacing: 0.1em; text-transform: uppercase; color: var(--sage-text); margin-bottom: 2px; }
-  .hfl-tool-title { font-family: 'Fraunces', serif; font-size: 18px; font-weight: 700; color: var(--plum); line-height: 1.2; }
-  .hfl-tool-desc { font-size: 13px; color: var(--plum-mid); line-height: 1.65; flex: 1; }
-  .hfl-tool-cta { display: inline-flex; align-items: center; gap: 6px; font-size: 13px; font-weight: 700; color: var(--plum); margin-top: 4px; }
-
-  /* ── FEATURE SHOWCASE ────────────────────────────────────────────────── */
-  .hfl-showcase { padding: 0 56px 100px; }
-  .hfl-showcase-header { max-width: 540px; margin-bottom: 40px; }
-  .hfl-showcase-inner {
-    background: var(--plum);
-    display: flex; overflow: hidden;
-    border: 1px solid rgba(122,175,118,0.15);
-  }
-  /* Left nav */
-  .hfl-sc-nav {
-    width: 248px; flex-shrink: 0;
-    background: rgba(253,252,250,0.04);
-    border-right: 1px solid rgba(253,252,250,0.08);
-    padding: 28px 16px;
-    display: flex; flex-direction: column; gap: 4px;
-  }
-  .hfl-sc-nav-label {
-    font-size: 10px; font-weight: 700; letter-spacing: 2px; text-transform: uppercase;
-    color: var(--sage); padding: 0 12px; margin-bottom: 12px;
-  }
-  .hfl-sc-tab {
-    width: 100%; background: none; border: none; cursor: pointer; text-align: left;
-    padding: 12px 14px; border-radius: 10px;
-    font-family: 'Plus Jakarta Sans', sans-serif;
-    transition: background .15s;
-  }
-  .hfl-sc-tab:hover:not(.hfl-sc-tab-active) { background: rgba(253,252,250,0.06); }
-  .hfl-sc-tab-active { background: rgba(253,252,250,0.1); }
-  .hfl-sc-tab-row { display: flex; align-items: center; gap: 10px; }
-  .hfl-sc-tab-icon { font-size: 16px; flex-shrink: 0; }
-  .hfl-sc-tab-title {
-    font-size: 13px; font-weight: 600; color: rgba(253,252,250,0.55); line-height: 1.3;
-  }
-  .hfl-sc-tab-active .hfl-sc-tab-title { color: white; }
-  .hfl-sc-progress-track {
-    height: 2px; background: rgba(253,252,250,0.08); border-radius: 100px;
-    overflow: hidden; margin-top: 10px;
-  }
-  .hfl-sc-progress-bar {
-    height: 100%; background: var(--sage); border-radius: 100px;
-    animation: hfl-sc-fill 8s linear forwards;
-  }
-  @keyframes hfl-sc-fill { from { width: 0 } to { width: 100% } }
-  /* Content panel */
-  .hfl-sc-content {
-    flex: 1; min-width: 0; padding: 48px 52px 56px;
-    display: grid; grid-template-columns: 1fr 280px; gap: 44px; align-items: start;
-    position: relative; overflow: hidden;
-  }
-  .hfl-sc-content::before {
-    content: ''; position: absolute; top: -30%; right: -5%; width: 380px; height: 380px;
-    background: radial-gradient(circle, rgba(122,175,118,0.1), transparent 65%);
-    pointer-events: none;
-  }
-  .hfl-sc-kicker {
-    font-size: 11px; font-weight: 700; letter-spacing: 2px; text-transform: uppercase;
-    color: var(--sage); margin-bottom: 14px;
-  }
-  .hfl-sc-heading {
-    font-family: 'Fraunces', serif; font-size: clamp(26px, 2.8vw, 36px);
-    font-weight: 900; color: white; line-height: 1.1;
-    letter-spacing: -0.5px; margin-bottom: 14px;
-  }
-  .hfl-sc-heading em { color: var(--sage); font-style: italic; font-weight: 300; }
-  .hfl-sc-desc {
-    font-size: 15px; color: rgba(253,252,250,0.62); line-height: 1.75; margin-bottom: 24px;
-  }
-  .hfl-sc-bullets {
-    list-style: none; display: flex; flex-direction: column; gap: 9px; margin-bottom: 28px;
-  }
-  .hfl-sc-bullets li {
-    display: flex; align-items: flex-start; gap: 10px;
-    font-size: 13px; color: rgba(253,252,250,0.78); line-height: 1.5;
-  }
-  .hfl-sc-bullet-dot {
-    width: 18px; height: 18px; background: rgba(122,175,118,0.22); border-radius: 50%;
-    display: flex; align-items: center; justify-content: center;
-    font-size: 9px; color: var(--sage); flex-shrink: 0; margin-top: 2px; font-weight: 700;
-  }
-  .hfl-sc-cta {
-    display: inline-flex; align-items: center; gap: 8px;
-    background: var(--sage); color: var(--plum);
-    padding: 11px 22px; border-radius: 100px;
-    font-size: 13px; font-weight: 700; border: none; cursor: pointer;
-    font-family: 'Plus Jakarta Sans', sans-serif;
-    transition: transform .2s, box-shadow .2s;
-  }
-  .hfl-sc-cta:hover { transform: translateY(-2px); box-shadow: 0 8px 20px rgba(122,175,118,0.3); }
-  /* Slide-in animation */
-  .hfl-sc-slide { animation: hfl-sc-in .35s ease both; }
-  .hfl-sc-ai-row {
-    display: flex; align-items: center; gap: 16px; margin-bottom: 28px;
-  }
-  .hfl-sc-ai-row .hfl-sc-bullets { margin-bottom: 0; flex: 1; }
-  .hfl-sc-ai-buddy {
-    width: 130px; height: auto; flex-shrink: 0;
-    mix-blend-mode: lighten; opacity: 0.9;
-  }
-  @keyframes hfl-sc-in { from { opacity: 0; transform: translateY(10px); } to { opacity: 1; transform: translateY(0); } }
-  /* Visual column */
-  .hfl-sc-visual {
-    overflow: hidden; height: 360px; position: relative; background: white;
-    box-shadow: 0 20px 60px rgba(0,0,0,0.35); flex-shrink: 0;
-    border: 1px solid rgba(253,252,250,0.08);
-  }
-  .hfl-sc-vis-inner {
-    position: absolute; top: 0; left: 0;
-    width: calc(100% / 0.75);
-    transform: scale(0.75);
-    transform-origin: top left;
-  }
-  /* Mobile showcase */
-  @media (max-width: 900px) {
-    .hfl-showcase { padding: 0 24px 64px; }
-    .hfl-showcase-inner { flex-direction: column; min-height: auto; }
-    .hfl-sc-nav { width: 100%; flex-direction: row; gap: 6px; overflow-x: auto; padding: 16px; border-right: none; border-bottom: 1px solid rgba(253,252,250,0.08); }
-    .hfl-sc-nav-label { display: none; }
-    .hfl-sc-tab { padding: 10px 14px; white-space: nowrap; flex-shrink: 0; width: auto; }
-    .hfl-sc-progress-track { display: none; }
-    .hfl-sc-content { grid-template-columns: 1fr; padding: 28px 24px; gap: 28px; }
-    .hfl-sc-visual { display: none; }
-  }
-
-  /* ── FOOTER ───────────────────────────────────────────────────────────── */
-  .hfl-footer { background: var(--charcoal); padding: 64px 56px 32px; }
-  .hfl-footer-top {
-    display: grid; grid-template-columns: 1.6fr 1fr 1fr 1fr; gap: 48px; margin-bottom: 52px;
-  }
-  .hfl-footer-logo { font-family: 'Fraunces', serif; font-size: 24px; font-weight: 900; color: white; margin-bottom: 14px; display: block; text-decoration: none; }
-  .hfl-footer-logo span { color: var(--sage); font-style: italic; font-weight: 300; }
-  .hfl-footer-tagline { font-size: 14px; color: rgba(253,252,250,0.6); line-height: 1.65; max-width: 220px; margin-bottom: 24px; }
-  .hfl-footer-social { display: flex; gap: 10px; }
-  .hfl-footer-social a {
-    color: rgba(253,252,250,0.4); transition: color .2s; display: flex; align-items: center;
-    width: 36px; height: 36px; background: rgba(253,252,250,0.06); border-radius: 50%;
-    justify-content: center; transition: color .2s, background .2s;
-  }
-  .hfl-footer-social a:hover { color: var(--sage); background: rgba(122,175,118,0.15); }
-  .hfl-footer-col-title {
-    font-size: 11px; font-weight: 700; letter-spacing: 1.5px; text-transform: uppercase;
-    color: rgba(253,252,250,0.55); margin-bottom: 20px;
-  }
-  .hfl-footer-col-links { list-style: none; display: flex; flex-direction: column; gap: 12px; }
-  .hfl-footer-col-links a {
-    font-size: 14px; color: rgba(253,252,250,0.6); text-decoration: none;
-    transition: color .2s; cursor: pointer;
-  }
-  .hfl-footer-col-links a:hover { color: rgba(253,252,250,0.95); }
-  .hfl-footer-bottom {
-    border-top: 1px solid rgba(253,252,250,0.08); padding-top: 24px;
-    display: flex; align-items: center; justify-content: space-between;
-    font-size: 13px; color: rgba(253,252,250,0.55);
-  }
-  .hfl-footer-bottom-links { display: flex; gap: 24px; }
-  .hfl-footer-bottom-links a { color: rgba(253,252,250,0.55); text-decoration: none; transition: color .2s; }
-  .hfl-footer-bottom-links a:hover { color: rgba(253,252,250,0.85); }
-
-  /* ── ENTRANCE ANIMATIONS ──────────────────────────────────────────────── */
-  @keyframes hfl-fadeUp { from{opacity:0;transform:translateY(24px)} to{opacity:1;transform:translateY(0)} }
-
-  /* ── MOBILE ───────────────────────────────────────────────────────────── */
-  @media (max-width: 900px) {
-    .hfl-nav { padding: 0 24px; }
-    .hfl-nav-links {
-      display: none; position: fixed; top: 70px; left: 0; right: 0;
-      transform: none; flex-direction: column; gap: 0;
-      background: var(--white); border-top: 1px solid var(--rule);
-      padding: 8px 24px 24px; z-index: 99;
-    }
-    .hfl-nav-links.hfl-menu-open { display: flex; }
-    .hfl-nav-links.hfl-menu-open li { width: 100%; }
-    .hfl-nav-links.hfl-menu-open li a {
-      display: block; padding: 14px 0; font-size: 15px; border-radius: 0;
-      border-bottom: 1px solid var(--rule);
-    }
-    .hfl-nav-links.hfl-menu-open li:last-child a { border-bottom: none; }
-    .hfl-nav-signin { display: none; }
-    .hfl-hamburger { display: block; }
-    .hfl-hamburger.hfl-menu-open span:nth-child(1) { transform: translateY(7px) rotate(45deg); }
-    .hfl-hamburger.hfl-menu-open span:nth-child(2) { opacity: 0; }
-    .hfl-hamburger.hfl-menu-open span:nth-child(3) { transform: translateY(-7px) rotate(-45deg); }
-
-    .hfl-hero { grid-template-columns: 1fr; min-height: auto; padding: 90px 24px 48px; }
-    .hfl-hero-right { display: none; }
-    .hfl h1 { font-size: clamp(38px, 10vw, 54px); letter-spacing: -1.5px; }
-    .hfl-sub { font-size: 16px; max-width: 100%; }
-    .hfl-hero-trust { display: none; }
-
-    .hfl-trust-strip { padding: 16px 24px; gap: 16px; }
-    .hfl-trust-city { padding: 0 12px; font-size: 12px; }
-    .hfl-trust-rating { display: none; }
-
-    .hfl-metrics { grid-template-columns: 1fr 1fr; padding: 44px 24px; gap: 16px; }
-    .hfl-metric-num { font-size: 38px; }
-
-    .hfl-how { padding: 32px 24px 64px; }
-    .hfl-section-header { margin-bottom: 48px; }
-    .hfl-flow::before { display: none; }
-    .hfl-step-icon { width: 160px; height: 160px; font-size: 28px; }
-
-    .hfl-feat { grid-template-columns: 1fr; padding: 64px 24px; gap: 40px; }
-    .hfl-feat-2 .hfl-feat-text { order: 0; }
-    .hfl-feat-2 .hfl-feat-visual { order: 0; }
-
-    .hfl-report { padding: 0 24px 64px; }
-    .hfl-report h2 { font-size: 32px; }
-    .hfl-report-card { flex-direction: column; }
-    .hfl-report-img-col { flex: none; width: 100%; max-height: 320px; }
-    .hfl-report-body { padding: 36px 28px; }
-
-    .hfl-fdd { padding: 0 24px 64px; }
-    .hfl-fdd-inner { padding: 40px 28px; grid-template-columns: 1fr; gap: 36px; }
-    .hfl-fdd-row:last-child { border-bottom: 1px solid rgba(253,252,250,0.08); }
-    .hfl-testimonials { padding: 0 24px 64px; }
-    .hfl-tcard { flex-direction: column; }
-    .hfl-tcard-img { flex: none; width: 100%; max-height: 320px; }
-    .hfl-tcard-body { padding: 36px 28px; }
-    .hfl-featured-quote { padding: 36px 28px; }
-    .hfl-featured-result { display: none; }
-    .hfl-test-grid { grid-template-columns: 1fr; }
-
-    .hfl-cta { padding: 0 24px 64px; }
-    .hfl-cta-inner { padding: 48px 24px; }
-    .hfl-cta h2 { font-size: 34px; letter-spacing: -1px; }
-    .hfl-cta-sub { font-size: 15px; }
-    .hfl-personas { grid-template-columns: 1fr 1fr; max-width: 100%; }
-    .hfl-personas > *:last-child:nth-child(odd) { grid-column: span 2; max-width: 340px; margin: 0 auto; }
-
-    .hfl-data { padding: 0 24px 64px; }
-    .hfl-data-inner { grid-template-columns: 1fr; padding: 40px 28px; gap: 48px; }
-    .hfl-data h2 { font-size: 34px; }
-
-    .hfl-tools { padding: 0 24px 64px; }
-    .hfl-tools-inner { padding: 40px 28px; }
-    .hfl-tools-grid { grid-template-columns: 1fr 1fr; }
-
-    .hfl-footer { padding: 48px 24px 28px; }
-    .hfl-footer-top { grid-template-columns: 1fr 1fr; gap: 32px; }
-    .hfl-footer-bottom { flex-direction: column; gap: 16px; text-align: center; }
-    .hfl-footer-bottom-links { flex-wrap: wrap; justify-content: center; gap: 16px; }
-  }
-
-  @media (max-width: 480px) {
-    .hfl h1 { font-size: clamp(32px, 10vw, 44px); letter-spacing: -1px; }
-    .hfl-actions { flex-direction: column; align-items: stretch; }
-    .hfl-btn-main, .hfl-btn-soft { text-align: center; padding: 15px 20px; }
-    .hfl-trust-strip { display: none; }
-    .hfl-metrics { grid-template-columns: 1fr; padding: 36px 16px; }
-    .hfl-flow { grid-template-columns: 1fr; gap: 28px; }
-    .hfl-step { display: flex; align-items: flex-start; gap: 20px; text-align: left; }
-    .hfl-step-icon { width: 60px; height: 60px; font-size: 24px; flex-shrink: 0; margin: 0; }
-    .hfl h2 { font-size: 28px; }
-    .hfl-tools-grid { grid-template-columns: 1fr; }
-    .hfl-footer-top { grid-template-columns: 1fr; }
-    .hfl-report { margin: 0 16px 48px; padding: 32px 20px; }
-  }
-
-  @media (min-width: 901px) and (max-width: 1100px) {
-    .hfl-nav { padding: 0 32px; }
-    .hfl-hero { padding: 20px 32px 0; gap: 32px; }
-    .hfl-blob-wrap { width: 360px; height: 420px; }
-    .hfl-dash-card { width: 290px; }
-    .hfl-trust-strip { padding: 18px 32px; }
-    .hfl-metrics { padding: 56px 32px; }
-    .hfl-how { padding: 40px 32px 80px; }
-    .hfl-feat { padding: 72px 32px; gap: 48px; }
-    .hfl-report { padding: 0 32px 80px; }
-    .hfl-fdd { padding: 0 32px 80px; }
-    .hfl-fdd-inner { padding: 56px 48px; grid-template-columns: 1fr; gap: 40px; }
-    .hfl-testimonials { padding-left: 32px; padding-right: 32px; }
-    .hfl-tcard-img { flex: 0 0 50%; }
-    .hfl-tools { padding: 0 32px 80px; }
-    .hfl-tools-inner { padding: 52px 48px; }
-    .hfl-data { padding: 0 32px 80px; }
-    .hfl-data-inner { padding: 56px 48px; }
-    .hfl-footer { padding: 52px 32px 28px; }
-    .hfl-problem { padding: 0 32px 80px; }
-    .hfl-problem-img { flex: 0 0 44%; }
-    .hfl-problem-text { padding: 48px 40px; }
-    .hfl-pricing { padding: 0 32px 80px; }
-    .hfl-pricing-inner { padding: 56px 48px; }
-    .hfl-final-cta { padding: 0 32px 80px; }
-    .hfl-final-cta-inner { padding: 72px 48px; }
-  }
-
-  /* ── SOCIAL PROOF BAR ────────────────────────────────────────────────── */
-  .hfl-proof-bar {
-    margin-top: 70px;
-    background: var(--sage-light); border-bottom: 1px solid rgba(46,37,64,0.1);
-    padding: 10px 56px; display: flex; align-items: center; justify-content: center; gap: 12px;
-    font-size: 13px; font-weight: 500; color: var(--plum);
-  }
-  .hfl-proof-stars { color: #F4B942; letter-spacing: 1px; }
-  .hfl-proof-sep { color: var(--plum-mid); opacity: 0.4; }
-  .hfl-proof-quote { font-style: italic; color: var(--plum); }
-  .hfl-proof-stat { font-weight: 700; color: var(--plum); }
-
-  /* ── HERO — updated padding + new elements ───────────────────────────── */
-  .hfl-hero { padding: 20px 56px 0; }
-  .hfl-hero-bullets {
-    list-style: none; display: flex; flex-direction: column; gap: 14px;
-    margin-bottom: 40px; max-width: 480px;
-    animation: hfl-fadeUp .5s .2s ease both;
-  }
-  .hfl-hero-bullets li {
-    display: flex; align-items: flex-start; gap: 12px;
-    font-size: 17px; color: var(--plum); font-weight: 500; line-height: 1.5;
-  }
-  .hfl-hb-dot {
-    width: 22px; height: 22px; background: var(--sage-light); border-radius: 50%;
-    display: flex; align-items: center; justify-content: center;
-    font-size: 10px; color: var(--sage-text); flex-shrink: 0; margin-top: 2px; font-weight: 800;
-  }
-  .hfl-price-anchor {
-    font-size: 13px; font-weight: 700; color: var(--plum-mid);
-    font-family: 'Plus Jakarta Sans', sans-serif;
-    padding: 8px 16px; background: rgba(46,37,64,0.06); border-radius: 100px;
-    border: 1px solid rgba(46,37,64,0.1); white-space: nowrap;
-  }
-  .hfl-demo-link {
-    display: inline-block; font-size: 15px; font-weight: 600; color: var(--plum-mid);
-    text-decoration: none; cursor: pointer; margin-bottom: 32px; margin-top: 4px;
-    border-bottom: 1px solid rgba(46,37,64,0.2);
-    transition: color .15s, border-color .15s;
-    animation: hfl-fadeUp .5s .35s ease both;
-  }
-  .hfl-demo-link:hover { color: var(--plum); border-color: var(--plum); }
-  .hfl-stat-chip {
-    display: inline-flex; align-items: center; gap: 8px;
-    background: var(--sage-light); border: 1px solid var(--sage-mid); border-radius: 100px;
-    padding: 6px 16px; font-size: 13px; font-weight: 700; color: var(--plum);
-  }
-  .hfl-hero-micro-quote {
-    margin-top: 16px; display: flex; flex-direction: column; gap: 4px;
-    max-width: 420px; animation: hfl-fadeUp .5s .45s ease both;
-  }
-  .hfl-hmq-stars { color: #F4B942; font-size: 13px; letter-spacing: 1px; }
-  .hfl-hmq-text { font-size: 13px; color: var(--plum-mid); line-height: 1.55; font-style: italic; }
-  .hfl-hmq-attr { font-size: 12px; font-weight: 700; color: var(--plum); }
-  /* Hero card phase indicator */
-  .hfl-dc-phase-dots { display: flex; justify-content: center; gap: 6px; padding: 10px 0 4px; }
-  .hfl-dc-phase-dot { width: 6px; height: 6px; border-radius: 50%; background: rgba(46,37,64,0.12); transition: background .3s; }
-  .hfl-dc-phase-dot-active { background: var(--sage); }
-
-  /* ── PROBLEM SECTION ─────────────────────────────────────────────────── */
-  .hfl-problem { padding: 0 56px 48px; }
-  .hfl-problem-inner { background: white; border: 1px solid var(--rule); overflow: hidden; display: flex; align-items: stretch; min-height: 480px; }
-  .hfl-problem-img { flex: 0 0 40%; overflow: hidden; }
-  .hfl-problem-img img { width: 100%; height: 100%; object-fit: cover; display: block; }
-  .hfl-problem-text { flex: 1; padding: 52px 48px; display: flex; flex-direction: column; justify-content: center; }
-
-  /* ── PRICING SECTION ─────────────────────────────────────────────────── */
-  .hfl-pricing { padding: 0 56px 100px; }
-  .hfl-pricing-inner { background: #FAF7F2; padding: 72px 80px; border: 1px solid var(--rule); }
-  .hfl-pricing-header { max-width: 540px; margin-bottom: 56px; }
-  .hfl-pricing-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 24px; margin-bottom: 36px; }
-  .hfl-plan-card {
-    background: white; padding: 36px 32px;
-    border: 1.5px solid var(--rule); position: relative;
-    display: flex; flex-direction: column;
-    transition: border-color .2s, box-shadow .2s;
-  }
-  .hfl-plan-card:hover { border-color: var(--sage); box-shadow: 0 8px 32px rgba(122,175,118,0.12); }
-  .hfl-plan-featured { border-color: var(--plum); border-width: 2px; }
-  .hfl-plan-featured:hover { border-color: var(--plum); box-shadow: 0 8px 32px rgba(46,37,64,0.18); }
-  .hfl-plan-badge {
-    position: absolute; top: -14px; left: 50%; transform: translateX(-50%);
-    background: var(--plum); color: white; font-size: 10px; font-weight: 800;
-    letter-spacing: 1.5px; text-transform: uppercase; padding: 5px 16px; border-radius: 100px;
-    white-space: nowrap;
-  }
-  .hfl-plan-tier { font-size: 11px; font-weight: 800; letter-spacing: 2px; text-transform: uppercase; color: var(--plum-mid); margin-bottom: 12px; }
-  .hfl-plan-price { font-family: 'Fraunces', serif; font-size: 52px; font-weight: 900; color: var(--plum); line-height: 1; margin-bottom: 28px; }
-  .hfl-plan-period { font-size: 18px; font-weight: 400; color: var(--plum-mid); }
-  .hfl-plan-features {
-    list-style: none; display: flex; flex-direction: column; gap: 10px;
-    font-size: 14px; line-height: 1.5; flex: 1; margin-bottom: 28px;
-  }
-  .hfl-plan-features li { display: flex; gap: 8px; color: var(--plum); }
-  .hfl-plan-cta {
-    width: 100%; padding: 14px 0; background: var(--sage-light);
-    border: 1.5px solid var(--sage-mid); border-radius: 0; cursor: pointer;
-    font-family: 'Plus Jakarta Sans', sans-serif; font-size: 14px; font-weight: 700;
-    color: var(--plum); transition: background .2s, border-color .2s;
-  }
-  .hfl-plan-cta:hover { background: var(--sage-mid); border-color: var(--sage); }
-  .hfl-plan-featured .hfl-plan-cta { background: var(--plum); color: white; border-color: var(--plum); }
-  .hfl-plan-featured .hfl-plan-cta:hover { background: var(--plum-light); }
-  .hfl-pricing-note { text-align: center; font-size: 14px; color: var(--plum-mid); font-weight: 500; }
-  .hfl-pricing-note a { color: var(--plum); font-weight: 700; text-decoration: none; border-bottom: 1px solid rgba(46,37,64,0.3); }
-  .hfl-pricing-note a:hover { border-color: var(--plum); }
-
-  /* ── FINAL CTA ───────────────────────────────────────────────────────── */
-  .hfl-final-cta { padding: 0 56px 100px; }
-  .hfl-final-cta-inner {
-    background: var(--plum); padding: 96px 80px;
-    text-align: center; position: relative; overflow: hidden;
-  }
-  .hfl-final-cta-inner::before {
-    content: ''; position: absolute; top: -60px; right: -60px;
-    width: 400px; height: 400px; border-radius: 50%;
-    background: radial-gradient(circle, rgba(201,76,46,0.25), transparent 70%);
-    pointer-events: none;
-  }
-  .hfl-final-cta-inner::after {
-    content: ''; position: absolute; bottom: -80px; left: -80px;
-    width: 360px; height: 360px; border-radius: 50%;
-    background: radial-gradient(circle, rgba(122,175,118,0.12), transparent 70%);
-    pointer-events: none;
-  }
-  .hfl-final-cta .hfl-kicker { position: relative; }
-  .hfl-final-cta h2 { color: white; margin-bottom: 20px; max-width: 620px; margin-left: auto; margin-right: auto; position: relative; }
-  .hfl-final-cta h2 em { color: var(--sage); }
-  .hfl-final-cta-sub { font-size: 17px; color: rgba(253,252,250,0.65); line-height: 1.7; max-width: 520px; margin: 0 auto 44px; position: relative; }
-  .hfl-final-cta-btn {
-    background: #C94C2E; color: white; padding: 20px 52px; border-radius: 0;
-    font-size: 17px; font-weight: 700; border: none; cursor: pointer;
-    font-family: 'Plus Jakarta Sans', sans-serif;
-    transition: background .2s, box-shadow .2s; position: relative;
-  }
-  .hfl-final-cta-btn:hover { background: #B54228; box-shadow: 0 12px 36px rgba(201,76,46,0.4); }
-  .hfl-final-cta-fine { margin-top: 20px; font-size: 12px; color: rgba(253,252,250,0.35); position: relative; }
-
-  /* ── MOBILE — new elements ───────────────────────────────────────────── */
-  @media (max-width: 900px) {
-    .hfl-proof-bar { padding: 8px 24px; gap: 8px; flex-wrap: wrap; justify-content: center; font-size: 12px; }
-    .hfl-hero { padding: 16px 24px 48px; }
-    .hfl-hero-bullets li { font-size: 15px; }
-    .hfl-hero-micro-quote { display: none; }
-    .hfl-problem { padding: 0 24px 64px; }
-    .hfl-problem-inner { flex-direction: column; }
-    .hfl-problem-img { flex: none; width: 100%; max-height: 320px; }
-    .hfl-problem-text { padding: 36px 28px; }
-    .hfl-pricing { padding: 0 24px 64px; }
-    .hfl-pricing-inner { padding: 40px 28px; }
-    .hfl-pricing-grid { grid-template-columns: 1fr; gap: 32px; }
-    .hfl-plan-card { padding: 28px 24px; }
-    .hfl-final-cta { padding: 0 24px 64px; }
-    .hfl-final-cta-inner { padding: 60px 28px; }
-    .hfl-final-cta h2 { font-size: 28px; }
-    .hfl-final-cta-sub { font-size: 15px; }
-    .hfl-final-cta-btn { padding: 16px 32px; font-size: 15px; width: 100%; }
-  }
-  @media (max-width: 480px) {
-    .hfl-proof-bar { font-size: 11px; padding: 8px 16px; }
-    .hfl-proof-quote { display: none; }
-  }
+/* ── Responsive ─────────────────────────────────────────────────────────── */
+@media(max-width:1024px){
+  .hfl-pricing-grid { grid-template-columns:repeat(3,1fr); }
+  .hfl-features-grid { grid-template-columns:repeat(2,1fr); }
+}
+@media(max-width:768px){
+  .hfl-nav-links { display:none; }
+  .hfl-hamburger { display:flex; }
+  .hfl-hero { grid-template-columns:1fr; }
+  .hfl-hero-img-wrap { display:none; }
+  .hfl-trust-inner { grid-template-columns:repeat(2,1fr); }
+  .hfl-trust-item:nth-child(2) { border-right:none; }
+  .hfl-trust-item:nth-child(3) { border-top:1px solid var(--lp-rule); }
+  .hfl-trust-item:nth-child(4) { border-top:1px solid var(--lp-rule); border-right:none; }
+  .hfl-roles-grid { grid-template-columns:1fr; }
+  .hfl-features-grid { grid-template-columns:repeat(2,1fr); }
+  .hfl-strip-inner { grid-template-columns:1fr; }
+  .hfl-strip-col { border-right:none; border-bottom:1px solid var(--lp-rule); }
+  .hfl-strip-col:last-child { border-bottom:none; }
+  .hfl-pricing-grid { grid-template-columns:1fr 1fr; }
+  .hfl-footer-inner { flex-direction:column; align-items:flex-start; }
+}
+@media(max-width:480px){
+  .hfl-hero { padding:2.5rem 1rem 2rem; }
+  .hfl-pricing-grid { grid-template-columns:1fr; }
+  .hfl-trust-inner { grid-template-columns:1fr; }
+  .hfl-trust-item { border-right:none; border-bottom:1px solid var(--lp-rule); }
+  .hfl-trust-item:last-child { border-bottom:none; }
+  .hfl-features-grid { grid-template-columns:1fr; }
+  .hfl-nav { padding:0 1rem; }
+  .hfl-integrations { padding:2rem 1rem; }
+}
 `;

--- a/frontend/src/pages/landingStyles.ts
+++ b/frontend/src/pages/landingStyles.ts
@@ -19,7 +19,8 @@ export const CSS = `
   text-decoration:none; display:flex; align-items:center; gap:7px;
   flex-shrink:0;
 }
-.hfl-logo span { color:var(--lp-green); }
+.hfl-logo-text { color:var(--lp-navy); }
+.hfl-logo-text span { color:var(--lp-green); }
 .hfl-nav-links {
   display:flex; align-items:center; list-style:none;
   margin:0; padding:0;

--- a/frontend/src/pages/landingStyles.ts
+++ b/frontend/src/pages/landingStyles.ts
@@ -1,7 +1,7 @@
 export const CSS = `
 /* ── Reset / Variables ──────────────────────────────────────────────────── */
 .hfl { --lp-navy:#0F172A; --lp-text:#1E293B; --lp-muted:#64748B;
-  --lp-rule:#E2E8F0; --lp-light:#F8FAFC; --lp-green:#16A34A;
+  --lp-rule:#E2E8F0; --lp-light:#F8FAFC; --lp-green:#15803D;
   --lp-blue:#2563EB; --lp-white:#FFFFFF;
   font-family:'Inter','Segoe UI',system-ui,sans-serif;
   color:var(--lp-text); background:var(--lp-white);
@@ -228,7 +228,7 @@ export const CSS = `
   gap:2.5rem; flex-wrap:wrap; max-width:900px; margin:0 auto;
 }
 .hfl-integ-logo {
-  font-size:0.82rem; font-weight:700; color:#94A3B8; white-space:nowrap;
+  font-size:0.82rem; font-weight:700; color:#64748B; white-space:nowrap;
 }
 
 /* ── Pricing ────────────────────────────────────────────────────────────── */
@@ -310,7 +310,7 @@ export const CSS = `
   display:flex; align-items:center; gap:5px;
   font-size:12px; font-weight:800; color:#0F172A;
 }
-.hfl-dm-topbar-logo .green { color:#16A34A; }
+.hfl-dm-topbar-logo .green { color:#15803D; }
 .hfl-dm-topbar-icons { display:flex; gap:8px; color:#94A3B8; font-size:14px; }
 .hfl-dm-body { display:flex; }
 .hfl-dm-sidebar {
@@ -343,8 +343,8 @@ export const CSS = `
   content:""; position:absolute; inset:7px; border-radius:50%; background:#F8FAFC;
 }
 .hfl-dm-score-val { position:relative; z-index:1; font-size:13px; font-weight:800; color:#0F172A; }
-.hfl-dm-score-delta { font-size:8px; color:#16A34A; font-weight:600; }
-.hfl-dm-score-sub { font-size:7px; color:#94A3B8; }
+.hfl-dm-score-delta { font-size:8px; color:#15803D; font-weight:600; }
+.hfl-dm-score-sub { font-size:7px; color:#64748B; }
 .hfl-dm-maint-nums { display:flex; gap:14px; padding-top:2px; }
 .hfl-dm-maint-num { font-size:20px; font-weight:800; color:#0F172A; line-height:1; }
 .hfl-dm-maint-lbl { font-size:7.5px; color:#64748B; margin-top:2px; }
@@ -357,7 +357,7 @@ export const CSS = `
 .hfl-dm-stat-val { font-size:15px; font-weight:800; color:#0F172A; line-height:1.1; }
 .hfl-dm-stat-link { font-size:7.5px; color:#2563EB; font-weight:600; }
 .hfl-dm-activity-label {
-  font-size:7.5px; font-weight:700; color:#94A3B8;
+  font-size:7.5px; font-weight:700; color:#64748B;
   text-transform:uppercase; letter-spacing:0.07em; margin-bottom:5px;
 }
 .hfl-dm-act-item {
@@ -370,8 +370,8 @@ export const CSS = `
 .hfl-dm-act-dot-orange { background:#F97316; }
 .hfl-dm-act-body { flex:1; min-width:0; }
 .hfl-dm-act-title { font-size:8.5px; font-weight:600; color:#1E293B; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
-.hfl-dm-act-sub   { font-size:7px; color:#94A3B8; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
-.hfl-dm-act-date  { font-size:7.5px; color:#94A3B8; flex-shrink:0; white-space:nowrap; }
+.hfl-dm-act-sub   { font-size:7px; color:#64748B; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+.hfl-dm-act-date  { font-size:7.5px; color:#64748B; flex-shrink:0; white-space:nowrap; }
 
 /* ── Footer ─────────────────────────────────────────────────────────────── */
 .hfl-footer { background:var(--lp-navy); padding:1.5rem 2rem; }

--- a/tests/e2e/landing.spec.ts
+++ b/tests/e2e/landing.spec.ts
@@ -18,13 +18,13 @@ test.describe("LandingPage — /", () => {
   });
 
   test("shows current nav links including Pricing", async ({ page }) => {
-    await expect(page.locator("nav li a", { hasText: "Demo" })).toBeVisible();
+    await expect(page.locator("nav li a", { hasText: "Features" })).toBeVisible();
     await expect(page.locator("nav li a", { hasText: "Pricing" })).toBeVisible();
   });
 
-  test("Pricing nav link navigates to /pricing", async ({ page }) => {
+  test("Pricing nav link scrolls to the pricing section", async ({ page }) => {
     await page.locator("nav li a", { hasText: "Pricing" }).click();
-    await expect(page).toHaveURL("/pricing");
+    await expect(page.locator("#hfl-pricing-section")).toBeVisible();
   });
 
   // ── Hero CTA ──────────────────────────────────────────────────────────────
@@ -42,20 +42,19 @@ test.describe("LandingPage — /", () => {
   // ── Hero content ──────────────────────────────────────────────────────────
 
   test("shows hero heading text", async ({ page }) => {
-    // The hero h1 contains some variant of HomeGentic value proposition
     await expect(page.locator("h1").first()).toBeVisible();
   });
 
-  // ── How it Works section ──────────────────────────────────────────────────
+  // ── Pricing section ───────────────────────────────────────────────────────
 
-  test("shows How It Works section heading", async ({ page }) => {
-    await expect(page.getByText(/How It Works/i)).toBeVisible();
+  test("shows Pricing section heading", async ({ page }) => {
+    await expect(page.locator("#hfl-pricing-section")).toBeVisible();
   });
 
   // ── Features section ─────────────────────────────────────────────────────
 
   test("shows Features section", async ({ page }) => {
-    await expect(page.getByText("Features")).toBeVisible();
+    await expect(page.locator("#hfl-features-section")).toBeVisible();
   });
 
   // ── Mobile nav ────────────────────────────────────────────────────────────
@@ -63,7 +62,6 @@ test.describe("LandingPage — /", () => {
   test("hamburger menu is hidden at desktop width", async ({ page }) => {
     await page.setViewportSize({ width: 1280, height: 800 });
     const hamburger = page.locator(".hfl-hamburger");
-    // Should not be visible at desktop (CSS display: none)
     await expect(hamburger).toBeHidden();
   });
 
@@ -73,7 +71,7 @@ test.describe("LandingPage — /", () => {
     await expect(hamburger).toBeVisible();
   });
 
-  // ── Footer / Sign-in links ────────────────────────────────────────────────
+  // ── Nav CTA ───────────────────────────────────────────────────────────────
 
   test("shows Sign In link in nav", async ({ page }) => {
     await expect(page.getByRole("button", { name: /sign in|get started/i }).first()).toBeVisible();

--- a/tests/e2e/login.spec.ts
+++ b/tests/e2e/login.spec.ts
@@ -18,25 +18,21 @@ test.describe("LoginPage — /login", () => {
     await expect(page.getByText(/HomeGentic/).first()).toBeVisible();
   });
 
-  test("shows 'Sign In' eyebrow label", async ({ page }) => {
-    await expect(page.getByText("Sign In").first()).toBeVisible();
+  test("shows 'Log in to your account' heading", async ({ page }) => {
+    await expect(page.getByRole("heading", { name: /log in to your account/i })).toBeVisible();
   });
 
-  test("shows 'Welcome back.' heading", async ({ page }) => {
+  test("shows 'Welcome back!' heading on the left panel", async ({ page }) => {
     await expect(page.getByRole("heading", { name: /welcome back/i })).toBeVisible();
   });
 
-  test("shows friendly sign-in description mentioning Google and Apple", async ({ page }) => {
-    await expect(page.getByText(/Google/).first()).toBeVisible();
-    await expect(page.getByText(/Apple/).first()).toBeVisible();
+  test("shows Google and Apple sign-in buttons", async ({ page }) => {
+    await expect(page.getByRole("button", { name: /continue with google/i })).toBeVisible();
+    await expect(page.getByRole("button", { name: /continue with apple/i })).toBeVisible();
   });
 
-  test("shows biometric option hint", async ({ page }) => {
-    await expect(page.getByText(/Touch ID|Face ID/i)).toBeVisible();
-  });
-
-  test("shows 'Continue' button", async ({ page }) => {
-    await expect(page.getByRole("button", { name: /continue/i })).toBeVisible();
+  test("shows Internet Computer sign-in button", async ({ page }) => {
+    await expect(page.getByRole("button", { name: /continue with internet computer/i })).toBeVisible();
   });
 
   test("shows 'Secured by Internet Identity' footer note", async ({ page }) => {
@@ -46,7 +42,6 @@ test.describe("LoginPage — /login", () => {
   // ── Dev login (only rendered when import.meta.env.DEV is true) ────────────
 
   test("shows Dev Login button in dev mode", async ({ page }) => {
-    // Vite dev server sets DEV=true — this button should be present
     await expect(page.getByRole("button", { name: /dev login/i })).toBeVisible();
   });
 
@@ -64,7 +59,6 @@ test.describe("LoginPage — /login", () => {
   // ── Protected route redirect ──────────────────────────────────────────────
 
   test("unauthenticated access to /dashboard redirects to /login", async ({ page }) => {
-    // Without auth injection, PrivateRoute should redirect to /login
     await page.goto("/dashboard");
     await expect(page).toHaveURL("/login");
   });
@@ -74,21 +68,10 @@ test.describe("LoginPage — /login", () => {
     await expect(page).toHaveURL("/login");
   });
 
-  // ── Back link ─────────────────────────────────────────────────────────────
+  // ── Sign-up link ──────────────────────────────────────────────────────────
 
-  test("shows '← Back to HomeGentic' link", async ({ page }) => {
-    await expect(page.getByText(/← Back to HomeGentic/)).toBeVisible();
-  });
-
-  test("back link navigates to /", async ({ page }) => {
-    await page.getByText(/← Back to HomeGentic/).click();
-    await expect(page).toHaveURL("/");
-  });
-
-  // ── No account link ───────────────────────────────────────────────────────
-
-  test("shows 'No account?' text with Create one link", async ({ page }) => {
-    await expect(page.getByText(/No account/)).toBeVisible();
-    await expect(page.getByText(/Create one free/)).toBeVisible();
+  test("shows 'Don't have an account?' with Get Started link", async ({ page }) => {
+    await expect(page.getByText(/don't have an account/i)).toBeVisible();
+    await expect(page.getByText(/get started/i).first()).toBeVisible();
   });
 });


### PR DESCRIPTION
## Summary

- New design system (Inter font, navy/green/blue CSS variables) replacing the old Fraunces editorial theme
- Hero with ICP badge, split-column layout, and dashboard screenshot
- Trust badges (Blockchain Verified, Secure & Private, Dual-Signature, Internet Computer)
- Roles section (Homeowners, Contractors, Realtors/Admins) and 8-feature card grid
- Trust strip highlighting Quorum HOA 10% discount (`QUORUM10`), Invite a Neighbor referrals, and ICP infrastructure
- 5-tier pricing grid: Basic $10 / Pro $20 / Premium $40 (Most Popular) / Contractor Free / ContractorPro $30
- Compact dark footer with ICP branding and Quorum code badge
- Updated `LandingPageMob2.test.tsx`: replaced `.hfl-step` count assertion with pricing grid check

## Test plan

- [x] All 8 unit tests in `LandingPageMob2.test.tsx` pass
- [ ] Verify hero renders correctly on desktop and mobile
- [ ] Verify pricing cards show correct tier names and prices matching CLAUDE.md tier table
- [ ] Verify Quorum discount code `QUORUM10` visible in trust strip and footer
- [ ] Verify `?ref=` query param still captured via `neighborReferralService.capturePendingRefCode`
- [ ] Verify hamburger menu toggles on mobile (<768px)

🤖 Generated with [Claude Code](https://claude.com/claude-code)